### PR TITLE
Faster transportation_names

### DIFF
--- a/layers/transportation_name/merge_highways.sql
+++ b/layers/transportation_name/merge_highways.sql
@@ -20,14 +20,14 @@ CREATE MATERIALIZED VIEW osm_transportation_name_linestring AS (
 		member_osm_ids[0] AS osm_id,
 		member_osm_ids,
 		name,
-        ref,
+        	ref,
 		highway,
 		z_order
 	FROM (
 		SELECT
-			ST_LineMerge(ST_Union(geometry)) AS geometry,
+			ST_LineMerge(ST_Collect(geometry)) AS geometry,
 			name,
-            ref,
+            		ref,
 			highway,
 			min(z_order) AS z_order,
 			array_agg(DISTINCT osm_id) AS member_osm_ids


### PR DESCRIPTION
This is a test of faster transportation_names, by using ST_Collect in place of ST_Union. It's still going through testing, but the `import-sql` is significantly faster, but still has fast generating of mbtiles (unlike some of the approaches tried in #129 )

I will rebase this if #131 gets merged.

Don't merge yet!!