### PR TITLE
Add support for PBF tiles generated directly from postgres

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -19,10 +19,12 @@
     * https://docs.docker.com/compose/install/
 * disk space ( >= ~15Gb  )
     * for small extracts  >= ~15Gb
-    * for big extracts ( continents, planet) > 20 ... 1000 Gb
+    * for big extracts ( continents, planet) 250 Gb
     * And depends on
         * OpenStreetMap data size
         * Zoom level
+    * Best on SSD for postserve but completely usable on HDD
+    * Takes 24hrs to import on a reasonable machine, and is immediately available with postserve
 * memory ( >= 3Gb )
     * for small extracts 3Gb-8Gb RAM
     * for big extracts ( Europe, Planet) > 8-32 Gb
@@ -368,6 +370,10 @@ mkdir -p data
 mv my.osm.pbf data/
 ./quickstart.sh my
 ```
+
+### Check postserve
+*  ` docker-compose up -d postserve`
+and the generated maps are going to be available in browser on [localhost:8090/0/0/0.pbf](http://localhost:8090/0/0/0.pbf).
 
 ### Check tileserver
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
   cache:
 services:
   postgres:
-    image: "openmaptiles/postgis:2.3"
+    image: "openmaptiles/postgis:2.5"
     volumes:
     - pgdata:/var/lib/postgresql/data
     networks:
@@ -113,6 +113,16 @@ services:
       BBOX: ${BBOX}
       MIN_ZOOM: ${MIN_ZOOM}
       MAX_ZOOM: ${MAX_ZOOM}
+  postserve:
+    image: "openmaptiles/postserve"
+    env_file: .env
+    networks:
+     - postgres_conn
+    ports:
+    - "8090:8080"
+    volumes:
+     - ./build/openmaptiles.tm2source:/mapping
+
 
 networks:
   postgres_conn:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       MIN_ZOOM: ${MIN_ZOOM}
       MAX_ZOOM: ${MAX_ZOOM}
   postserve:
-    image: "openmaptiles/postserve"
+    image: "openmaptiles/postserve:0.1"
     env_file: .env
     networks:
      - postgres_conn

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -244,6 +244,11 @@ make psql-analyze
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
+echo "====> : Bring up postserve at localhost:8090/tiles/{z}/{x}/{y}.pbf"
+docker-compose up -d postserve
+
+echo " "
+echo "-------------------------------------------------------------------------------------"
 echo "====> : Start generating MBTiles (containing gzipped MVT PBF) from a TM2Source project. "
 echo "      : TM2Source project definitions : ./build/openmaptiles.tm2source/data.yml "
 echo "      : Output MBTiles: ./data/tiles.mbtiles  "


### PR DESCRIPTION
Without the image in docker hub yet, you would need to build the docker image by cloning [postserve](https://github.com/openmaptiles/postserve) and running:

docker build -t openmaptiles/postserve .

Then, run quickstart.sh as normal, and it should come up at "localhost:8090/tiles/0/0/0.pbf"

@klokan / @jirik Please add the postserve image to Docker Hub. I will wait for you to do so before I commit so that the Travis tests can pass.

This closes https://github.com/openmaptiles/openmaptiles/issues/3