### PR TITLE
Add brunnel to waterway layer

### DIFF
--- a/layers/waterway/mapping.yaml
+++ b/layers/waterway/mapping.yaml
@@ -14,6 +14,20 @@ generalized_tables:
     source: waterway_linestring
     sql_filter: waterway IN ('river')
     tolerance: ZRES11
+
+tunnel_field: &tunnel
+  key: tunnel
+  name: is_tunnel
+  type: bool
+bridge_field: &bridge
+  key: bridge
+  name: is_bridge
+  type: bool
+ford_field: &ford
+  key: ford
+  name: is_ford
+  type: bool
+
 tables:
   # etldoc: imposm3 -> osm_waterway_linestring
   waterway_linestring:
@@ -37,6 +51,9 @@ tables:
       type: string
     - name: tags
       type: hstore_tags
+    - *tunnel
+    - *bridge
+    - *ford
     mapping:
       waterway:
       - stream

--- a/layers/waterway/waterway.sql
+++ b/layers/waterway/waterway.sql
@@ -1,66 +1,81 @@
+CREATE OR REPLACE FUNCTION brunnel(is_bridge BOOL, is_tunnel BOOL, is_ford BOOL) RETURNS TEXT AS $$
+    SELECT CASE
+        WHEN is_bridge THEN 'bridge'
+        WHEN is_tunnel THEN 'tunnel'
+        WHEN is_ford THEN 'ford'
+        ELSE NULL
+    END;
+$$ LANGUAGE SQL IMMUTABLE STRICT;
 
 -- etldoc: ne_110m_rivers_lake_centerlines ->  waterway_z3
 CREATE OR REPLACE VIEW waterway_z3 AS (
-    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en, NULL::text AS name_de, NULL::hstore AS tags
+    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en, NULL::text AS name_de, NULL::hstore AS tags, NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel, NULL::boolean AS is_ford
     FROM ne_110m_rivers_lake_centerlines
     WHERE featurecla = 'River'
 );
 
 -- etldoc: ne_50m_rivers_lake_centerlines ->  waterway_z4
 CREATE OR REPLACE VIEW waterway_z4 AS (
-    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en, NULL::text AS name_de, NULL::hstore AS tags
+    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en, NULL::text AS name_de, NULL::hstore AS tags, NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel, NULL::boolean AS is_ford
     FROM ne_50m_rivers_lake_centerlines
     WHERE featurecla = 'River'
 );
 
 -- etldoc: ne_10m_rivers_lake_centerlines ->  waterway_z6
 CREATE OR REPLACE VIEW waterway_z6 AS (
-    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en, NULL::text AS name_de, NULL::hstore AS tags
+    SELECT geometry, 'river'::text AS class, NULL::text AS name, NULL::text AS name_en, NULL::text AS name_de, NULL::hstore AS tags, NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel, NULL::boolean AS is_ford
     FROM ne_10m_rivers_lake_centerlines
     WHERE featurecla = 'River'
 );
 
 -- etldoc: osm_important_waterway_linestring_gen3 ->  waterway_z9
 CREATE OR REPLACE VIEW waterway_z9 AS (
-    SELECT geometry, 'river'::text AS class, name, name_en, name_de, tags FROM osm_important_waterway_linestring_gen3
+    SELECT geometry, 'river'::text AS class, name, name_en, name_de, tags, NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel, NULL::boolean AS is_ford
+    FROM osm_important_waterway_linestring_gen3
 );
 
 -- etldoc: osm_important_waterway_linestring_gen2 ->  waterway_z10
 CREATE OR REPLACE VIEW waterway_z10 AS (
-    SELECT geometry, 'river'::text AS class, name, name_en, name_de, tags FROM osm_important_waterway_linestring_gen2
+    SELECT geometry, 'river'::text AS class, name, name_en, name_de, tags, NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel, NULL::boolean AS is_ford
+    FROM osm_important_waterway_linestring_gen2
 );
 
 -- etldoc:osm_important_waterway_linestring_gen1 ->  waterway_z11
 CREATE OR REPLACE VIEW waterway_z11 AS (
-    SELECT geometry, 'river'::text AS class, name, name_en, name_de, tags FROM osm_important_waterway_linestring_gen1
+    SELECT geometry, 'river'::text AS class, name, name_en, name_de, tags, NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel, NULL::boolean AS is_ford
+    FROM osm_important_waterway_linestring_gen1
 );
 
 -- etldoc: osm_waterway_linestring ->  waterway_z12
 CREATE OR REPLACE VIEW waterway_z12 AS (
-    SELECT geometry, waterway AS class, name, name_en, name_de, tags FROM osm_waterway_linestring
+    SELECT geometry, waterway::text AS class, name, name_en, name_de, tags, is_bridge, is_tunnel, is_ford
+    FROM osm_waterway_linestring
     WHERE waterway IN ('river', 'canal')
 );
 
 -- etldoc: osm_waterway_linestring ->  waterway_z13
 CREATE OR REPLACE VIEW waterway_z13 AS (
-    SELECT geometry, waterway::text AS class, name, name_en, name_de, tags FROM osm_waterway_linestring
+    SELECT geometry, waterway::text AS class, name, name_en, name_de, tags, is_bridge, is_tunnel, is_ford
+    FROM osm_waterway_linestring
     WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
 );
 
 -- etldoc: osm_waterway_linestring ->  waterway_z14
 CREATE OR REPLACE VIEW waterway_z14 AS (
-    SELECT geometry, waterway::text AS class, name, name_en, name_de, tags FROM osm_waterway_linestring
+    SELECT geometry, waterway::text AS class, name, name_en, name_de, tags, is_bridge, is_tunnel, is_ford
+    FROM osm_waterway_linestring
 );
 
 -- etldoc: layer_waterway[shape=record fillcolor=lightpink, style="rounded,filled",
 -- etldoc:     label="layer_waterway | <z3> z3 |<z4_5> z4-z5 |<z6_8> z6-8 | <z9> z9 |<z10> z10 |<z11> z11 |<z12> z12|<z13> z13|<z14> z14+" ];
 
 CREATE OR REPLACE FUNCTION layer_waterway(bbox geometry, zoom_level int)
-RETURNS TABLE(geometry geometry, class text, name text, name_en text, name_de text, tags hstore) AS $$
+RETURNS TABLE(geometry geometry, class text, name text, name_en text, name_de text, brunnel text, tags hstore) AS $$
     SELECT geometry, class,
         NULLIF(name, '') AS name,
         COALESCE(NULLIF(name_en, ''), name) AS name_en,
         COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
+        brunnel(is_bridge, is_tunnel, is_ford) AS brunnel,
         tags
     FROM (
         -- etldoc: waterway_z3 ->  layer_waterway:z3

--- a/layers/waterway/waterway.yaml
+++ b/layers/waterway/waterway.yaml
@@ -21,9 +21,16 @@ layer:
       - canal
       - drain
       - ditch
+    brunnel:
+      description: |
+          Mark whether way is a tunnel or bridge.
+      values:
+        - bridge
+        - tunnel
+        - ford
   datasource:
     geometry_field: geometry
-    query: (SELECT geometry, name, name_en, name_de, {name_languages}, class FROM layer_waterway(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, name, name_en, name_de, {name_languages}, class, brunnel FROM layer_waterway(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./name.sql
   - ./update_waterway_linestring.sql


### PR DESCRIPTION
Can tunnel/bridge tags be added to the waterway layer? This is needed for displaying things like aqueducts.

This PR adds a 'brunnel' column consistent with the transportation layer (coming in from z12 onwards).