### PR TITLE
quickstart.sh support macOS

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -288,7 +288,11 @@ cat ./data/quickstart_checklist.chk
 
 ENDTIME=$(date +%s)
 ENDDATE=$(date +"%Y-%m-%dT%H:%M%z")
-MODDATE=$(stat -c  %y  ./data/${testdata} )
+if stat --help >/dev/null 2>&1; then
+  MODDATE=$(stat -c %y ./data/${testdata} )
+else
+  MODDATE=$(stat -f%Sm -t '%F %T %z' ./data/${testdata} )
+fi
 
 echo " "
 echo " "
@@ -314,7 +318,7 @@ echo "====> : (disk space) We have created the new vectortiles ( ./data/tiles.mb
 echo "      : Please respect the licenses (OdBL for OSM data) of the sources when distributing the MBTiles file."
 echo "      : Created from $testdata ( file moddate: $MODDATE ) "
 echo "      : Size: "
-ls ./data/*.mbtiles -la
+ls -la ./data/*.mbtiles
 
 echo " "
 echo "-------------------------------------------------------------------------------------"


### PR DESCRIPTION
My latest fix for macOS ( #164) enable to build tile but quickstart.sh stop before output all messages.

- Check GNU Coreutils stat command and if fail use BSD stat command.
- Fix ls option position