### PR TITLE
Remove the area condition on highway polygon.

### DIFF
--- a/layers/transportation/layer.sql
+++ b/layers/transportation/layer.sql
@@ -366,7 +366,7 @@ indoor INT, bicycle TEXT, foot TEXT, horse TEXT, mtb_scale TEXT, surface TEXT) A
         WHERE zoom_level >= 13
             AND (
                   man_made IN ('bridge', 'pier')
-                  OR (is_area AND COALESCE(layer, 0) >= 0)
+                  OR (ST_GeometryType(geometry) IN ('ST_Polygon','ST_MultiPolygon') AND COALESCE(layer, 0) >= 0)
             )
     ) AS zoom_levels
     WHERE geometry && bbox


### PR DESCRIPTION
For some reason highway multipolygon where not rendered. We use them a lot in Montrouge, France as we map sidewalk with multipolygon.

An example of multipolygon rendered with openmaptiles after this patch:

![Screenshot_2019-07-16 OSMontrouge](https://user-images.githubusercontent.com/86659/61329045-ac03ed80-a81c-11e9-8f5f-9361a31fb15d.png)

- the relation: https://www.openstreetmap.org/relation/9792499
- the live map: https://osmontrouge.fr/@48.818765,2.320661,18.36
