### PR TITLE
Add colour to buildings

### DIFF
--- a/layers/building/building.yaml
+++ b/layers/building/building.yaml
@@ -5,12 +5,14 @@ layer:
       this is welcomed.
   buffer_size: 4
   datasource:
-    query: (SELECT geometry, render_height, render_min_height, hide_3d FROM layer_building(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, render_height, render_min_height, colour, hide_3d FROM layer_building(!bbox!, z(!scale_denominator!))) AS t
   fields:
     render_height: |
         An approximated height from levels and height of the building or building:part after the method of Paul Norman in [OSM Clear](https://github.com/ClearTables/osm-clear). For future 3D rendering of buildings.
     render_min_height: |
         An approximated height from levels and height of the bottom of the building or building:part after the method of Paul Norman in [OSM Clear](https://github.com/ClearTables/osm-clear). For future 3D rendering of buildings.
+    colour: |
+        Colour
     hide_3d: |
         If True, building (part) should not be rendered in 3D. Currently, [building outlines](https://wiki.openstreetmap.org/wiki/Simple_3D_buildings) are marked as hide_3d.
 schema:

--- a/layers/building/mapping.yaml
+++ b/layers/building/mapping.yaml
@@ -17,6 +17,12 @@ tables:
       type: area
     - name: webmerc_area
       type: webmerc_area
+    - name: material
+      key: building:material
+      type: string
+    - name: colour
+      key: building:colour
+      type: string
     - name: building
       key: building
       type: string
@@ -78,6 +84,12 @@ tables:
       key: building
       type: string
       from_member: true
+    - name: material
+      key: building:material
+      type: string
+    - name: colour
+      key: building:colour
+      type: string
     - name: buildingpart
       key: building:part
       type: string
@@ -166,6 +178,12 @@ tables:
       key: building
       type: string
       from_member: true
+    - name: material
+      key: building:material
+      type: string
+    - name: colour
+      key: building:colour
+      type: string
     - name: buildingpart
       key: building:part
       type: string
@@ -254,6 +272,12 @@ tables:
       key: building
       type: string
       from_member: true
+    - name: material
+      key: building:material
+      type: string
+    - name: colour
+      key: building:colour
+      type: string
     - name: buildingpart
       key: building:part
       type: string
@@ -342,6 +366,12 @@ tables:
       key: building
       type: string
       from_member: true
+    - name: material
+      key: building:material
+      type: string
+    - name: colour
+      key: building:colour
+      type: string
     - name: buildingpart
       key: building:part
       type: string


### PR DESCRIPTION
Add colour to building from `building:colour` tag and colour derived from `building:material` tags as fallback.
![3dcolour](https://user-images.githubusercontent.com/1785486/50335227-e4537f80-050a-11e9-84ee-18df6094a274.jpeg)
