### PR TITLE
Updated attribution and description links to HTTPS

### DIFF
--- a/openmaptiles.yaml
+++ b/openmaptiles.yaml
@@ -19,8 +19,8 @@ tileset:
   name: OpenMapTiles
   version: 3.3.0
   id: openmaptiles
-  description: "A tileset showcasing all layers in OpenMapTiles. http://openmaptiles.org"
-  attribution: '<a href="http://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a> <a href="http://www.openstreetmap.org/about/" target="_blank">&copy; OpenStreetMap contributors</a>'
+  description: "A tileset showcasing all layers in OpenMapTiles. https://openmaptiles.org"
+  attribution: '<a href="https://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a> <a href="https://www.openstreetmap.org/about/" target="_blank">&copy; OpenStreetMap contributors</a>'
   center: [-12.2168, 28.6135, 4]
   maxzoom: 14
   minzoom: 0


### PR DESCRIPTION
Attribution and description links are for HTTP, which are redirected to HTTPS always.