### PR TITLE
fix class for bicycle_rental pois

### DIFF
--- a/layers/poi/class.sql
+++ b/layers/poi/class.sql
@@ -49,6 +49,7 @@ RETURNS TEXT AS $$
         WHEN subclass IN ('chocolate','confectionery') THEN 'ice_cream'
         WHEN subclass IN ('post_box','post_office') THEN 'post'
         WHEN subclass IN ('cafe') THEN 'cafe'
+        WHEN subclass IN ('bicycle_rental') THEN 'bicycle_share'
         WHEN subclass IN ('school','kindergarten') THEN 'school'
         WHEN subclass IN ('alcohol','beverages','wine') THEN 'alcohol_shop'
         WHEN subclass IN ('bar','nightclub') THEN 'bar'


### PR DESCRIPTION
This PR changes `bicycle_rental` class to `bicycle_share` because the maki icon has got this name.

Not sure this is the right way to handle this...