### PR TITLE
Remove duplicate POI class match on chocolate and confectionery

### DIFF
--- a/layers/poi/class.sql
+++ b/layers/poi/class.sql
@@ -30,7 +30,7 @@ $$ LANGUAGE SQL IMMUTABLE;
 CREATE OR REPLACE FUNCTION poi_class(subclass TEXT, mapping_key TEXT)
 RETURNS TEXT AS $$
     SELECT CASE
-        WHEN subclass IN ('accessories','antiques','beauty','bed','boutique','camera','carpet','charity','chemist','chocolate','coffee','computer','confectionery','convenience','copyshop','cosmetics','garden_centre','doityourself','erotic','electronics','fabric','florist','frozen_food','furniture','video_games','video','general','gift','hardware','hearing_aids','hifi','ice_cream','interior_decoration','jewelry','kiosk','lamps','mall','massage','motorcycle','mobile_phone','newsagent','optician','outdoor','perfumery','perfume','pet','photo','second_hand','shoes','sports','stationery','tailor','tattoo','ticket','tobacco','toys','travel_agency','watches','weapons','wholesale') THEN 'shop'
+        WHEN subclass IN ('accessories','antiques','beauty','bed','boutique','camera','carpet','charity','chemist','coffee','computer','convenience','copyshop','cosmetics','garden_centre','doityourself','erotic','electronics','fabric','florist','frozen_food','furniture','video_games','video','general','gift','hardware','hearing_aids','hifi','ice_cream','interior_decoration','jewelry','kiosk','lamps','mall','massage','motorcycle','mobile_phone','newsagent','optician','outdoor','perfumery','perfume','pet','photo','second_hand','shoes','sports','stationery','tailor','tattoo','ticket','tobacco','toys','travel_agency','watches','weapons','wholesale') THEN 'shop'
         WHEN subclass IN ('townhall','public_building','courthouse','community_centre') THEN 'town_hall'
         WHEN subclass IN ('golf','golf_course','miniature_golf') THEN 'golf'
         WHEN subclass IN ('fast_food','food_court') THEN 'fast_food'


### PR DESCRIPTION
I am afraid we must remove some chocolate tiles.

`chocolate` and `confectionery` POI subclass are duplicated:
* https://github.com/openmaptiles/openmaptiles/blob/master/layers/poi/class.sql#L33
* https://github.com/openmaptiles/openmaptiles/blob/master/layers/poi/class.sql#L48
