### PR TITLE
add type of sport as subclass for pitch poi

### DIFF
--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -14,6 +14,8 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de
                 THEN NULLIF(information, '')
             WHEN subclass = 'place_of_worship'
                     THEN NULLIF(religion, '')
+            WHEN subclass = 'pitch'
+                    THEN NULLIF(sport, '')
             ELSE subclass
         END AS subclass,
         agg_stop,

--- a/layers/poi/mapping.yaml
+++ b/layers/poi/mapping.yaml
@@ -345,6 +345,9 @@ tables:
     - name: religion
       key: religion
       type: string
+    - name: sport
+      key: sport
+      type: string
     mapping:
       aerialway: *poi_mapping_aerialway
       amenity: *poi_mapping_amenity
@@ -397,6 +400,9 @@ tables:
       type: string
     - name: religion
       key: religion
+      type: string
+    - name: sport
+      key: sport
       type: string
     mapping:
       aerialway: *poi_mapping_aerialway


### PR DESCRIPTION
This PR add the type of sport (from the `sport` tag) as a subclass for pitch poi that have this tag.

This allow for better filtering in the style according to the sport which can be played on the pitch.