### PR TITLE
Fix tile URL served from postserve

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -373,7 +373,7 @@ mv my.osm.pbf data/
 
 ### Check postserve
 *  ` docker-compose up -d postserve`
-and the generated maps are going to be available in browser on [localhost:8090/0/0/0.pbf](http://localhost:8090/0/0/0.pbf).
+and the generated maps are going to be available in browser on [localhost:8090/tiles/0/0/0.pbf](http://localhost:8090/tiles/0/0/0.pbf).
 
 ### Check tileserver
 


### PR DESCRIPTION
Fix the tile URL as coded at https://github.com/openmaptiles/postserve/blob/master/server.py#L97 . 
The tiles are served under /tiles from a postserve instance. I checked this using the actual running instance.