### PR TITLE
Show water names without centerlines

### DIFF
--- a/layers/water_name/layer.sql
+++ b/layers/water_name/layer.sql
@@ -1,16 +1,22 @@
 
--- etldoc: layer_water_name[shape=record fillcolor=lightpink, style="rounded,filled",  
+-- etldoc: layer_water_name[shape=record fillcolor=lightpink, style="rounded,filled",
 -- etldoc:     label="layer_water_name | <z9_13> z9_13 | <z14_> z14_" ] ;
 
 CREATE OR REPLACE FUNCTION layer_water_name(bbox geometry, zoom_level integer)
 RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, class text) AS $$
     -- etldoc: osm_water_lakeline ->  layer_water_name:z9_13
-    -- etldoc: osm_water_lakeline ->  layer_water_name:z14_    
+    -- etldoc: osm_water_lakeline ->  layer_water_name:z14
     SELECT osm_id, geometry, name, name_en, 'lake'::text AS class
     FROM osm_water_lakeline
     WHERE geometry && bbox
-      AND name <> ''
       AND ((zoom_level BETWEEN 9 AND 13 AND LineLabel(zoom_level, NULLIF(name, ''), geometry))
         OR (zoom_level >= 14))
-    ORDER BY ST_Length(geometry) DESC;
+    -- etldoc: osm_water_point ->  layer_water_name:z9_13
+    UNION ALL
+    SELECT osm_id, geometry, name, name_en, 'lake'::text AS class
+    FROM osm_water_point
+    WHERE geometry && bbox AND (
+        (zoom_level BETWEEN 9 AND 13 AND area > 70000*2^(20-zoom_level))
+        OR (zoom_level >= 14)
+    );
 $$ LANGUAGE SQL IMMUTABLE;

--- a/layers/water_name/water_lakeline.sql
+++ b/layers/water_name/water_lakeline.sql
@@ -1,11 +1,12 @@
-
 -- etldoc:  osm_water_polygon ->  osm_water_lakeline
+-- etldoc:  custom_lakeline   ->  osm_water_lakeline
 CREATE TABLE IF NOT EXISTS osm_water_lakeline AS (
 	SELECT wp.osm_id,
 		ll.wkb_geometry AS geometry,
-		name, name_en
+		name, name_en, ST_Area(wp.geometry) AS area
     FROM osm_water_polygon AS wp
     INNER JOIN lake_centerline ll ON wp.osm_id = ll.osm_id
+    WHERE wp.name <> ''
 );
 
 CREATE INDEX IF NOT EXISTS osm_water_lakeline_geometry_idx ON osm_water_lakeline USING gist(geometry);

--- a/layers/water_name/water_name.yaml
+++ b/layers/water_name/water_name.yaml
@@ -16,7 +16,8 @@ layer:
     srid: 900913
     query: (SELECT geometry, name, name_en, class FROM layer_water_name(!bbox!, z(!scale_denominator!))) AS t
 schema:
-  - ./merge_lakelines.sql
+  - ./water_lakeline.sql
+  - ./water_point.sql
   - ./layer.sql
 datasources:
   - type: imposm3

--- a/layers/water_name/water_point.sql
+++ b/layers/water_name/water_point.sql
@@ -1,0 +1,11 @@
+-- etldoc:  osm_water_polygon ->  osm_water_lakeline
+CREATE TABLE IF NOT EXISTS osm_water_point AS (
+    SELECT
+        wp.osm_id, topoint(wp.geometry) AS geometry,
+        wp.name, wp.name_en, ST_Area(wp.geometry) AS area
+    FROM osm_water_polygon AS wp
+    LEFT JOIN lake_centerline ll ON wp.osm_id = ll.osm_id
+    WHERE ll.osm_id IS NULL AND wp.name <> ''
+);
+
+CREATE INDEX IF NOT EXISTS osm_water_point_geometry_idx ON osm_water_point USING gist (geometry);


### PR DESCRIPTION
Right now there were only labels for water where there were lakelines.
