### PR TITLE
Fix err in transportation update_gbr_route_members

### DIFF
--- a/layers/transportation_name/update_route_member.sql
+++ b/layers/transportation_name/update_route_member.sql
@@ -8,7 +8,7 @@ BEGIN
   select st_buffer(geometry, 10000) into gbr_geom from ne_10m_admin_0_countries where iso_a2 = 'GB';
   delete from osm_route_member where network IN('omt-gb-motorway', 'omt-gb-trunk');
 
-  insert into osm_route_member (member, ref, network)
+  insert into osm_route_member (osm_id, ref, network)
     (
       SELECT hw.osm_id, substring(hw.ref from E'^[AM][0-9AM()]+'), 'omt-gb-motorway'
       from osm_highway_linestring hw

--- a/layers/transportation_name/update_route_member.sql
+++ b/layers/transportation_name/update_route_member.sql
@@ -8,14 +8,14 @@ BEGIN
   select st_buffer(geometry, 10000) into gbr_geom from ne_10m_admin_0_countries where iso_a2 = 'GB';
   delete from osm_route_member where network IN('omt-gb-motorway', 'omt-gb-trunk');
 
-  insert into osm_route_member (osm_id, ref, network)
+  insert into osm_route_member (osm_id, member, ref, network)
     (
-      SELECT hw.osm_id, substring(hw.ref from E'^[AM][0-9AM()]+'), 'omt-gb-motorway'
+      SELECT 0, hw.osm_id, substring(hw.ref from E'^[AM][0-9AM()]+'), 'omt-gb-motorway'
       from osm_highway_linestring hw
       where length(hw.ref)>0 and ST_Intersects(hw.geometry, gbr_geom)
         and hw.highway IN ('motorway')
     ) UNION (
-      SELECT hw.osm_id, substring(hw.ref from E'^[AM][0-9AM()]+'), 'omt-gb-trunk'
+      SELECT 0, hw.osm_id, substring(hw.ref from E'^[AM][0-9AM()]+'), 'omt-gb-trunk'
       from osm_highway_linestring hw
       where length(hw.ref)>0 and ST_Intersects(hw.geometry, gbr_geom)
         and hw.highway IN ('trunk')


### PR DESCRIPTION
The query was producing 3 columns - `(member, ref, network)`,
whereas osm_id is a required field (otherwise it throws null constraint).

I suspect this was never triggered before because no data has ever matched
the filter, thus always producing null results, and hence being skipped.