### PR TITLE
Adjust zres values to decrease tile size

### DIFF
--- a/layers/aeroway/mapping.yaml
+++ b/layers/aeroway/mapping.yaml
@@ -2,19 +2,19 @@ generalized_tables:
   # etldoc: imposm3 -> osm_aeroway_polygon_gen3
   aeroway_polygon_gen3:
     source: aeroway_polygon_gen2
-    sql_filter: area>power(ZRES11,2)
+    sql_filter: area>power(ZRES10,2)
     tolerance: ZRES11
 
   # etldoc: imposm3 -> osm_aeroway_polygon_gen2
   aeroway_polygon_gen2:
     source: aeroway_polygon_gen1
-    sql_filter: area>power(ZRES12,2)
+    sql_filter: area>power(ZRES11,2)
     tolerance: ZRES12
 
   # etldoc: imposm3 -> osm_aeroway_polygon_gen1
   aeroway_polygon_gen1:
     source: aeroway_polygon
-    sql_filter: area>power(ZRES13,2)
+    sql_filter: area>power(ZRES12,2)
     tolerance: ZRES13
 tables:
   # etldoc: imposm3 -> osm_aeroway_polygon

--- a/layers/building/mapping.yaml
+++ b/layers/building/mapping.yaml
@@ -5,7 +5,7 @@ generalized_tables:
   # etldoc: imposm3 -> osm_building_polygon_gen1
   building_polygon_gen1:
     source: building_polygon
-    sql_filter: area>power(ZRES13,2)
+    sql_filter: area>power(ZRES12,2)
     tolerance: ZRES13
 
 tables:

--- a/layers/landcover/mapping.yaml
+++ b/layers/landcover/mapping.yaml
@@ -4,37 +4,37 @@ generalized_tables:
   # etldoc: imposm3 -> osm_landcover_polygon_gen6
   landcover_polygon_gen6:
     source: landcover_polygon_gen5
-    sql_filter: area>power(ZRES8,2)
+    sql_filter: area>power(ZRES6,2)
     tolerance: ZRES8
 
   # etldoc: imposm3 -> osm_landcover_polygon_gen5
   landcover_polygon_gen5:
     source: landcover_polygon_gen4
-    sql_filter: area>power(ZRES9,2)
+    sql_filter: area>power(ZRES7,2)
     tolerance: ZRES9
 
   # etldoc: imposm3 -> osm_landcover_polygon_gen4
   landcover_polygon_gen4:
     source: landcover_polygon_gen3
-    sql_filter: area>power(ZRES10,2)
+    sql_filter: area>power(ZRES8,2)
     tolerance: ZRES10
 
   # etldoc: imposm3 -> osm_landcover_polygon_gen3
   landcover_polygon_gen3:
     source: landcover_polygon_gen2
-    sql_filter: area>power(ZRES11,2)
+    sql_filter: area>power(ZRES8,2)
     tolerance: ZRES11
 
   # etldoc: imposm3 -> osm_landcover_polygon_gen2
   landcover_polygon_gen2:
     source: landcover_polygon_gen1
-    sql_filter: area>power(ZRES12,2)
+    sql_filter: area>power(ZRES9,2)
     tolerance: ZRES12
 
   # etldoc: imposm3 -> osm_landcover_polygon_gen1
   landcover_polygon_gen1:
     source: landcover_polygon
-    sql_filter: area>power(ZRES13,2)
+    sql_filter: area>power(ZRES10,2)
     tolerance: ZRES13
 
 tables:

--- a/layers/landuse/mapping.yaml
+++ b/layers/landuse/mapping.yaml
@@ -2,27 +2,27 @@ generalized_tables:
   # etldoc: imposm3 -> osm_landuse_polygon_gen5
   landuse_polygon_gen5:
     source: landuse_polygon_gen4
-    sql_filter: area>power(ZRES9,2)
+    sql_filter: area>power(ZRES7,2)
     tolerance: ZRES9
   # etldoc: imposm3 -> osm_landuse_polygon_gen4
   landuse_polygon_gen4:
     source: landuse_polygon_gen3
-    sql_filter: area>power(ZRES10,2)
+    sql_filter: area>power(ZRES8,2)
     tolerance: ZRES10
   # etldoc: imposm3 -> osm_landuse_polygon_gen3
   landuse_polygon_gen3:
     source: landuse_polygon_gen2
-    sql_filter: area>power(ZRES11,2)
+    sql_filter: area>power(ZRES9,2)
     tolerance: ZRES11
   # etldoc: imposm3 -> osm_landuse_polygon_gen2
   landuse_polygon_gen2:
     source: landuse_polygon_gen1
-    sql_filter: area>power(ZRES12,2)
+    sql_filter: area>power(ZRES10,2)
     tolerance: ZRES12
   # etldoc: imposm3 -> osm_landuse_polygon_gen1
   landuse_polygon_gen1:
     source: landuse_polygon
-    sql_filter: area>power(ZRES13,2)
+    sql_filter: area>power(ZRES11,2)
     tolerance: ZRES13
 
 tables:

