### PR TITLE
Remove pixel_scale

### DIFF
--- a/openmaptiles.yaml
+++ b/openmaptiles.yaml
@@ -25,7 +25,6 @@ tileset:
   bounds: [-180.0,-85.0511,180.0,85.0511]
   maxzoom: 14
   minzoom: 0
-  pixel_scale: 256
   languages:
     - ar # Arabic
     - az # Azerbaijani, Latin


### PR DESCRIPTION
There is `pixel_scale: 256` in the metadata, but I don't think there's any practical reason for this.

- Vector tiles are usually rasterized into 512x512 (so why 256?)
- I couldn't find any library using this value for anything