### PR TITLE
Fix typo in update_osm_park_polygon_row function

### DIFF
--- a/layers/park/update_park_polygon.sql
+++ b/layers/park/update_park_polygon.sql
@@ -85,7 +85,7 @@ AS
 $BODY$
 BEGIN
   NEW.tags = update_tags(NEW.tags, NEW.geometry);
-  NEW.geometry_point = NEW.st_centroid(geometry);
+  NEW.geometry_point = st_centroid(NEW.geometry);
   RETURN NEW;
 END;
 $BODY$


### PR DESCRIPTION
This fixes an issue which was recently introduced with recent changes in `update_park_polygon.sql`

A typo in a SQL function causes `imposm diff` to fail with:
```
[WARN] [writer] SQL Error: pq: column "geometry" does not exist in query INSERT INTO 
"public"."osm_park_polygon" ("osm_id", "geometry", "name", "name_en", "name_de", "tags", 
"landuse", "leisure", "boundary", "area", "webmerc_area") VALUES ($1, $2::Geometry, $3, 
$4, $5, $6, $7, $8, $9, $10, $11)
...
```