### PR TITLE
Adding tag natural=volcano to the layer mountain_peak; issue #420

### DIFF
--- a/layers/mountain_peak/mapping.yaml
+++ b/layers/mountain_peak/mapping.yaml
@@ -28,3 +28,4 @@ tables:
     mapping:
       natural:
       - peak
+      - volcano


### PR DESCRIPTION
* https://github.com/openmaptiles/openmaptiles/issues/420
* adding tag natural=volcano into mountain_peak layer
* tested on data of Italian islands (isole-latest.osm.pbf)
-- before: 3278 records in osm_peak_point
-- after: 3327 records
-- e.g. 
```
SELECT * FROM import.osm_peak_point
WHERE name = 'Etna' OR name = 'Stromboli';
```
gives results now.