### PR TITLE
Support natural=dune aside of beach and sand

### DIFF
--- a/layers/landcover/landcover.sql
+++ b/layers/landcover/landcover.sql
@@ -21,7 +21,7 @@ CREATE OR REPLACE FUNCTION landcover_class(landuse VARCHAR, "natural" VARCHAR, l
             OR leisure IN ('park', 'garden')
             THEN 'grass'
         WHEN "natural"='wetland' OR wetland IN ('bog', 'swamp', 'wet_meadow', 'marsh', 'reedbed', 'saltern', 'tidalflat', 'saltmarsh', 'mangrove') THEN 'wetland'
-        WHEN "natural"IN ('beach', 'sand') THEN 'sand'
+        WHEN "natural"IN ('beach', 'sand', 'dune') THEN 'sand'
         ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE;

--- a/layers/landcover/landcover.yaml
+++ b/layers/landcover/landcover.yaml
@@ -29,6 +29,7 @@ layer:
       - bare_rock
       - beach
       - bog
+      - dune
       - farm
       - farmland
       - forest

--- a/layers/landcover/mapping.yaml
+++ b/layers/landcover/mapping.yaml
@@ -92,6 +92,7 @@ tables:
       - scree
       - beach
       - sand
+      - dune
       leisure:
       - park
       - garden


### PR DESCRIPTION
Add `natural=dune` in the sand landcover class.

There is not lot of `natural=dune` but there are major objects of the landscape, and can be simply mapped the `sand` class.

https://taginfo.openstreetmap.org/tags/natural=dune#overview
