### PR TITLE
tileserver-gl integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,9 @@ refresh-docker-images:
 remove-docker-images:
 	@echo "Deleting all openmaptiles related docker image(s)..."
 	@docker-compose down
-	@docker images | grep "<none>" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi
-	@docker images | grep "openmaptiles" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi
-	@docker images | grep "osm2vectortiles/mapbox-studio" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi
-	@docker images | grep "klokantech/tileserver-gl"      | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi
+	@docker images | grep "openmaptiles" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi -f 
+	@docker images | grep "osm2vectortiles/mapbox-studio" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi -f
+	@docker images | grep "klokantech/tileserver-gl"      | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi -f
 
 docker-unnecessary-clean:
 	@echo "Deleting unnecessary container(s)..."

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo "  "
 	@echo "Hints for designers:"
 	@echo "  ....TODO....                         # start Maputnik "
-	@echo "  ....TODO....                         # start Tileserver-gl-light"
+	@echo "  make start-tileserver                # start klokantech/tileserver-gl [ see localhost:8080 ] "
 	@echo "  make start-mapbox-studio             # start Mapbox Studio"
 	@echo "  "
 	@echo "Hints for developers:"
@@ -64,6 +64,7 @@ remove-docker-images:
 	@docker images | grep "<none>" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi
 	@docker images | grep "openmaptiles" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi
 	@docker images | grep "osm2vectortiles/mapbox-studio" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi
+	@docker images | grep "klokantech/tileserver-gl"      | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi
 
 docker-unnecessary-clean:
 	@echo "Deleting unnecessary container(s)..."
@@ -116,6 +117,26 @@ list:
 # same as a `make list`
 download-geofabrik-list:
 	docker-compose run --rm import-osm  ./download-geofabrik-list.sh
+
+start-tileserver:
+	@echo " "	
+	@echo "***********************************************************"
+	@echo "* "		
+	@echo "* Download latest klokantech/tileserver-gl docker image    "
+	@echo "* see documentation: https://github.com/klokantech/tileserver-gl"	
+	@echo "* "			
+	@echo "***********************************************************"
+	@echo " "	
+	docker pull klokantech/tileserver-gl
+	@echo " "	
+	@echo "***********************************************************"
+	@echo "* "	
+	@echo "* Start klokantech/tileserver-gl "
+	@echo "*       ----------------------------> check localhost:8080 "
+	@echo "* "		
+	@echo "***********************************************************"
+	@echo " "
+	docker run -it -v $$(pwd)/data:/data -p 8080:80 klokantech/tileserver-gl
 
 start-mapbox-studio:
 	docker-compose up mapbox-studio

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ refresh-docker-images:
 remove-docker-images:
 	@echo "Deleting all openmaptiles related docker image(s)..."
 	@docker-compose down
-	@docker images | grep "openmaptiles" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi -f 
+	@docker images | grep "openmaptiles" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi -f
 	@docker images | grep "osm2vectortiles/mapbox-studio" | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi -f
 	@docker images | grep "klokantech/tileserver-gl"      | awk -F" " '{print $$3}' | xargs --no-run-if-empty docker rmi -f
 
@@ -118,21 +118,21 @@ download-geofabrik-list:
 	docker-compose run --rm import-osm  ./download-geofabrik-list.sh
 
 start-tileserver:
-	@echo " "	
+	@echo " "
 	@echo "***********************************************************"
-	@echo "* "		
-	@echo "* Download latest klokantech/tileserver-gl docker image    "
-	@echo "* see documentation: https://github.com/klokantech/tileserver-gl"	
-	@echo "* "			
+	@echo "* "
+	@echo "* Download/refresh klokantech/tileserver-gl docker image"
+	@echo "* see documentation: https://github.com/klokantech/tileserver-gl"
+	@echo "* "
 	@echo "***********************************************************"
-	@echo " "	
+	@echo " "
 	docker pull klokantech/tileserver-gl
-	@echo " "	
+	@echo " "
 	@echo "***********************************************************"
-	@echo "* "	
+	@echo "* "
 	@echo "* Start klokantech/tileserver-gl "
 	@echo "*       ----------------------------> check localhost:8080 "
-	@echo "* "		
+	@echo "* "
 	@echo "***********************************************************"
 	@echo " "
 	docker run -it --rm -v $$(pwd)/data:/data -p 8080:80 klokantech/tileserver-gl

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ start-tileserver:
 	@echo "* "		
 	@echo "***********************************************************"
 	@echo " "
-	docker run -it -v $$(pwd)/data:/data -p 8080:80 klokantech/tileserver-gl
+	docker run -it --rm -v $$(pwd)/data:/data -p 8080:80 klokantech/tileserver-gl
 
 start-mapbox-studio:
 	docker-compose up mapbox-studio

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -272,14 +272,18 @@ This is generating `.mbtiles` for your area :  [ MIN_ZOOM: "0"  - MAX_ZOOM: "7" 
 ./quickstart.sh yukon
 ```
 
-### Check other commands
+### Check tileserver
 
-`make help`
+start: 
+*  ` make start-tileserver` 
+and the generated maps are going to be available in webbrowser on [localhost:8080](http://localhost:8080/).
+
+This is only a quick preview, because your mbtiles only generated to zoom level 7 !  
 
 
 ### Change MIN_ZOOM and MAX_ZOOM
 
-modify the settings in the `.env`  file
+modify the settings in the `.env`  file, the defaults :
 * QUICKSTART_MIN_ZOOM=0
 * QUICKSTART_MAX_ZOOM=7  
 
@@ -292,3 +296,6 @@ Hints:
 * Small increments! Never starts with the MAX_ZOOM = 14
 * The suggested  MAX_ZOOM = 14  - use only with small extracts
 
+### Check other commands
+
+`make help`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     volumes:
      - ./build:/sql
   openmaptiles-tools:
-    image: "openmaptiles/openmaptiles-tools:latest"
+    image: "openmaptiles/openmaptiles-tools:0.3"
     env_file: .env
     links:
     - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     volumes:
      - ./build:/sql
   openmaptiles-tools:
-    image: "openmaptiles/openmaptiles-tools:0.3"
+    image: "openmaptiles/openmaptiles-tools:latest"
     env_file: .env
     links:
     - postgres

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -243,6 +243,12 @@ docker-compose -f docker-compose.yml -f ./data/docker-compose-config.yml  run --
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
+echo "====> : Add special metadata to mbtiles! "
+docker-compose run --rm openmaptiles-tools  generate-metadata ./data/tiles.mbtiles
+docker-compose run --rm openmaptiles-tools  chmod 666         ./data/tiles.mbtiles	
+
+echo " "
+echo "-------------------------------------------------------------------------------------"
 echo "====> : Stop PostgreSQL service ( but we keep PostgreSQL data volume for debugging )"
 docker-compose stop postgres
 


### PR DESCRIPTION
work in progress ( https://github.com/openmaptiles/openmaptiles/issues/122 )

- [x] `make start-tileserver`
- [x]  quickstart ` generate-metadata ./data/tiles.mbtiles`
- [x]  testing ..

now the  `"openmaptiles/openmaptiles-tools:latest"` ( https://github.com/openmaptiles/openmaptiles-tools/pull/10 )  contains the `generate-metadata` tool  , 
it is on the docker hub : https://hub.docker.com/r/openmaptiles/openmaptiles-tools/builds/
