### PR TITLE
Add bc as dependency for the quickstart script

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -14,6 +14,7 @@
 * git
 * make 
 * bc
+* md5sum
 * docker         >=1.12.3
     * https://www.docker.com/products/overview
 * docker-compose >=1.7.1

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -13,6 +13,7 @@
 * bash
 * git
 * make 
+* bc
 * docker         >=1.12.3
     * https://www.docker.com/products/overview
 * docker-compose >=1.7.1


### PR DESCRIPTION
Hi,

`bc` is required for memory computation https://github.com/openmaptiles/openmaptiles/blob/master/quickstart.sh#L105.

Best,

EDIT: I noticed also a small typo in the PR template: https://github.com/openmaptiles/openmaptiles/blob/master/.github/pull_request_template.md (should be "are" instead of "rea" in the last paragraph). Not sure if it's worth making a PR to fix this.