### PR TITLE
Optional wikidata (need import-sql:0.9)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -39,9 +39,10 @@ Important:  The ./quickstart.sh is for small extracts - not optimal for a Planet
 ```bash
 git clone https://github.com/openmaptiles/openmaptiles.git
 cd openmaptiles
-./quickstart.sh
+./quickstart.sh --no-wikidata
 ```
 
+**Caution**! Latest Wikidata is more than 50GB. If you are just doing an experiment, always use option `--no-wikidata`.
 If you have problems with the quickstart
 * check the ./quickstart.log!
 * doublecheck the system requirements!

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can execute the following manual steps (for better understanding)
 or use the provided `quickstart.sh` script.
 
 ```
-./quickstart.sh
+./quickstart.sh --no-wikidata
 ```
 
 ### Prepare the Database
@@ -101,6 +101,15 @@ docker-compose run import-water
 docker-compose run import-natural-earth
 docker-compose run import-lakelines
 docker-compose run import-osmborder
+```
+
+**[Optional]**
+Import latest Wikidata. If an OSM feature has [Key:wikidata](https://wiki.openstreetmap.org/wiki/Key:wikidata), OpenMapTiles check corresponding item in Wikidata and use its [labels](https://www.wikidata.org/wiki/Help:Label) for languages listed in [openmaptiles.yaml](openmaptiles.yaml). So the generated vector tiles includes multi-languages in name field.
+
+Beware that current Wikidata is more than 50GB, it takes time to download and import it. If you just want to have a quickstart on OpenMapTiles, just skip this step.
+
+```bash
+docker-compose run import-wikidata
 ```
 
 [Download OpenStreetMap data extracts](http://download.geofabrik.de/) and store the PBF file in the `./data` directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
      - ./build:/mapping
      - cache:/cache
   import-sql:
-    image: "openmaptiles/import-sql:0.8"
+    image: "openmaptiles/import-sql:0.9"
     env_file: .env
     networks:
     - postgres_conn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
      - ./build:/mapping
      - cache:/cache
   import-sql:
-    image: "openmaptiles/import-sql:0.9"
+    image: "openmaptiles/import-sql:1.0"
     env_file: .env
     networks:
     - postgres_conn

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -21,12 +21,20 @@ set -o nounset
 # see more QUICKSTART.md
 #
 
-if [ $# -eq 0 ]; then
-    osm_area=albania                         #  default test country
-    echo "No parameter - set area=$osm_area "
-else
-    osm_area=$1
-fi
+osm_area=albania #  default test country
+for i in "$@"
+do
+case $i in
+    --no-wikidata)
+    NO_WIKIDATA=true # do not import Wikidata
+    shift
+    ;;
+    *)
+    osm_area=$i
+    shift
+    ;;
+esac
+done
 testdata=${osm_area}.osm.pbf
 
 ##  Min versions ...
@@ -232,13 +240,15 @@ echo "      : The OpenstreetMap data license: https://www.openstreetmap.org/copy
 echo "      : Thank you OpenStreetMap Contributors ! "
 docker-compose run --rm import-osm
 
-echo " "
-echo "-------------------------------------------------------------------------------------"
-echo "====> : Start importing Wikidata: ./wikidata/latest-all.json.gz -> PostgreSQL"
-echo "      : Source code: https://github.com/openmaptiles/import-wikidata "
-echo "      : The Wikidata license: https://www.wikidata.org/wiki/Wikidata:Database_download/en#License "
-echo "      : Thank you Wikidata Contributors ! "
-docker-compose run --rm import-wikidata
+if [ "$NO_WIKIDATA" != true ]; then
+    echo " "
+    echo "-------------------------------------------------------------------------------------"
+    echo "====> : Start importing Wikidata: ./wikidata/latest-all.json.gz -> PostgreSQL"
+    echo "      : Source code: https://github.com/openmaptiles/import-wikidata "
+    echo "      : The Wikidata license: https://www.wikidata.org/wiki/Wikidata:Database_download/en#License "
+    echo "      : Thank you Wikidata Contributors ! "
+    docker-compose run --rm import-wikidata
+fi
 
 echo " "
 echo "-------------------------------------------------------------------------------------"


### PR DESCRIPTION
### [Caution] This PR should only be merged when image of [`import-sql:0.9`](https://github.com/openmaptiles/import-sql/releases/tag/v0.9) is on [DockerHub](https://hub.docker.com/r/openmaptiles/import-sql/tags)


#548 

- Use `import-sql:0.9`, which allows no Wikidata in psql
- Add option `--no-wikidata` for `quickstart.sh`, to skip importing Wikidata.
- Also add description about Wikidata in `README.md` and new suggestion in `QUICKSTART.md`.

Latest Wikidata is about 50GB, which means it is not **quick** for newcomers who just want to try OpenMapTiles. So excluding it from `quickstart.sh` is reasonable. But since travis CI use `quickstart.sh` to do build check, I think one more option is the simplest way I can do.

By the way, add option `--wikidata` and skip importing by default is also fine in this case, any idea?