### PR TITLE
Quickstart refactoring   #261

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,25 @@
+##### Zoom level settings for users
+QUICKSTART_MIN_ZOOM=0
+QUICKSTART_MAX_ZOOM=7
+
+
+
+#####  Database settings
 POSTGRES_DB=openmaptiles
 POSTGRES_USER=openmaptiles
 POSTGRES_PASSWORD=openmaptiles
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
-QUICKSTART_MIN_ZOOM=0
-QUICKSTART_MAX_ZOOM=7
+
+
+####  Database update mode
 DIFF_MODE=false
+
+
+###############################################
+### Default settings, for avoid warnings , do not modify
+##############################################
+MIN_ZOOM=$QUICKSTART_MIN_ZOOM
+MAX_ZOOM=$QUICKSTART_MAX_ZOOM
+BBOX=
+###############################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ before_install:
 script:
   - sudo service docker restart
   - docker-compose config
+  - make generate-devdoc
   - sudo ./quickstart.sh
   

--- a/Makefile
+++ b/Makefile
@@ -155,17 +155,19 @@ generate-qareports:
 # work in progress - please don't remove
 generate-devdoc:
 	mkdir -p ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/aeroway/aeroway.yaml               ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/boundary/boundary.yaml             ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/building/building.yaml             ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/housenumber/housenumber.yaml       ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/landcover/landcover.yaml           ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/landuse/landuse.yaml               ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/park/park.yaml                     ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/place/place.yaml                   ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/poi/poi.yaml                       ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/transportation/transportation.yaml ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/transportation_name/transportation_name.yaml ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/water/water.yaml                   ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/water_name/water_name.yaml         ./build/devdoc
