### PR TITLE
suburb and neighbourhood added for landuse-residential

### DIFF
--- a/layers/landuse/landuse.sql
+++ b/layers/landuse/landuse.sql
@@ -1,55 +1,55 @@
 -- etldoc: ne_50m_urban_areas -> landuse_z4
 CREATE OR REPLACE VIEW landuse_z4 AS (
-    SELECT NULL::bigint AS osm_id, geometry, 'residential'::text AS landuse, NULL::text AS amenity, NULL::text AS leisure, NULL::text AS tourism, scalerank
+    SELECT NULL::bigint AS osm_id, geometry, 'residential'::text AS landuse, NULL::text AS amenity, NULL::text AS leisure, NULL::text AS tourism, NULL::text AS place, scalerank
     FROM ne_50m_urban_areas
     WHERE scalerank <= 2
 );
 
 -- etldoc: ne_50m_urban_areas -> landuse_z5
 CREATE OR REPLACE VIEW landuse_z5 AS (
-    SELECT NULL::bigint AS osm_id, geometry, 'residential'::text AS landuse, NULL::text AS amenity, NULL::text AS leisure, NULL::text AS tourism, scalerank
+    SELECT NULL::bigint AS osm_id, geometry, 'residential'::text AS landuse, NULL::text AS amenity, NULL::text AS leisure, NULL::text AS tourism, NULL::text AS place, scalerank
     FROM ne_50m_urban_areas
 );
 
 -- etldoc: ne_10m_urban_areas -> landuse_z6
 CREATE OR REPLACE VIEW landuse_z6 AS (
-    SELECT NULL::bigint AS osm_id, geometry, 'residential'::text AS landuse, NULL::text AS amenity, NULL::text AS leisure, NULL::text AS tourism, scalerank
+    SELECT NULL::bigint AS osm_id, geometry, 'residential'::text AS landuse, NULL::text AS amenity, NULL::text AS leisure, NULL::text AS tourism, NULL::text AS place, scalerank
     FROM ne_10m_urban_areas
 );
 
 -- etldoc: osm_landuse_polygon_gen5 -> landuse_z9
 CREATE OR REPLACE VIEW landuse_z9 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, NULL::int as scalerank
     FROM osm_landuse_polygon_gen5
 );
 
 -- etldoc: osm_landuse_polygon_gen4 -> landuse_z10
 CREATE OR REPLACE VIEW landuse_z10 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, NULL::int as scalerank
     FROM osm_landuse_polygon_gen4
 );
 
 -- etldoc: osm_landuse_polygon_gen3 -> landuse_z11
 CREATE OR REPLACE VIEW landuse_z11 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, NULL::int as scalerank
     FROM osm_landuse_polygon_gen3
 );
 
 -- etldoc: osm_landuse_polygon_gen2 -> landuse_z12
 CREATE OR REPLACE VIEW landuse_z12 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, NULL::int as scalerank
     FROM osm_landuse_polygon_gen2
 );
 
 -- etldoc: osm_landuse_polygon_gen1 -> landuse_z13
 CREATE OR REPLACE VIEW landuse_z13 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure,tourism, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, NULL::int as scalerank
     FROM osm_landuse_polygon_gen1
 );
 
 -- etldoc: osm_landuse_polygon -> landuse_z14
 CREATE OR REPLACE VIEW landuse_z14 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, NULL::int as scalerank
     FROM osm_landuse_polygon
 );
 
@@ -63,7 +63,8 @@ RETURNS TABLE(osm_id bigint, geometry geometry, class text) AS $$
             NULLIF(landuse, ''),
             NULLIF(amenity, ''),
             NULLIF(leisure, ''),
-            NULLIF(tourism, '')
+            NULLIF(tourism, ''),
+            NULLIF(place, '')
         ) AS class
         FROM (
         -- etldoc: landuse_z4 -> layer_landuse:z4

--- a/layers/landuse/landuse.yaml
+++ b/layers/landuse/landuse.yaml
@@ -9,17 +9,12 @@ layer:
       description: |
           Use the **class** to assign special colors to areas.
           Original value of either the
-          [`amenity`](http://wiki.openstreetmap.org/wiki/Key:amenity),
-          [`tourism`](http://wiki.openstreetmap.org/wiki/Key:tourism),
           [`landuse`](http://wiki.openstreetmap.org/wiki/Key:landuse),
-          or [`leisure`](http://wiki.openstreetmap.org/wiki/Key:leisure) tag.
+          [`amenity`](http://wiki.openstreetmap.org/wiki/Key:amenity),
+          [`leisure`](http://wiki.openstreetmap.org/wiki/Key:leisure),
+          [`tourism`](http://wiki.openstreetmap.org/wiki/Key:tourism),
+          or [`place`](http://wiki.openstreetmap.org/wiki/Key:place) tag.
       values:
-      - school
-      - university
-      - kindergarten
-      - college
-      - library
-      - hospital
       - railway
       - cemetery
       - military
@@ -27,12 +22,20 @@ layer:
       - commercial
       - industrial
       - retail
+      - bus_station
+      - school
+      - university
+      - kindergarten
+      - college
+      - library
+      - hospital
       - stadium
       - pitch
       - playground
       - theme_park
-      - bus_station
       - zoo
+      - suburb
+      - neighbourhood
   datasource:
     geometry_field: geometry
     query: (SELECT geometry, class FROM layer_landuse(!bbox!, z(!scale_denominator!))) AS t

--- a/layers/landuse/mapping.yaml
+++ b/layers/landuse/mapping.yaml
@@ -46,19 +46,14 @@ tables:
     - name: tourism
       key: tourism
       type: string
+    - name: place
+      key: place
+      type: string
     - name: area
       type: area
     - name: webmerc_area
       type: webmerc_area
     mapping:
-      amenity:
-      - bus_station
-      - school
-      - university
-      - kindergarten
-      - college
-      - library
-      - hospital
       landuse:
       - railway
       - cemetery
@@ -68,6 +63,14 @@ tables:
       - commercial
       - industrial
       - retail
+      amenity:
+      - bus_station
+      - school
+      - university
+      - kindergarten
+      - college
+      - library
+      - hospital
       leisure:
       - stadium
       - pitch
@@ -75,3 +78,6 @@ tables:
       tourism:
       - theme_park
       - zoo
+      place:
+      - suburb
+      - neighbourhood


### PR DESCRIPTION
- https://github.com/openmaptiles/openmaptiles/issues/268
- importing place=suburb and place=neighbourhood polygons to fill gaps in residential areas
(https://wiki.openstreetmap.org/wiki/Tag:landuse%3Dresidential)
- in style of layer `landuse-residential` should now be:
`class in residential,suburb,neighbourhood`
this has no conflict with current version (`class == residential` only), so style can be changed already before the data are updated
