### PR TITLE
remove osm2vectortiles/mapbox-studio from project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ help:
 	@echo "Hints for designers:"
 	@echo "  make start-postserve                 # start Postserver + Maputnik Editor [ see localhost:8088 ] "
 	@echo "  make start-tileserver                # start klokantech/tileserver-gl [ see localhost:8080 ] "
-	@echo "  make start-mapbox-studio             # start Mapbox Studio"
 	@echo "  "
 	@echo "Hints for developers:"
 	@echo "  make                                 # build source code  "
@@ -144,12 +143,6 @@ start-postserve:
 	@echo " "
 	docker rm -f maputnik_editor || true
 	docker run --name maputnik_editor -d -p 8088:8888 maputnik/editor
-
-
-start-mapbox-studio:
-	docker-compose up mapbox-studio
-
-
 
 generate-qareports:
 	./qa/run.sh

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -415,15 +415,16 @@ Hints for testing areas
   ./quickstart.sh <<your-area>>        # example:  ./quickstart.sh madagascar 
   
 Hints for designers:
-  ....TODO....                         # start Maputnik 
+  make start-postserve                 # start Postserver + Maputnik Editor [ see localhost:8088 ] 
   make start-tileserver                # start klokantech/tileserver-gl [ see localhost:8080 ] 
-  make start-mapbox-studio             # start Mapbox Studio
   
 Hints for developers:
   make                                 # build source code  
   make download-geofabrik area=albania # download OSM data from geofabrik, and create config file
   make psql                            # start PostgreSQL console 
   make psql-list-tables                # list all PostgreSQL tables 
+  make psql-vacuum-analyze             # PostgreSQL: VACUUM ANALYZE
+  make psql-analyze                    # PostgreSQL: ANALYZE
   make generate-qareports              # generate reports [./build/qareports]
   make generate-devdoc                 # generate devdoc  [./build/devdoc]
   make import-sql-dev                  # start import-sql  /bin/bash terminal 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,14 +90,6 @@ services:
     volumes:
      - .:/tileset
      - ./build:/sql
-  mapbox-studio:
-    image: "osm2vectortiles/mapbox-studio"
-    volumes:
-     - ./build/openmaptiles.tm2source:/projects/openmaptiles.tm2source
-    networks:
-     - postgres_conn
-    ports:
-     - "3000:3000"
   generate-changed-vectortiles:
     image: "openmaptiles/generate-vectortiles:0.1.1"
     command: ./export-list.sh


### PR DESCRIPTION
Based on #505 
Simply remove mapbox-studio-classic from docker-compose options and Makefile.
I leave tutorial in README since there still has related document on [https://openmaptiles.org](https://openmaptiles.org/docs/style/mapbox-studio-classic/), for now :grin: