### PR TITLE
Missing islands

### DIFF
--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -1,5 +1,6 @@
-CREATE OR REPLACE FUNCTION water_class(waterway TEXT) RETURNS TEXT AS $$
+CREATE OR REPLACE FUNCTION water_class(waterway TEXT, "natural" TEXT) RETURNS TEXT AS $$
     SELECT CASE
+           WHEN "natural"='bay' THEN 'bay'
            WHEN waterway='' THEN 'lake'
            WHEN waterway='dock' THEN 'dock'
            ELSE 'river'
@@ -53,7 +54,7 @@ CREATE OR REPLACE VIEW water_z6 AS (
     SELECT geometry, 'ocean'::text AS class FROM ne_10m_ocean
     UNION ALL
    -- etldoc:  osm_water_polygon_gen6 ->  water_z6
-    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen6
+    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen6
 );
 
 CREATE OR REPLACE VIEW water_z7 AS (
@@ -61,7 +62,7 @@ CREATE OR REPLACE VIEW water_z7 AS (
     SELECT geometry, 'ocean'::text AS class FROM ne_10m_ocean
     UNION ALL
     -- etldoc:  osm_water_polygon_gen5 ->  water_z7
-    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen5
+    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen5
 );
 
 CREATE OR REPLACE VIEW water_z8 AS (
@@ -69,7 +70,7 @@ CREATE OR REPLACE VIEW water_z8 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon_gen4
     UNION ALL
     -- etldoc:  osm_water_polygon_gen4 ->  water_z8
-    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen4
+    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen4
 );
 
 CREATE OR REPLACE VIEW water_z9 AS (
@@ -77,7 +78,7 @@ CREATE OR REPLACE VIEW water_z9 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon_gen3
     UNION ALL
     -- etldoc:  osm_water_polygon_gen3 ->  water_z9
-    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen3
+    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen3
 );
 
 CREATE OR REPLACE VIEW water_z10 AS (
@@ -85,7 +86,7 @@ CREATE OR REPLACE VIEW water_z10 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon_gen2
     UNION ALL
     -- etldoc:  osm_water_polygon_gen2 ->  water_z10
-    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen2
+    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen2
 );
 
 CREATE OR REPLACE VIEW water_z11 AS (
@@ -93,7 +94,7 @@ CREATE OR REPLACE VIEW water_z11 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon_gen1
     UNION ALL
     -- etldoc:  osm_water_polygon_gen1 ->  water_z11
-    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen1
+    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen1
 );
 
 CREATE OR REPLACE VIEW water_z12 AS (
@@ -101,7 +102,7 @@ CREATE OR REPLACE VIEW water_z12 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon
     UNION ALL
     -- etldoc:  osm_water_polygon ->  water_z12
-    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon
+    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon
 );
 
 CREATE OR REPLACE VIEW water_z13 AS (
@@ -109,7 +110,7 @@ CREATE OR REPLACE VIEW water_z13 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon
     UNION ALL
     -- etldoc:  osm_water_polygon ->  water_z13
-    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon
+    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon
 );
 
 CREATE OR REPLACE VIEW water_z14 AS (
@@ -117,7 +118,7 @@ CREATE OR REPLACE VIEW water_z14 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon
     UNION ALL
     -- etldoc:  osm_water_polygon ->  water_z14
-    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon
+    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon
 );
 
 -- etldoc: layer_water [shape=record fillcolor=lightpink, style="rounded,filled",

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -1,7 +1,7 @@
-CREATE OR REPLACE FUNCTION water_class(waterway TEXT, "natural" TEXT) RETURNS TEXT AS $$
+CREATE OR REPLACE FUNCTION water_class(waterway TEXT) RETURNS TEXT AS $$
     SELECT CASE
-           WHEN "natural"='bay' THEN 'bay'
            WHEN waterway='' THEN 'lake'
+           WHEN waterway='lake' THEN 'lake'
            WHEN waterway='dock' THEN 'dock'
            ELSE 'river'
    END;
@@ -54,7 +54,8 @@ CREATE OR REPLACE VIEW water_z6 AS (
     SELECT geometry, 'ocean'::text AS class FROM ne_10m_ocean
     UNION ALL
    -- etldoc:  osm_water_polygon_gen6 ->  water_z6
-    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen6
+    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen6
+    WHERE "natural" != 'bay'
 );
 
 CREATE OR REPLACE VIEW water_z7 AS (
@@ -62,7 +63,8 @@ CREATE OR REPLACE VIEW water_z7 AS (
     SELECT geometry, 'ocean'::text AS class FROM ne_10m_ocean
     UNION ALL
     -- etldoc:  osm_water_polygon_gen5 ->  water_z7
-    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen5
+    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen5
+    WHERE "natural" != 'bay'
 );
 
 CREATE OR REPLACE VIEW water_z8 AS (
@@ -70,7 +72,8 @@ CREATE OR REPLACE VIEW water_z8 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon_gen4
     UNION ALL
     -- etldoc:  osm_water_polygon_gen4 ->  water_z8
-    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen4
+    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen4
+    WHERE "natural" != 'bay'
 );
 
 CREATE OR REPLACE VIEW water_z9 AS (
@@ -78,7 +81,8 @@ CREATE OR REPLACE VIEW water_z9 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon_gen3
     UNION ALL
     -- etldoc:  osm_water_polygon_gen3 ->  water_z9
-    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen3
+    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen3
+    WHERE "natural" != 'bay'
 );
 
 CREATE OR REPLACE VIEW water_z10 AS (
@@ -86,7 +90,8 @@ CREATE OR REPLACE VIEW water_z10 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon_gen2
     UNION ALL
     -- etldoc:  osm_water_polygon_gen2 ->  water_z10
-    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen2
+    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen2
+    WHERE "natural" != 'bay'
 );
 
 CREATE OR REPLACE VIEW water_z11 AS (
@@ -94,7 +99,8 @@ CREATE OR REPLACE VIEW water_z11 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon_gen1
     UNION ALL
     -- etldoc:  osm_water_polygon_gen1 ->  water_z11
-    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon_gen1
+    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon_gen1
+    WHERE "natural" != 'bay'
 );
 
 CREATE OR REPLACE VIEW water_z12 AS (
@@ -102,7 +108,8 @@ CREATE OR REPLACE VIEW water_z12 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon
     UNION ALL
     -- etldoc:  osm_water_polygon ->  water_z12
-    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon
+    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon
+    WHERE "natural" != 'bay'
 );
 
 CREATE OR REPLACE VIEW water_z13 AS (
@@ -110,7 +117,8 @@ CREATE OR REPLACE VIEW water_z13 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon
     UNION ALL
     -- etldoc:  osm_water_polygon ->  water_z13
-    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon
+    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon
+    WHERE "natural" != 'bay'
 );
 
 CREATE OR REPLACE VIEW water_z14 AS (
@@ -118,7 +126,8 @@ CREATE OR REPLACE VIEW water_z14 AS (
     SELECT geometry, 'ocean'::text AS class FROM osm_ocean_polygon
     UNION ALL
     -- etldoc:  osm_water_polygon ->  water_z14
-    SELECT geometry, water_class(waterway, "natural") AS class FROM osm_water_polygon
+    SELECT geometry, water_class(waterway) AS class FROM osm_water_polygon
+    WHERE "natural" != 'bay'
 );
 
 -- etldoc: layer_water [shape=record fillcolor=lightpink, style="rounded,filled",


### PR DESCRIPTION
Solving https://github.com/openmaptiles/openmaptiles/issues/522 and related.

After several experiments - trying to cut holes in `osm_water_polygon` to it doesn't cover islands, I decided to not import `"natural" = 'bay'` into `water_z` views. Bay polygons mostly duplicate another water areas (from osm_water_polygon or osm_ocean_polygon) and are the only ones found covering islands.
Bays stay in osm_water_polygon for generating labels in `water_name` layer.

Tested on San Francisco area (complete duplicate), Finland (complete duplicate) and Florida. In Florida some parts of water areas are missing in comparison with current OMT version, however not displaying bays corresponds with openstreetmap.org (e.g. https://www.openstreetmap.org/#map=15/30.1273/-85.5190) and I think correction for these cases should be made on data side (according to recommendations here: https://wiki.openstreetmap.org/wiki/Tag%3Anatural%3Dbay).

No changes in style needed.
_____
I tested importing island + islet and removing them from osm_water_polygon (ST_Difference in places where polygons ST_Intersects), but 1) it is really time consuming even only on one land data extract + there is need to store more data in database, 2) there are water polygons on big islands (e.g. https://www.openstreetmap.org/#map=10/60.1989/20.0466) that should not be removed, so there is need of additional conditions --> completely not realistic time.