### PR TITLE
Add Kurdish language (ku)  to the "openmaptiles.yaml"

### DIFF
--- a/openmaptiles.yaml
+++ b/openmaptiles.yaml
@@ -65,6 +65,7 @@ tileset:
     - kn # Kannada
     - ko # Korean
     - ko_rm # romanization of Korean, Latin
+    - ku # Kurdish, Latin
     - la # Latin, Latin
     - lb # Luxembourgish, Latin
     - lt # Lithuanian, Latin


### PR DESCRIPTION
Some information about this key:

- Geographical distribution of this language (name:ku): https://taginfo.openstreetmap.org/keys/name:ku#map

- Overview: https://taginfo.openstreetmap.org/keys/name:ku#overview