--- a/layers/park/mapping.yaml
+++ b/layers/park/mapping.yaml
@@ -2,49 +2,49 @@ generalized_tables:
   # etldoc: imposm3 -> osm_park_polygon_gen8
   park_polygon_gen8:
     source: park_polygon_gen6
-    sql_filter: area>power(ZRES6,2)
+    sql_filter: area>power(ZRES5,2)
     tolerance: ZRES6
 
   # etldoc: imposm3 -> osm_park_polygon_gen7
   park_polygon_gen7:
     source: park_polygon_gen6
-    sql_filter: area>power(ZRES7,2)
+    sql_filter: area>power(ZRES6,2)
     tolerance: ZRES7
 
   # etldoc: imposm3 -> osm_park_polygon_gen6
   park_polygon_gen6:
     source: park_polygon_gen5
-    sql_filter: area>power(ZRES8,2)
+    sql_filter: area>power(ZRES7,2)
     tolerance: ZRES8
 
   # etldoc: imposm3 -> osm_park_polygon_gen5
   park_polygon_gen5:
     source: park_polygon_gen4
-    sql_filter: area>power(ZRES9,2)
+    sql_filter: area>power(ZRES8,2)
     tolerance: ZRES9
 
   # etldoc: imposm3 -> osm_park_polygon_gen4
   park_polygon_gen4:
     source: park_polygon_gen3
-    sql_filter: area>power(ZRES10,2)
+    sql_filter: area>power(ZRES9,2)
     tolerance: ZRES10
 
   # etldoc: imposm3 -> osm_park_polygon_gen3
   park_polygon_gen3:
     source: park_polygon_gen2
-    sql_filter: area>power(ZRES11,2)
+    sql_filter: area>power(ZRES10,2)
     tolerance: ZRES11
 
   # etldoc: imposm3 -> osm_park_polygon_gen2
   park_polygon_gen2:
     source: park_polygon_gen1
-    sql_filter: area>power(ZRES12,2)
+    sql_filter: area>power(ZRES11,2)
     tolerance: ZRES12
 
   # etldoc: imposm3 -> osm_park_polygon_gen1
   park_polygon_gen1:
     source: park_polygon
-    sql_filter: area>power(ZRES13,2)
+    sql_filter: area>power(ZRES12,2)
     tolerance: ZRES13
 
 tables:

--- a/layers/water/mapping.yaml
+++ b/layers/water/mapping.yaml
@@ -3,37 +3,37 @@ generalized_tables:
   # etldoc: imposm3 -> osm_water_polygon_gen6
   water_polygon_gen6:
     source: water_polygon_gen5
-    sql_filter: area>power(ZRES6,2)
+    sql_filter: area>power(ZRES5,2)
     tolerance: ZRES6
 
   # etldoc: imposm3 -> osm_water_polygon_gen5
   water_polygon_gen5:
     source: water_polygon_gen4
-    sql_filter: area>power(ZRES7,2)
+    sql_filter: area>power(ZRES6,2)
     tolerance: ZRES7
 
   # etldoc: imposm3 -> osm_water_polygon_gen4
   water_polygon_gen4:
     source: water_polygon_gen3
-    sql_filter: area>power(ZRES8,2)
+    sql_filter: area>power(ZRES7,2)
     tolerance: ZRES8
 
   # etldoc: imposm3 -> osm_water_polygon_gen3
   water_polygon_gen3:
     source: water_polygon_gen2
-    sql_filter: area>power(ZRES9,2)
+    sql_filter: area>power(ZRES8,2)
     tolerance: ZRES9
 
   # etldoc: imposm3 -> osm_water_polygon_gen2
   water_polygon_gen2:
     source: water_polygon_gen1
-    sql_filter: area>power(ZRES10,2)
+    sql_filter: area>power(ZRES9,2)
     tolerance: ZRES10
 
   # etldoc: imposm3 -> osm_water_polygon_gen1
   water_polygon_gen1:
     source: water_polygon
-    sql_filter: area>power(ZRES11,2)
+    sql_filter: area>power(ZRES10,2)
     tolerance: ZRES11
 
 tables:

