### PR TITLE
use common date command option between GNU date and BSD date

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -282,7 +282,7 @@ md5sum ./data/osmstat.txt                     >> ./data/quickstart_checklist.chk
 cat ./data/quickstart_checklist.chk
 
 ENDTIME=$(date +%s)
-ENDDATE=$(date -Iminutes)
+ENDDATE=$(date +"%Y-%m-%dT%H:%M%z")
 MODDATE=$(stat -c  %y  ./data/${testdata} )
 
 echo " "

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -33,7 +33,7 @@ testdata=${osm_area}.osm.pbf
 MIN_COMPOSE_VER=1.7.1
 MIN_DOCKER_VER=1.10.0
 STARTTIME=$(date +%s)
-STARTDATE=$(date -Iminutes)
+STARTDATE=$(date +"%Y-%m-%dT%H:%M%z")
 githash=$( git rev-parse HEAD )
 
 log_file=./quickstart.log


### PR DESCRIPTION
quickstart.sh stop at date command in Mac environment because -Iminutes option is only available in GNU date command.