### PR TITLE
[quickstart] fix docker-compose version check ( >= 1.10 )

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -51,14 +51,17 @@ echo "      : Your docker system:"
 docker         --version
 docker-compose --version
 
+# based on: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers 
+function version { echo "$@" | tr -cs '0-9.' '.' | gawk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
+
 COMPOSE_VER=$(docker-compose version --short)
-if [ $COMPOSE_VER "<" $MIN_COMPOSE_VER ]; then
+if [ "$(version "$COMPOSE_VER")" -lt "$(version "$MIN_COMPOSE_VER")" ]; then
   echo "ERR: Your Docker-compose version is Known to have bugs , Please Update docker-compose!"
   exit 1
 fi
 
 DOCKER_VER="$(docker -v | awk -F '[ ,]+' '{ print $3 }')"
-if [ $DOCKER_VER "<" $MIN_DOCKER_VER ]; then
+if [ "$(version "$DOCKER_VER")" -lt "$(version "$MIN_DOCKER_VER")" ]; then
   echo "ERR: Your Docker version is not compatible. Please Update docker!"
   exit 1
 fi


### PR DESCRIPTION
I am so sorry, because my `quickstart.sh` failed with  the new docker-compose:  1.10.0
https://github.com/docker/compose/releases/tag/1.10.0

so this is my fix ...


I have tested with special version numbers  like ` 1.7.0rc1` , `1.11.2nightly`, ... 
so I hope it works ... 
```
version: 001001002 :: 1.1.2
version: 001012000 :: 1.12.0
version: 001007000 :: 1.7.0rc1
version: 001007000 :: 1.7.0dev
version: 001007000 :: 1.7.0-dev
version: 001011002 :: 1.11.2nightly
version: 001021000 :: 1.21.0rc13
version: 001008000 :: 1.8.0-rc1
```

and I have tested with  reinstalling 3 `docker-compose` versions

if anybody have a better solutions, please replace ..
 