### PR TITLE
Add German names (name_de), unify English names (name_en)

### DIFF
--- a/layers/mountain_peak/layer.sql
+++ b/layers/mountain_peak/layer.sql
@@ -3,11 +3,13 @@
 -- etldoc:     style="rounded,filled", label="layer_mountain_peak | <z7_> z7+" ] ;
 
 CREATE OR REPLACE FUNCTION layer_mountain_peak(bbox geometry, zoom_level integer, pixel_width numeric)
-RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, ele int, ele_ft int, "rank" int) AS $$
+RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de text, ele int, ele_ft int, "rank" int) AS $$
    -- etldoc: osm_peak_point -> layer_mountain_peak:z7_
-   SELECT osm_id, geometry, name, name_en, ele::int, ele_ft::int, rank::int
+   SELECT osm_id, geometry, name, name_en, name_de, ele::int, ele_ft::int, rank::int
    FROM (
-     SELECT osm_id, geometry, name, name_en,
+     SELECT osm_id, geometry, name,
+     COALESCE(NULLIF(name_en, ''), name) AS name_en,
+     COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
      substring(ele from E'^(-?\\d+)(\\D|$)')::int AS ele,
      round(substring(ele from E'^(-?\\d+)(\\D|$)')::int*3.2808399)::int AS ele_ft,
        row_number() OVER (

--- a/layers/mountain_peak/mapping.yaml
+++ b/layers/mountain_peak/mapping.yaml
@@ -15,6 +15,9 @@ tables:
     - name: name_en
       key: name:en
       type: string
+    - name: name_de
+      key: name:de
+      type: string
     - name: ele
       key: ele
       type: string

--- a/layers/mountain_peak/mountain_peak.yaml
+++ b/layers/mountain_peak/mountain_peak.yaml
@@ -6,7 +6,8 @@ layer:
   srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
   fields:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Key:name) value of the peak.
-    name_en: The english `name:en` value if available.
+    name_en: English name `name:en` if available, otherwise `name`.
+    name_de: German name `name:de` if available, otherwise `name` or `name:en`.
     elev_m: Elevation (`ele`) in meters.
   datasource:
     geometry_field: geometry

--- a/layers/mountain_peak/mountain_peak.yaml
+++ b/layers/mountain_peak/mountain_peak.yaml
@@ -11,7 +11,7 @@ layer:
   datasource:
     geometry_field: geometry
     srid: 900913
-    query: (SELECT osm_id, geometry, name, name_en, ele, ele_ft, rank FROM layer_mountain_peak(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, name, name_en, name_de, ele, ele_ft, rank FROM layer_mountain_peak(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:
   - ./layer.sql
 datasources:

--- a/layers/place/city.sql
+++ b/layers/place/city.sql
@@ -4,8 +4,11 @@
 
 -- etldoc: osm_city_point -> layer_city:z2_14
 CREATE OR REPLACE FUNCTION layer_city(bbox geometry, zoom_level int, pixel_width numeric)
-RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, place city_place, "rank" int, capital int) AS $$
-    SELECT osm_id, geometry, name, COALESCE(NULLIF(name_en, ''), name) AS name_en, place, "rank", normalize_capital_level(capital) AS capital
+RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de text, place city_place, "rank" int, capital int) AS $$
+    SELECT osm_id, geometry, name,
+    COALESCE(NULLIF(name_en, ''), name) AS name_en,
+    COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
+    place, "rank", normalize_capital_level(capital) AS capital
     FROM osm_city_point
     WHERE geometry && bbox
       AND ((zoom_level = 2 AND "rank" = 1)
@@ -14,11 +17,15 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, place c
     UNION ALL
     SELECT osm_id, geometry, name,
         COALESCE(NULLIF(name_en, ''), name) AS name_en,
+        COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
         place,
         COALESCE("rank", gridrank + 10),
         normalize_capital_level(capital) AS capital
     FROM (
-      SELECT osm_id, geometry, name, name_en, place, "rank", capital,
+      SELECT osm_id, geometry, name,
+      COALESCE(NULLIF(name_en, ''), name) AS name_en,
+      COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
+      place, "rank", capital,
       row_number() OVER (
         PARTITION BY LabelGrid(geometry, 128 * pixel_width)
         ORDER BY "rank" ASC NULLS LAST,

--- a/layers/place/mapping.yaml
+++ b/layers/place/mapping.yaml
@@ -55,6 +55,7 @@ tables:
       type: geometry
     - *name
     - *name_en
+    - *name_de
     filters:
       require:
         name: ["__any__"]

--- a/layers/place/place.yaml
+++ b/layers/place/place.yaml
@@ -52,7 +52,7 @@ layer:
   buffer_size: 128
   datasource:
     geometry_field: geometry
-    query: (SELECT geometry, name, name_en, class, rank, capital FROM layer_place(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT geometry, name, name_en, name_de, class, rank, capital FROM layer_place(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:
   - ./types.sql
   - ./capital.sql

--- a/layers/place/place.yaml
+++ b/layers/place/place.yaml
@@ -7,7 +7,8 @@ layer:
       We suggest you use different font styles and sizes to create a text hierarchy.
   fields:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Key:name) value of the POI.
-    name_en: The English `name:en` value or local `name` if not available.
+    name_en: English name `name:en` if available, otherwise `name`.
+    name_de: German name `name:de` if available, otherwise `name` or `name:en`.
     capital:
       description: |
           The **capital** field marks the

--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -3,8 +3,11 @@
 -- etldoc:     label="layer_poi | <z14_> z14+" ] ;
 
 CREATE OR REPLACE FUNCTION layer_poi(bbox geometry, zoom_level integer, pixel_width numeric)
-RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, class text, subclass text, "rank" int) AS $$
-    SELECT osm_id, geometry, NULLIF(name, '') AS name, NULLIF(name_en, '') AS name_en, poi_class(subclass) AS class, subclass,
+RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de text, class text, subclass text, "rank" int) AS $$
+    SELECT osm_id, geometry, NULLIF(name, '') AS name,
+    COALESCE(NULLIF(name_en, ''), name) AS name_en,
+    COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
+    poi_class(subclass) AS class, subclass,
         row_number() OVER (
             PARTITION BY LabelGrid(geometry, 100 * pixel_width)
             ORDER BY CASE WHEN name = '' THEN 2000 ELSE poi_class_rank(poi_class(subclass)) END ASC

--- a/layers/poi/mapping.yaml
+++ b/layers/poi/mapping.yaml
@@ -1,6 +1,6 @@
 
-# imposm3 mapping file for https://github.com/osm2vectortiles/imposm3 
-# Warning: this is not the official imposm3  
+# imposm3 mapping file for https://github.com/osm2vectortiles/imposm3
+# Warning: this is not the official imposm3
 
 # aerialway values , see http://taginfo.openstreetmap.org/keys/aerialway#values
 def_poi_mapping_aerialway: &poi_mapping_aerialway
@@ -306,6 +306,9 @@ tables:
     - name: name_en
       key: name:en
       type: string
+    - name: name_de
+      key: name:de
+      type: string
     - name: subclass
       type: mapping_value
     mapping:
@@ -335,6 +338,9 @@ tables:
       type: string
     - name: name_en
       key: name:en
+      type: string
+    - name: name_de
+      key: name:de
       type: string
     - name: subclass
       type: mapping_value

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -31,9 +31,9 @@ layer:
   datasource:
     geometry_field: geometry
     srid: 900913
-    query: (SELECT geometry, name, name_en, class, subclass, rank FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT geometry, name, name_en, name_de, class, subclass, rank FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:
-  - ./poi_polygon_update.sql 
+  - ./poi_polygon_update.sql
   - ./class.sql
   - ./layer.sql
 datasources:

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -7,7 +7,8 @@ layer:
   srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
   fields:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Key:name) value of the POI.
-    name_en: The english `name:en` value if available.
+    name_en: English name `name:en` if available, otherwise `name`.
+    name_de: German name `name:de` if available, otherwise `name` or `name:en`.
     class: |
         More general classes of POIs. If there is no more general `class` for the `subclass`
         this field will contain the same value as `subclass`.

--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -55,6 +55,10 @@ name_en_field: &name_en
   name: name_en
   key: name:en
   type: string
+name_de_field: &name_de
+  name: name_de
+  key: name:de
+  type: string
 short_name_field: &short_name
   key: short_name
   name: short_name
@@ -125,6 +129,7 @@ tables:
     - *layer
     - *name
     - *name_en
+    - *name_de
     - *short_name
     - *tunnel
     - *bridge
@@ -178,6 +183,7 @@ tables:
     - *layer
     - *name
     - *name_en
+    - *name_de
     - *short_name
     - *tunnel
     - *bridge

--- a/layers/transportation_name/layer.sql
+++ b/layers/transportation_name/layer.sql
@@ -3,10 +3,11 @@
 -- etldoc:     label="layer_transportation_name | <z6> z6 | <z7> z7 | <z8> z8 |<z9> z9 |<z10> z10 |<z11> z11 |<z12> z12|<z13> z13|<z14_> z14+" ] ;
 
 CREATE OR REPLACE FUNCTION layer_transportation_name(bbox geometry, zoom_level integer)
-RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, ref text, ref_length int, network text, class text) AS $$
+RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de text, ref text, ref_length int, network text, class text) AS $$
     SELECT osm_id, geometry,
       NULLIF(name, '') AS name,
-      COALESCE(NULLIF(name_en, ''), NULLIF(name, '')) AS name_en,
+      COALESCE(NULLIF(name_en, ''), name) AS name_en,
+      COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
       NULLIF(ref, ''), NULLIF(LENGTH(ref), 0) AS ref_length,
       --TODO: The road network of the road is not yet implemented
       case

--- a/layers/transportation_name/merge_highways.sql
+++ b/layers/transportation_name/merge_highways.sql
@@ -14,7 +14,8 @@ CREATE MATERIALIZED VIEW osm_transportation_name_network AS (
       hl.geometry,
       hl.osm_id,
       hl.name,
-      COALESCE(NULLIF(hl.name_en, ''), hl.name) AS name_en,
+      hl.name_en,
+      hl.name_de,
       rm.network_type,
       CASE
         WHEN (rm.network_type is not null AND nullif(rm.ref::text, '') is not null)
@@ -41,6 +42,7 @@ CREATE MATERIALIZED VIEW osm_transportation_name_linestring AS (
         member_osm_ids,
         name,
         name_en,
+        name_de,
         ref,
         highway,
         network_type AS network,
@@ -50,6 +52,7 @@ CREATE MATERIALIZED VIEW osm_transportation_name_linestring AS (
           ST_LineMerge(ST_Collect(geometry)) AS geometry,
           name,
           name_en,
+          name_de,
           ref,
           highway,
           network_type,
@@ -59,14 +62,14 @@ CREATE MATERIALIZED VIEW osm_transportation_name_linestring AS (
       WHERE ("rank"=1 OR "rank" is null)
         AND (name <> '' OR ref <> '')
         AND NULLIF(highway, '') IS NOT NULL
-      group by name, name_en, ref, highway, network_type
+      group by name, name_en, name_de, ref, highway, network_type
     ) AS highway_union
 );
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_geometry_idx ON osm_transportation_name_linestring USING gist(geometry);
 
 -- etldoc: osm_transportation_name_linestring -> osm_transportation_name_linestring_gen1
 CREATE MATERIALIZED VIEW osm_transportation_name_linestring_gen1 AS (
-    SELECT ST_Simplify(geometry, 50) AS geometry, osm_id, member_osm_ids, name, name_en, ref, highway, network, z_order
+    SELECT ST_Simplify(geometry, 50) AS geometry, osm_id, member_osm_ids, name, name_en, name_de, ref, highway, network, z_order
     FROM osm_transportation_name_linestring
     WHERE highway IN ('motorway','trunk')  AND ST_Length(geometry) > 8000
 );
@@ -74,7 +77,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen1_geometry_idx 
 
 -- etldoc: osm_transportation_name_linestring_gen1 -> osm_transportation_name_linestring_gen2
 CREATE MATERIALIZED VIEW osm_transportation_name_linestring_gen2 AS (
-    SELECT ST_Simplify(geometry, 120) AS geometry, osm_id, member_osm_ids, name, name_en, ref, highway, network, z_order
+    SELECT ST_Simplify(geometry, 120) AS geometry, osm_id, member_osm_ids, name, name_en, name_de, ref, highway, network, z_order
     FROM osm_transportation_name_linestring_gen1
     WHERE highway IN ('motorway','trunk')  AND ST_Length(geometry) > 14000
 );
@@ -82,7 +85,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen2_geometry_idx 
 
 -- etldoc: osm_transportation_name_linestring_gen2 -> osm_transportation_name_linestring_gen3
 CREATE MATERIALIZED VIEW osm_transportation_name_linestring_gen3 AS (
-    SELECT ST_Simplify(geometry, 200) AS geometry, osm_id, member_osm_ids, name, name_en, ref, highway, network, z_order
+    SELECT ST_Simplify(geometry, 200) AS geometry, osm_id, member_osm_ids, name, name_en, name_de, ref, highway, network, z_order
     FROM osm_transportation_name_linestring_gen2
     WHERE highway = 'motorway' AND ST_Length(geometry) > 20000
 );
@@ -90,7 +93,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen3_geometry_idx 
 
 -- etldoc: osm_transportation_name_linestring_gen3 -> osm_transportation_name_linestring_gen4
 CREATE MATERIALIZED VIEW osm_transportation_name_linestring_gen4 AS (
-    SELECT ST_Simplify(geometry, 500) AS geometry, osm_id, member_osm_ids, name, name_en, ref, highway, network, z_order
+    SELECT ST_Simplify(geometry, 500) AS geometry, osm_id, member_osm_ids, name, name_en, name_de, ref, highway, network, z_order
     FROM osm_transportation_name_linestring_gen3
     WHERE highway = 'motorway' AND ST_Length(geometry) > 20000
 );

--- a/layers/transportation_name/transportation_name.yaml
+++ b/layers/transportation_name/transportation_name.yaml
@@ -9,7 +9,8 @@ layer:
   srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
   fields:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Highways#Names_and_references) value of the highway.
-    name_en: The english `name:en` value if available.
+    name_en: English name `name:en` if available, otherwise `name`.
+    name_de: German name `name:de` if available, otherwise `name` or `name:en`.
     ref: The OSM [`ref`](http://wiki.openstreetmap.org/wiki/Key:ref) tag of the motorway or its network.
     ref_length: Length of the `ref` field. Useful for having a shield icon as background for labeling motorways.
     network:

--- a/layers/transportation_name/transportation_name.yaml
+++ b/layers/transportation_name/transportation_name.yaml
@@ -45,7 +45,7 @@ layer:
   datasource:
     geometry_field: geometry
     srid: 900913
-    query: (SELECT geometry, name, name_en, ref, ref_length, network::text, class::text FROM layer_transportation_name(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, name, name_en, name_de, ref, ref_length, network::text, class::text FROM layer_transportation_name(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./network_type.sql
   - ./merge_highways.sql

--- a/layers/water/mapping.yaml
+++ b/layers/water/mapping.yaml
@@ -53,6 +53,9 @@ tables:
     - name: name_en
       key: name:en
       type: string
+    - name: name_de
+      key: name:de
+      type: string
     - name: natural
       key: natural
       type: string

--- a/layers/water_name/layer.sql
+++ b/layers/water_name/layer.sql
@@ -3,10 +3,13 @@
 -- etldoc:     label="layer_water_name | <z9_13> z9_13 | <z14_> z14+" ] ;
 
 CREATE OR REPLACE FUNCTION layer_water_name(bbox geometry, zoom_level integer)
-RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, class text) AS $$
+RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de text, class text) AS $$
     -- etldoc: osm_water_lakeline ->  layer_water_name:z9_13
     -- etldoc: osm_water_lakeline ->  layer_water_name:z14_
-    SELECT osm_id, geometry, name, name_en, 'lake'::text AS class
+    SELECT osm_id, geometry, name,
+    COALESCE(NULLIF(name_en, ''), name) AS name_en,
+    COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
+    'lake'::text AS class
     FROM osm_water_lakeline
     WHERE geometry && bbox
       AND ((zoom_level BETWEEN 9 AND 13 AND LineLabel(zoom_level, NULLIF(name, ''), geometry))
@@ -14,7 +17,10 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, class t
     -- etldoc: osm_water_point ->  layer_water_name:z9_13
     -- etldoc: osm_water_point ->  layer_water_name:z14_
     UNION ALL
-    SELECT osm_id, geometry, name, name_en, 'lake'::text AS class
+    SELECT osm_id, geometry, name,
+    COALESCE(NULLIF(name_en, ''), name) AS name_en,
+    COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
+    'lake'::text AS class
     FROM osm_water_point
     WHERE geometry && bbox AND (
         (zoom_level BETWEEN 9 AND 13 AND area > 70000*2^(20-zoom_level))
@@ -22,7 +28,10 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, class t
     )
     -- etldoc: osm_marine_point ->  layer_water_name:z0_14_
     UNION ALL
-    SELECT osm_id, geometry, name, name_en, place::text AS class
+    SELECT osm_id, geometry, name,
+    COALESCE(NULLIF(name_en, ''), name) AS name_en,
+    COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
+    place::text AS class
     FROM osm_marine_point
     WHERE geometry && bbox AND (
         place = 'ocean'

--- a/layers/water_name/mapping.yaml
+++ b/layers/water_name/mapping.yaml
@@ -13,6 +13,9 @@ tables:
     - name: name_en
       key: name:en
       type: string
+    - name: name_de
+      key: name:de
+      type: string
     - name: place
       key: place
       type: string

--- a/layers/water_name/water_lakeline.sql
+++ b/layers/water_name/water_lakeline.sql
@@ -8,7 +8,7 @@ DROP MATERIALIZED VIEW IF EXISTS osm_water_lakeline CASCADE;
 CREATE MATERIALIZED VIEW osm_water_lakeline AS (
 	SELECT wp.osm_id,
 		ll.wkb_geometry AS geometry,
-		name, name_en, ST_Area(wp.geometry) AS area
+		name, name_en, name_de, ST_Area(wp.geometry) AS area
     FROM osm_water_polygon AS wp
     INNER JOIN lake_centerline ll ON wp.osm_id = ll.osm_id
     WHERE wp.name <> ''
@@ -24,7 +24,7 @@ CREATE OR REPLACE FUNCTION water_lakeline.flag() RETURNS trigger AS $$
 BEGIN
     INSERT INTO water_lakeline.updates(t) VALUES ('y')  ON CONFLICT(t) DO NOTHING;
     RETURN null;
-END;    
+END;
 $$ language plpgsql;
 
 CREATE OR REPLACE FUNCTION water_lakeline.refresh() RETURNS trigger AS

--- a/layers/water_name/water_name.yaml
+++ b/layers/water_name/water_name.yaml
@@ -17,7 +17,7 @@ layer:
   datasource:
     geometry_field: geometry
     srid: 900913
-    query: (SELECT geometry, name, name_en, class FROM layer_water_name(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, name, name_en, name_de, class FROM layer_water_name(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./merge_marine_rank.sql
   - ./water_lakeline.sql

--- a/layers/water_name/water_name.yaml
+++ b/layers/water_name/water_name.yaml
@@ -6,7 +6,8 @@ layer:
       which derives nice centerlines from OSM water bodies. Only the most important lakes contain labels.
   fields:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Key:name) value of the water body.
-    name_en: The english `name:en` value if available.
+    name_en: English name `name:en` if available, otherwise `name`.
+    name_de: German name `name:de` if available, otherwise `name` or `name:en`.
     class:
       description: |
           At the moment only `lake` since no ocean parts are labelled. *Reserved for future use*.

--- a/layers/water_name/water_point.sql
+++ b/layers/water_name/water_point.sql
@@ -8,13 +8,13 @@ DROP MATERIALIZED VIEW IF EXISTS  osm_water_point CASCADE;
 CREATE MATERIALIZED VIEW osm_water_point AS (
     SELECT
         wp.osm_id, ST_PointOnSurface(wp.geometry) AS geometry,
-        wp.name, wp.name_en, ST_Area(wp.geometry) AS area
+        wp.name, wp.name_en, wp.name_de, ST_Area(wp.geometry) AS area
     FROM osm_water_polygon AS wp
     LEFT JOIN lake_centerline ll ON wp.osm_id = ll.osm_id
     WHERE ll.osm_id IS NULL AND wp.name <> ''
 );
 CREATE INDEX IF NOT EXISTS osm_water_point_geometry_idx ON osm_water_point USING gist (geometry);
- 
+
 -- Handle updates
 
 CREATE SCHEMA IF NOT EXISTS water_point;
@@ -24,7 +24,7 @@ CREATE OR REPLACE FUNCTION water_point.flag() RETURNS trigger AS $$
 BEGIN
     INSERT INTO water_point.updates(t) VALUES ('y')  ON CONFLICT(t) DO NOTHING;
     RETURN null;
-END;    
+END;
 $$ language plpgsql;
 
 CREATE OR REPLACE FUNCTION water_point.refresh() RETURNS trigger AS

--- a/layers/waterway/mapping.yaml
+++ b/layers/waterway/mapping.yaml
@@ -32,6 +32,9 @@ tables:
     - name: name_en
       key: name:en
       type: string
+    - name: name_de
+      key: name:de
+      type: string
     mapping:
       waterway:
       - stream

--- a/layers/waterway/merge_waterway.sql
+++ b/layers/waterway/merge_waterway.sql
@@ -14,21 +14,21 @@ DROP MATERIALIZED VIEW IF EXISTS osm_important_waterway_linestring_gen3 CASCADE;
 CREATE MATERIALIZED VIEW osm_important_waterway_linestring AS (
     SELECT
         (ST_Dump(geometry)).geom AS geometry,
-        name, name_en
+        name, name_en, name_de
     FROM (
         SELECT
             ST_LineMerge(ST_Union(geometry)) AS geometry,
-            name, COALESCE(NULLIF(name_en, ''), name) AS name_en
+            name, name_en, name_de
         FROM osm_waterway_linestring
         WHERE name <> '' AND waterway = 'river'
-        GROUP BY name, name_en
+        GROUP BY name, name_en, name_de
     ) AS waterway_union
 );
 CREATE INDEX IF NOT EXISTS osm_important_waterway_linestring_geometry_idx ON osm_important_waterway_linestring USING gist(geometry);
 
 -- etldoc: osm_important_waterway_linestring -> osm_important_waterway_linestring_gen1
 CREATE MATERIALIZED VIEW osm_important_waterway_linestring_gen1 AS (
-    SELECT ST_Simplify(geometry, 60) AS geometry, name, name_en
+    SELECT ST_Simplify(geometry, 60) AS geometry, name, name_en, name_de
     FROM osm_important_waterway_linestring
     WHERE ST_Length(geometry) > 1000
 );
@@ -36,7 +36,7 @@ CREATE INDEX IF NOT EXISTS osm_important_waterway_linestring_gen1_geometry_idx O
 
 -- etldoc: osm_important_waterway_linestring_gen1 -> osm_important_waterway_linestring_gen2
 CREATE MATERIALIZED VIEW osm_important_waterway_linestring_gen2 AS (
-    SELECT ST_Simplify(geometry, 100) AS geometry, name, name_en
+    SELECT ST_Simplify(geometry, 100) AS geometry, name, name_en, name_de
     FROM osm_important_waterway_linestring_gen1
     WHERE ST_Length(geometry) > 4000
 );
@@ -44,7 +44,7 @@ CREATE INDEX IF NOT EXISTS osm_important_waterway_linestring_gen2_geometry_idx O
 
 -- etldoc: osm_important_waterway_linestring_gen2 -> osm_important_waterway_linestring_gen3
 CREATE MATERIALIZED VIEW osm_important_waterway_linestring_gen3 AS (
-    SELECT ST_Simplify(geometry, 200) AS geometry, name, name_en
+    SELECT ST_Simplify(geometry, 200) AS geometry, name, name_en, name_de
     FROM osm_important_waterway_linestring_gen2
     WHERE ST_Length(geometry) > 8000
 );
@@ -86,6 +86,3 @@ CREATE CONSTRAINT TRIGGER trigger_refresh
     INITIALLY DEFERRED
     FOR EACH ROW
     EXECUTE PROCEDURE waterway.refresh();
-
-
-

--- a/layers/waterway/waterway.sql
+++ b/layers/waterway/waterway.sql
@@ -1,65 +1,66 @@
 
 -- etldoc: ne_110m_rivers_lake_centerlines ->  waterway_z3
 CREATE OR REPLACE VIEW waterway_z3 AS (
-    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en
+    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en, NULL::text AS name_de
     FROM ne_110m_rivers_lake_centerlines
     WHERE featurecla = 'River'
 );
 
 -- etldoc: ne_50m_rivers_lake_centerlines ->  waterway_z4
 CREATE OR REPLACE VIEW waterway_z4 AS (
-    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en
+    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en, NULL::text AS name_de
     FROM ne_50m_rivers_lake_centerlines
     WHERE featurecla = 'River'
 );
 
 -- etldoc: ne_10m_rivers_lake_centerlines ->  waterway_z6
 CREATE OR REPLACE VIEW waterway_z6 AS (
-    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en
+    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en, NULL::text AS name_de
     FROM ne_10m_rivers_lake_centerlines
     WHERE featurecla = 'River'
 );
 
 -- etldoc: osm_important_waterway_linestring_gen3 ->  waterway_z9
 CREATE OR REPLACE VIEW waterway_z9 AS (
-    SELECT geometry, 'river'::text AS class, name, name_en FROM osm_important_waterway_linestring_gen3
+    SELECT geometry, 'river'::text AS class, name, name_en, name_de FROM osm_important_waterway_linestring_gen3
 );
 
 -- etldoc: osm_important_waterway_linestring_gen2 ->  waterway_z10
 CREATE OR REPLACE VIEW waterway_z10 AS (
-    SELECT geometry, 'river'::text AS class, name, name_en FROM osm_important_waterway_linestring_gen2
+    SELECT geometry, 'river'::text AS class, name, name_en, name_de FROM osm_important_waterway_linestring_gen2
 );
 
 -- etldoc:osm_important_waterway_linestring_gen1 ->  waterway_z11
 CREATE OR REPLACE VIEW waterway_z11 AS (
-    SELECT geometry, 'river'::text AS class, name, name_en FROM osm_important_waterway_linestring_gen1
+    SELECT geometry, 'river'::text AS class, name, name_en, name_de FROM osm_important_waterway_linestring_gen1
 );
 
 -- etldoc: osm_waterway_linestring ->  waterway_z12
 CREATE OR REPLACE VIEW waterway_z12 AS (
-    SELECT geometry, waterway AS class, name, name_en FROM osm_waterway_linestring
+    SELECT geometry, waterway AS class, name, name_en, name_de FROM osm_waterway_linestring
     WHERE waterway IN ('river', 'canal')
 );
 
 -- etldoc: osm_waterway_linestring ->  waterway_z13
 CREATE OR REPLACE VIEW waterway_z13 AS (
-    SELECT geometry, waterway::text AS class, name, name_en FROM osm_waterway_linestring
+    SELECT geometry, waterway::text AS class, name, name_en, name_de FROM osm_waterway_linestring
     WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
 );
 
 -- etldoc: osm_waterway_linestring ->  waterway_z14
 CREATE OR REPLACE VIEW waterway_z14 AS (
-    SELECT geometry, waterway::text AS class, name, name_en FROM osm_waterway_linestring
+    SELECT geometry, waterway::text AS class, name, name_en, name_de FROM osm_waterway_linestring
 );
 
 -- etldoc: layer_waterway[shape=record fillcolor=lightpink, style="rounded,filled",
 -- etldoc:     label="layer_waterway | <z3> z3 |<z4_5> z4-z5 |<z6_8> z6-8 | <z9> z9 |<z10> z10 |<z11> z11 |<z12> z12|<z13> z13|<z14> z14+" ];
 
 CREATE OR REPLACE FUNCTION layer_waterway(bbox geometry, zoom_level int)
-RETURNS TABLE(geometry geometry, class text, name text, name_en text) AS $$
+RETURNS TABLE(geometry geometry, class text, name text, name_en text, name_de text) AS $$
     SELECT geometry, class,
         NULLIF(name, '') AS name,
-        COALESCE(NULLIF(name_en, ''), name) AS name_en
+        COALESCE(NULLIF(name_en, ''), name) AS name_en,
+        COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de
     FROM (
         -- etldoc: waterway_z3 ->  layer_waterway:z3
         SELECT * FROM waterway_z3 WHERE zoom_level = 3

--- a/layers/waterway/waterway.yaml
+++ b/layers/waterway/waterway.yaml
@@ -22,7 +22,7 @@ layer:
       - ditch
   datasource:
     geometry_field: geometry
-    query: (SELECT geometry, name, name_en, class FROM layer_waterway(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, name, name_en, name_de, class FROM layer_waterway(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./merge_waterway.sql
   - ./waterway.sql

--- a/layers/waterway/waterway.yaml
+++ b/layers/waterway/waterway.yaml
@@ -10,7 +10,8 @@ layer:
     name: |
         The OSM [`name`](http://wiki.openstreetmap.org/wiki/Key:name) value of the waterway.
         The `name` field may be empty for NaturalEarth data or at lower zoom levels.
-    name_en: The english `name:en` value if available.
+    name_en: English name `name:en` if available, otherwise `name`.
+    name_de: German name `name:de` if available, otherwise `name` or `name:en`.
     class:
       description: |
         The original value of the [`waterway`](http://wiki.openstreetmap.org/wiki/Key:waterway) tag.


### PR DESCRIPTION
German names `name_de` added to layers. It contains value of the first non-empty tag:
1. `name:de`
1. `name`
1. `name:en`

Similarly, `name_en` now contains value of the first non-empty tag:
1. `name:en`
1. `name`

All layers with names were affected:
- mountain_peak
- place
- poi
- transportation_name
- water_name
- waterway