--- a/qa/osm_gen_sizes.py
+++ b/qa/osm_gen_sizes.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+import sys
+import argparse
+import subprocess
+
+parser  = argparse.ArgumentParser()
+parser.add_argument('--noan', action='store_true', help='Not to run make psql-analyze')
+
+
+TOTAL_SIZE_SQL = """SELECT
+  pg_size_pretty(sum(size)) AS size
+FROM (
+  SELECT
+    relname as "Table",
+    pg_total_relation_size(relid) as "size"
+  FROM pg_catalog.pg_statio_user_tables
+  WHERE schemaname='public'
+    AND relname::text ~ '^osm_.*_gen[0-9]{1,2}$'
+) a
+;""".replace('\"', '\\\"')
+
+
+TABLE_SIZES_SQL="""SELECT
+  a.relname as "table",
+  pg_table_size(a.relid) as "size",
+  b.n_live_tup as "rows"
+FROM pg_catalog.pg_statio_user_tables a
+  LEFT JOIN pg_stat_user_tables b ON (a.relid = b.relid)
+WHERE
+  a.schemaname='public' AND
+  a.relname::text ~ '^osm_.*_gen[0-9]{1,2}$'
+ORDER BY a.relname;
+""".replace('\"', '\\\"')
+
+
+TABLES_SQL = """SELECT
+  a.relname
+FROM pg_catalog.pg_statio_user_tables a
+WHERE
+  a.schemaname='public' AND
+  a.relname::text ~ '^osm_.*_gen[0-9]{1,2}$'
+ORDER BY a.relname;
+"""
+
+COLUMN_NAMES_SQL = """SELECT a.attname
+FROM pg_class As c
+  INNER JOIN pg_attribute As a ON c.oid = a.attrelid
+  LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+  LEFT JOIN pg_tablespace t ON t.oid = c.reltablespace
+WHERE
+  c.relkind IN('r', 'v', 'm') AND
+  a.attnum > 0 AND
+  n.nspname = 'public' AND
+  c.relname = '{0}'
+ORDER BY a.attname;
+"""
+
+COLUMNS_SQL = """select
+    sum(pg_column_size(t.*)) as "all",
+    {0}
+from {1} t;
+""".replace('\"', '\\\"')
+
+def print_column_sizes(tables):
+    for table in tables:
+        print "Column sizes of table "+table
+        cmds = [
+            'docker-compose run --rm import-osm',
+            '/usr/src/app/psql.sh -t -A -F\",\" -P pager=off',
+            '-c \"' + COLUMN_NAMES_SQL.format(table).replace('\n', ' ').replace('\r', '') + '\"'
+        ]
+        # print " ".join(cmds)
+        output = subprocess.check_output(" ".join(cmds), shell=True)
+        columns = filter(lambda c: len(c)>0, map(lambda l: l.strip(), output.split('\n')))
+
+        # print columns
+
+        col_sql = ",\n".join(map(lambda c: "sum(pg_column_size(\\\""+c+"\\\")) as \\\""+c+"\\\"", columns))
+
+        # print COLUMNS_SQL.format(col_sql, table);
+
+        cmds = [
+            'docker-compose run --rm import-osm',
+            '/usr/src/app/psql.sh -F\",\" --no-align -P pager=off',
+            '-c \"' + COLUMNS_SQL.format(col_sql, table).replace('\n', ' ').replace('\r', '') + '\"'
+        ]
+        # print " ".join(cmds)
+        col_csv = subprocess.check_output(" ".join(cmds), shell=True)
+        print col_csv
+
+
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    try:
+
+        if(not args.noan):
+            print "Running make psql-analyze"
+            subprocess.check_output("make psql-analyze", shell=True)
+
+
+        print "Total size of osm_.*_gen[0-9]+ tables"
+        cmds = [
+            'docker-compose run --rm import-osm',
+            '/usr/src/app/psql.sh -F\",\" --no-align -P pager=off',
+            '-c \"' + TOTAL_SIZE_SQL.replace('\n', ' ').replace('\r', '') + '\"'
+        ]
+        # print " ".join(cmds)
+        TOTAL_SIZE_CSV = subprocess.check_output(" ".join(cmds), shell=True)
+        print TOTAL_SIZE_CSV
+        print "\n"
+
+
+        print "Table sizes"
+        cmds = [
+            'docker-compose run --rm import-osm',
+            '/usr/src/app/psql.sh -F\",\" --no-align -P pager=off',
+            '-c \"' + TABLE_SIZES_SQL.replace('\n', ' ').replace('\r', '') + '\"'
+        ]
+        # print " ".join(cmds)
+        TABLE_SIZES_CSV = subprocess.check_output(" ".join(cmds), shell=True)
+        print TABLE_SIZES_CSV
+        print "\n"
+
+
+        print "Column sizes"
+        cmds = [
+            'docker-compose run --rm import-osm',
+            '/usr/src/app/psql.sh -t -A -F\",\" -P pager=off',
+            '-c \"' + TABLES_SQL.replace('\n', ' ').replace('\r', '') + '\"'
+        ]
+        # print " ".join(cmds)
+        output = subprocess.check_output(" ".join(cmds), shell=True)
+        tables = filter(lambda t: len(t)>0, map(lambda l: l.strip(), output.split('\n')))
+
+        print_column_sizes(tables);
+
+        # print tables
+    except subprocess.CalledProcessError, e:
+        print "Error:\n", e.output
+    sys.exit(0)


### PR DESCRIPTION
#214 added ZRES constant to work with tolerance and area filter more easily. It works great, but currently used values mean [84% increase of mbtile size (Belgium Z0-12)](https://github.com/openmaptiles/openmaptiles/pull/214#issuecomment-299451902).

This PR gets size of mbtiles's size closer to previous value by changing ZRES for
* osm_building_polygon_gen*
* osm_landcover_polygon_gen*
* osm_landuse_polygon_gen*

Furthermore, ZRES in area filter of other layers was decreased by 1, so now every polygon feature with area < 4px is eliminated.

Comparing to increase about 84% in case of original #214, this PR produces .mbtiles bigger only about [11%](https://github.com/openmaptiles/openmaptiles/pull/214#issuecomment-302726892).