### PR TITLE
[Resolved] Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: clean build/openmaptiles.tm2source/data.yml build/mapping.yaml build/tileset.sql
+all: build/openmaptiles.tm2source/data.yml build/mapping.yaml build/tileset.sql
 
 help:
 	@echo "=============================================================================="

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 OpenMapTiles is an extensible and open vector tile schema for a OpenStreetMap basemap. It is used to generate vector tiles for [openmaptiles.org](http://openmaptiles.org/) and [openmaptiles.com](http://openmaptiles.com/).
 
-We encourage you to collaborate, reuse and adapt existing layers and add your own layers or use our approach for your own vector tile project. The repository is built on top of the [openmaptiles/tools](https://github.com/openmaptiles/openmaptiles-tools) to simplify vector tile creation.
+We encourage you to collaborate, reuse and adapt existing layers and add your own layers or use our approach for your own vector tile project. The repository is built on top of the [openmaptiles/openmaptiles-tools](https://github.com/openmaptiles/openmaptiles-tools) to simplify vector tile creation.
 
 - :link: Docs http://openmaptiles.org/docs
 - :link: Schema: http://openmaptiles.org/schema
@@ -60,11 +60,10 @@ Together the layers make up the OpenMapTiles tileset.
 
 ## Develop
 
-To work on OpenMapTiles you need Docker and Python.
+To work on OpenMapTiles you need Docker.
 
 - Install [Docker](https://docs.docker.com/engine/installation/). Minimum version is 1.12.3+.
 - Install [Docker Compose](https://docs.docker.com/compose/install/). Minimum version is 1.7.1+.
-- Install [OpenMapTiles tools](https://github.com/openmaptiles/openmaptiles-tools) with `pip install openmaptiles-tools`
 
 ### Build
 
@@ -75,8 +74,6 @@ git clone git@github.com:openmaptiles/openmaptiles.git
 cd openmaptiles
 # Build the imposm mapping, the tm2source project and collect all SQL scripts
 make
-# You can also run the build process inside a Docker container
-docker run -v $(pwd):/tileset openmaptiles/openmaptiles-tools make
 ```
 
 You can execute the following manual steps (for better understanding)
@@ -122,7 +119,7 @@ docker-compose run import-osm
 Each time you modify layer SQL code run `make` and `docker-compose run import-sql`.
 
 ```
-make clean && make && docker-compose run import-sql
+make && docker-compose run import-sql
 ```
 
 Now you are ready to **generate the vector tiles**. Using environment variables

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ docker-compose run import-osm
 
 ### Work on Layers
 
-Each time you modify layer SQL code run `make` and `docker-compose run import-sql`.
+Each time you modify layer SQL code run `make` and `make import-sql`.
 
 ```
-make && docker-compose run import-sql
+make clean && make && make import-sql
 ```
 
 Now you are ready to **generate the vector tiles**. Using environment variables

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -166,15 +166,10 @@ fi
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
-echo "====> : Remove old generated source files ( ./build/* ) ( if they exist ) "
-docker-compose run --rm openmaptiles-tools make clean
-
-echo " "
-echo "-------------------------------------------------------------------------------------"
-echo "====> : Code generating from the layer definitions ( ./build/mapping.yaml; ./build/tileset.sql )"
+echo "====> : Regenerate source files from the layer definitions ( ./build/mapping.yaml; ./build/tileset.sql )"
 echo "      : The tool source code: https://github.com/openmaptiles/openmaptiles-tools "
 echo "      : But we generate the tm2source, Imposm mappings and SQL functions from the layer definitions! "
-docker-compose run --rm openmaptiles-tools make
+make
 
 echo " "
 echo "-------------------------------------------------------------------------------------"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -166,7 +166,12 @@ fi
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
-echo "====> : Regenerate source files from the layer definitions ( ./build/mapping.yaml; ./build/tileset.sql )"
+echo "====> : Remove old generated source files ( ./build/* ) ( if they exist ) "
+make clean
+
+echo " "
+echo "-------------------------------------------------------------------------------------"
+echo "====> : Code generating from the layer definitions ( ./build/mapping.yaml; ./build/tileset.sql )"
 echo "      : The tool source code: https://github.com/openmaptiles/openmaptiles-tools "
 echo "      : But we generate the tm2source, Imposm mappings and SQL functions from the layer definitions! "
 make
@@ -176,7 +181,7 @@ echo "--------------------------------------------------------------------------
 echo "====> : Start PostgreSQL service ; create PostgreSQL data volume "
 echo "      : Source code: https://github.com/openmaptiles/postgis "
 echo "      : Thank you: https://www.postgresql.org !  Thank you http://postgis.org !"
-docker-compose up   -d postgres
+docker-compose up -d postgres
 
 echo " "
 echo "-------------------------------------------------------------------------------------"


### PR DESCRIPTION
Merry Christmas! Here is some improvement for Makefile

#561 
* Totally use docker to generate source files. That is, no need to Install `openmaptiles-tools` 
with `pip install openmaptiles-tools`
* `make all` now cleans and generates source files, so `make cfg-remake` is removed.


#557 
* Add commands and hints to generate single etl or mapping graph:
`make etl-graph-[layer]` and `make mapping-graph-[layer]` to generate graph for a single layer
`make etl-graph` and `make mapping-graph` to show the hints for commands above

* The reason why I didn't use list variable in make target, is because there are too many options when using tab completion with `make`. I mean code in `Makefile` like:
```
layers = $(notdir $(wildcard layers/*)) # building poi...
etl-graphs = $(addprefix etl-graph-,$(layers)) # etl-graph-building etl-graph-poi...
$(etl-graphs):
        command...
```
then tab completion would be distracting:
![screenshot_2018-12-25 screenshot from 2018-12-25 23-04-34 png png image 1920 x 1053 pixels - scaled 88](https://user-images.githubusercontent.com/19887090/50424079-aacb9d00-0899-11e9-8e2a-e366db4aea0a.png)



* Use prerequisite in `make generate-devdoc`, So if a new layer is added, do not need to modify anything in `Makefile`.
