### PR TITLE
Add name field into park layer

### DIFF
--- a/layers/park/layer.sql
+++ b/layers/park/layer.sql
@@ -2,52 +2,52 @@
 -- etldoc:     label="layer_park |<z6> z6 |<z7> z7 |<z8> z8 |<z9> z9 |<z10> z10 |<z11> z11 |<z12> z12|<z13> z13|<z14> z14+" ] ;
 
 CREATE OR REPLACE FUNCTION layer_park(bbox geometry, zoom_level int)
-RETURNS TABLE(osm_id bigint, geometry geometry, class text) AS $$
-    SELECT osm_id, geometry,
+RETURNS TABLE(osm_id bigint, geometry geometry, name text, class text) AS $$
+    SELECT osm_id, geometry, name,
         COALESCE(NULLIF(leisure, ''), NULLIF(boundary, '')) AS class
         FROM (
         -- etldoc: osm_park_polygon_gen8 -> layer_park:z6
-        SELECT osm_id, geometry, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, leisure, boundary, NULL::int as scalerank
         FROM osm_park_polygon_gen8
         WHERE zoom_level = 6
         UNION ALL
         -- etldoc: osm_park_polygon_gen7 -> layer_park:z7
-        SELECT osm_id, geometry, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, leisure, boundary, NULL::int as scalerank
         FROM osm_park_polygon_gen7
         WHERE zoom_level = 7
         UNION ALL
         -- etldoc: osm_park_polygon_gen6 -> layer_park:z8
-        SELECT osm_id, geometry, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, leisure, boundary, NULL::int as scalerank
         FROM osm_park_polygon_gen6
         WHERE zoom_level = 8
         UNION ALL
         -- etldoc: osm_park_polygon_gen5 -> layer_park:z9
-        SELECT osm_id, geometry, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, leisure, boundary, NULL::int as scalerank
         FROM osm_park_polygon_gen5
         WHERE zoom_level = 9
         UNION ALL
         -- etldoc: osm_park_polygon_gen4 -> layer_park:z10
-        SELECT osm_id, geometry, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, leisure, boundary, NULL::int as scalerank
         FROM osm_park_polygon_gen4
         WHERE zoom_level = 10
         UNION ALL
         -- etldoc: osm_park_polygon_gen3 -> layer_park:z11
-        SELECT osm_id, geometry, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, leisure, boundary, NULL::int as scalerank
         FROM osm_park_polygon_gen3
         WHERE zoom_level = 11
         UNION ALL
         -- etldoc: osm_park_polygon_gen2 -> layer_park:z12
-        SELECT osm_id, geometry, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, leisure, boundary, NULL::int as scalerank
         FROM osm_park_polygon_gen2
         WHERE zoom_level = 12
         UNION ALL
         -- etldoc: osm_park_polygon_gen1 -> layer_park:z13
-        SELECT osm_id, geometry, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, leisure, boundary, NULL::int as scalerank
         FROM osm_park_polygon_gen1
         WHERE zoom_level = 13
         UNION ALL
         -- etldoc: osm_park_polygon -> layer_park:z14
-        SELECT osm_id, geometry, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, leisure, boundary, NULL::int as scalerank
         FROM osm_park_polygon
         WHERE zoom_level >= 14
     ) AS zoom_levels

--- a/layers/park/mapping.yaml
+++ b/layers/park/mapping.yaml
@@ -57,6 +57,9 @@ tables:
       type: id
     - name: geometry
       type: validated_geometry
+    - name: name
+      key: name
+      type: string
     - name: landuse
       key: landuse
       type: string

--- a/layers/park/park.yaml
+++ b/layers/park/park.yaml
@@ -4,6 +4,9 @@ layer:
       The park layer contains parks from OpenStreetMap tagged with either [`boundary=national_park`](http://wiki.openstreetmap.org/wiki/Tag:boundary%3Dnational_park) or [`leisure=nature_reserve`](http://wiki.openstreetmap.org/wiki/Tag:leisure%3Dnature_reserve).
   buffer_size: 4
   fields:
+    name:
+      description: |
+          The OSM `name` value of the park.
     class:
       description: |
           Use the **class** to differentiate between different parks.
@@ -12,7 +15,7 @@ layer:
       - nature_reserve
   datasource:
     geometry_field: geometry
-    query: (SELECT geometry, class FROM layer_park(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, class, name FROM layer_park(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./layer.sql
 datasources:


### PR DESCRIPTION
Based on #513 
Simply add name field into park layer, and do we need `name_en` or `name_de` like `mountain_peak` or `aerodrome_label`?

> When you are making PR that adds new spatial features to OpenMapTiles schema, please make also PR for at least one of our GL styles to show it on the map. Visual check is crucial.

I'll add another PR in [osm-bright-gl-style](https://github.com/openmaptiles/osm-bright-gl-style) later, for now the newly added field looks good on my machine, Check it [here](http://topo.tw:8080/data/v3/#10.37/24.3905/121.2383)(it only shows park layer in Taiwan)

![screenshot from 2018-10-25 13-00-39](https://user-images.githubusercontent.com/19887090/47477076-05268e00-d856-11e8-8211-91e4a6230516.png)