-	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/waterway/waterway.yaml             ./build/devdoc
+	rm -rf ./build/devdoc/*
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/water/water.yaml                      		./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/waterway/waterway.yaml						./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/landcover/landcover.yaml						./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/landuse/landuse.yaml							./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/mountain_peak/mountain_peak.yaml				./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/park/park.yaml								./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/boundary/boundary.yaml						./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/aeroway/aeroway.yaml							./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/transportation/transportation.yaml			./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/building/building.yaml						./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/water_name/water_name.yaml					./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/transportation_name/transportation_name.yaml	./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/place/place.yaml								./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/housenumber/housenumber.yaml					./build/devdoc
+	docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/poi/poi.yaml									./build/devdoc

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ start-tileserver:
 	docker run -it --rm -v $$(pwd)/data:/data -p 8080:80 klokantech/tileserver-gl
 
 start-mapbox-studio:
-	docker-compose up mapbox-studio
+	docker run -it --rm --network openmaptiles_postgres_conn  --link openmaptiles_postgres_1:postgres  -v $$(pwd)/build/openmaptiles.tm2source:/projects/openmaptiles.tm2source  -p 3000:3000  osm2vectortiles/mapbox-studio
 
 generate-qareports:
 	./qa/run.sh

--- a/Makefile
+++ b/Makefile
@@ -76,42 +76,42 @@ psql:
 	docker-compose run --rm import-osm /usr/src/app/psql.sh
 
 psql-list-tables:
-	docker-compose run --rm import-osm /usr/src/app/psql.sh  -P pager=off  -c "\d+"
+	docker-compose run -T --rm import-osm /usr/src/app/psql.sh  -P pager=off  -c "\d+"
 
 psql-pg-stat-reset:
-	docker-compose run --rm import-osm /usr/src/app/psql.sh  -P pager=off  -c 'SELECT pg_stat_statements_reset();'
+	docker-compose run -T --rm import-osm /usr/src/app/psql.sh  -P pager=off  -c 'SELECT pg_stat_statements_reset();'
 
 forced-clean-sql:
-	docker-compose run --rm import-osm /usr/src/app/psql.sh -c "DROP SCHEMA IF EXISTS public CASCADE ; CREATE SCHEMA IF NOT EXISTS public; "
-	docker-compose run --rm import-osm /usr/src/app/psql.sh -c "CREATE EXTENSION hstore; CREATE EXTENSION postgis; CREATE EXTENSION unaccent; CREATE EXTENSION fuzzystrmatch; CREATE EXTENSION osml10n; CREATE EXTENSION pg_stat_statements;"
-	docker-compose run --rm import-osm /usr/src/app/psql.sh -c "GRANT ALL ON SCHEMA public TO public;COMMENT ON SCHEMA public IS 'standard public schema';"
+	docker-compose run -T --rm import-osm /usr/src/app/psql.sh -c "DROP SCHEMA IF EXISTS public CASCADE ; CREATE SCHEMA IF NOT EXISTS public; "
+	docker-compose run -T --rm import-osm /usr/src/app/psql.sh -c "CREATE EXTENSION hstore; CREATE EXTENSION postgis; CREATE EXTENSION unaccent; CREATE EXTENSION fuzzystrmatch; CREATE EXTENSION osml10n; CREATE EXTENSION pg_stat_statements;"
+	docker-compose run -T --rm import-osm /usr/src/app/psql.sh -c "GRANT ALL ON SCHEMA public TO public;COMMENT ON SCHEMA public IS 'standard public schema';"
 
 pgclimb-list-views:
-	docker-compose run --rm import-osm /usr/src/app/pgclimb.sh -c "select schemaname,viewname from pg_views where schemaname='public' order by viewname;" csv
+	docker-compose run -T --rm import-osm /usr/src/app/pgclimb.sh -c "select schemaname,viewname from pg_views where schemaname='public' order by viewname;" csv
 
 pgclimb-list-tables:
-	docker-compose run --rm import-osm /usr/src/app/pgclimb.sh -c "select schemaname,tablename from pg_tables where schemaname='public' order by tablename;" csv
+	docker-compose run -T --rm import-osm /usr/src/app/pgclimb.sh -c "select schemaname,tablename from pg_tables where schemaname='public' order by tablename;" csv
 
 psql-vacuum-analyze:
 	@echo "Start - postgresql: VACUUM ANALYZE VERBOSE;"
-	docker-compose run --rm import-osm /usr/src/app/psql.sh  -P pager=off  -c 'VACUUM ANALYZE VERBOSE;'
+	docker-compose run -T --rm import-osm /usr/src/app/psql.sh  -P pager=off  -c 'VACUUM ANALYZE VERBOSE;'
 
 psql-analyze:
 	@echo "Start - postgresql: ANALYZE VERBOSE ;"
-	docker-compose run --rm import-osm /usr/src/app/psql.sh  -P pager=off  -c 'ANALYZE VERBOSE;'
+	docker-compose run -T --rm import-osm /usr/src/app/psql.sh  -P pager=off  -c 'ANALYZE VERBOSE;'
 
 import-sql-dev:
-	docker-compose run --rm import-sql /bin/bash
+	docker-compose run -T --rm import-sql /bin/bash
 
 import-osm-dev:
-	docker-compose run --rm import-osm /bin/bash
+	docker-compose run -T --rm import-osm /bin/bash
 
 download-geofabrik:
 	@echo ===============  download-geofabrik =======================
 	@echo Download area :   $(area)
 	@echo [[ example: make download-geofabrik  area=albania ]]
 	@echo [[ list areas:  make download-geofabrik-list       ]]
-	docker-compose run --rm import-osm  ./download-geofabrik.sh $(area)
+	docker-compose run -T --rm import-osm  ./download-geofabrik.sh $(area)
 	ls -la ./data/$(area).*
 	@echo "Generated config file: ./data/docker-compose-config.yml"
 	@echo " "
@@ -120,11 +120,11 @@ download-geofabrik:
 
 # the `download-geofabrik` error message mention `list`, if the area parameter is wrong. so I created a similar make command
 list:
-	docker-compose run --rm import-osm  ./download-geofabrik-list.sh
+	docker-compose run -T --rm import-osm  ./download-geofabrik-list.sh
 
 # same as a `make list`
 download-geofabrik-list:
-	docker-compose run --rm import-osm  ./download-geofabrik-list.sh
+	docker-compose run -T --rm import-osm  ./download-geofabrik-list.sh
 
 start-tileserver:
 	@echo " "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,14 +82,6 @@ services:
     volumes:
      - .:/tileset
      - ./build:/sql
-  mapbox-studio:
-    image: "osm2vectortiles/mapbox-studio"
-    volumes:
-     - ./build/openmaptiles.tm2source:/projects/openmaptiles.tm2source
-    networks:
-     - postgres_conn
-    ports:
-     - "3000:3000"
   generate-changed-vectortiles:
     image: "openmaptiles/generate-vectortiles:0.1.1"
     command: ./export-list.sh

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -166,14 +166,14 @@ fi
 echo " "
 echo "-------------------------------------------------------------------------------------"
 echo "====> : Remove old generated source files ( ./build/* ) ( if they exist ) "
-docker-compose run --rm openmaptiles-tools make clean
+docker-compose run -T --rm openmaptiles-tools make clean
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
 echo "====> : Code generating from the layer definitions ( ./build/mapping.yaml; ./build/tileset.sql )"
 echo "      : The tool source code: https://github.com/openmaptiles/openmaptiles-tools "
 echo "      : But we generate the tm2source, Imposm mappings and SQL functions from the layer definitions! "
-docker-compose run --rm openmaptiles-tools make
+docker-compose run -T --rm openmaptiles-tools make
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
@@ -195,7 +195,7 @@ echo "====> : Start importing water data from http://openstreetmapdata.com into 
 echo "      : Source code:  https://github.com/openmaptiles/import-water "
 echo "      : Data license: http://openstreetmapdata.com/info/license  "
 echo "      : Thank you: http://openstreetmapdata.com/info/supporting "
-docker-compose run --rm import-water
+docker-compose run -T --rm import-water
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
@@ -203,7 +203,7 @@ echo "====> : Start importing border data from http://openstreetmap.org into Pos
 echo "      : Source code:  https://github.com/openmaptiles/import-osmborder"
 echo "      : Data license: http://www.openstreetmap.org/copyright"
 echo "      : Thank you: https://github.com/pnorman/osmborder "
-docker-compose run --rm import-osmborder
+docker-compose run -T --rm import-osmborder
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
@@ -211,7 +211,7 @@ echo "====> : Start importing  http://www.naturalearthdata.com  into PostgreSQL 
 echo "      : Source code: https://github.com/openmaptiles/import-natural-earth "
 echo "      : Terms-of-use: http://www.naturalearthdata.com/about/terms-of-use  "
 echo "      : Thank you: Natural Earth Contributors! "
-docker-compose run --rm import-natural-earth
+docker-compose run -T --rm import-natural-earth
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
@@ -219,7 +219,7 @@ echo "====> : Start importing OpenStreetMap Lakelines data "
 echo "      : Source code: https://github.com/openmaptiles/import-lakelines "
 echo "      :              https://github.com/lukasmartinelli/osm-lakelines "
 echo "      : Data license: .. "
-docker-compose run --rm import-lakelines
+docker-compose run -T --rm import-lakelines
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
@@ -229,13 +229,13 @@ echo "      :   Thank you Omniscale! "
 echo "      :   Source code: https://github.com/openmaptiles/import-osm "
 echo "      : The OpenstreetMap data license: https://www.openstreetmap.org/copyright (ODBL) "
 echo "      : Thank you OpenStreetMap Contributors ! "
-docker-compose run --rm import-osm
+docker-compose run -T --rm import-osm
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
 echo "====> : Start SQL postprocessing:  ./build/tileset.sql -> PostgreSQL "
 echo "      : Source code: https://github.com/openmaptiles/import-sql "
-docker-compose run --rm import-sql
+docker-compose run -T --rm import-sql
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
@@ -260,13 +260,13 @@ echo "      :  "
 echo "      : You will see a lot of deprecated warning in the log! This is normal!  "
 echo "      :    like :  Mapnik LOG>  ... is deprecated and will be removed in Mapnik 4.x ... "
 
-docker-compose -f docker-compose.yml -f ./data/docker-compose-config.yml  run --rm generate-vectortiles
+docker-compose -f docker-compose.yml -f ./data/docker-compose-config.yml  run -T --rm generate-vectortiles
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
 echo "====> : Add special metadata to mbtiles! "
-docker-compose run --rm openmaptiles-tools  generate-metadata ./data/tiles.mbtiles
-docker-compose run --rm openmaptiles-tools  chmod 666         ./data/tiles.mbtiles
+docker-compose run -T --rm openmaptiles-tools  generate-metadata ./data/tiles.mbtiles
+docker-compose run -T --rm openmaptiles-tools  chmod 666         ./data/tiles.mbtiles
 
 echo " "
 echo "-------------------------------------------------------------------------------------"


### PR DESCRIPTION
First part of #261

quick refactoring
*  Moving 'osm2vectortiles/mapbox-studio ' definitions from the docker-compose.yml to the Makefile, 
   *   this part is needs more testing!   if the users complaining - we need to restore this part.
*  `nohup quickstart.sh`   support #166
*  removing current quickstart warnings.  ( quick fix )
```
The MIN_ZOOM variable is not set. Defaulting to a blank string.
The MAX_ZOOM variable is not set. Defaulting to a blank string.
```
*  add `generate-devdoc` to travis check  ( maybe this is help to detect warnings! ) 

example: 
```
docker-compose run -T --rm openmaptiles-tools generate-etlgraph layers/landcover/landcover.yaml						./build/devdoc
Warning: node layer_landcover, port z5_6 unrecognized
Warning: node layer_landcover, port z7 unrecognized
Warning: node layer_landcover, port z5_6 unrecognized
Warning: node layer_landcover, port z7 unrecognized
```