### PR TITLE
Add parking, bicycle_parking and motorcycle_parking as POIs

### DIFF
--- a/layers/poi/mapping.yaml
+++ b/layers/poi/mapping.yaml
@@ -39,6 +39,7 @@ def_poi_mapping_amenity: &poi_mapping_amenity
   - motorcycle_parking
   - nightclub
   - nursing_home
+  - parking
   - pharmacy
   - place_of_worship
   - police

--- a/layers/poi/mapping.yaml
+++ b/layers/poi/mapping.yaml
@@ -12,6 +12,7 @@ def_poi_mapping_amenity: &poi_mapping_amenity
   - bank
   - bar
   - bbq
+  - bicycle_parking
   - bicycle_rental
   - biergarten
   - bus_station
@@ -35,6 +36,7 @@ def_poi_mapping_amenity: &poi_mapping_amenity
   - kindergarten
   - library
   - marketplace
+  - motorcycle_parking
   - nightclub
   - nursing_home
   - pharmacy


### PR DESCRIPTION
Hi,

As discussed in https://github.com/openmaptiles/openmaptiles/issues/565, this PR adds support for `bicycle_parking` and `motorcycle_parking` as amenities.

On Albania, resulting tiles.mbtiles (at zoom level 14) is 106369024 bytes (versus 106508288 for the current master).

I'm trying to get numbers on Switzerland and Czechia at the moment.

Best,