### PR TITLE
Add roads under construction

### DIFF
--- a/layers/transportation/class.sql
+++ b/layers/transportation/class.sql
@@ -17,9 +17,8 @@ CREATE OR REPLACE FUNCTION highway_class(highway TEXT, public_transport TEXT) RE
         WHEN highway IN ('secondary', 'secondary_link') THEN 'secondary'
         WHEN highway IN ('tertiary', 'tertiary_link') THEN 'tertiary'
         WHEN highway IN ('unclassified', 'residential', 'living_street', 'road') THEN 'minor'
-        WHEN highway IN ('service', 'track') THEN highway
         WHEN highway IN ('pedestrian', 'path', 'footway', 'cycleway', 'steps', 'bridleway', 'corridor') OR public_transport IN ('platform') THEN 'path'
-        WHEN highway = 'raceway' THEN 'raceway'
+        WHEN highway IN ('service', 'track', 'raceway') THEN highway
         ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE;

--- a/layers/transportation/class.sql
+++ b/layers/transportation/class.sql
@@ -25,7 +25,7 @@ CREATE OR REPLACE FUNCTION highway_class(highway TEXT, public_transport TEXT, co
           WHEN construction IN ('primary', 'primary_link') THEN 'primary_construction'
           WHEN construction IN ('secondary', 'secondary_link') THEN 'secondary_construction'
           WHEN construction IN ('tertiary', 'tertiary_link') THEN 'tertiary_construction'
-          WHEN construction IS NULL OR construction IN ('unclassified', 'residential', 'living_street', 'road') THEN 'minor_construction'
+          WHEN construction = '' OR construction IN ('unclassified', 'residential', 'living_street', 'road') THEN 'minor_construction'
           WHEN construction IN ('pedestrian', 'path', 'footway', 'cycleway', 'steps', 'bridleway', 'corridor') OR public_transport IN ('platform') THEN 'path_construction'
           WHEN construction IN ('service', 'track', 'raceway') THEN CONCAT(highway, '_construction')
           ELSE NULL

--- a/layers/transportation/class.sql
+++ b/layers/transportation/class.sql
@@ -18,7 +18,7 @@ CREATE OR REPLACE FUNCTION highway_class(highway TEXT, public_transport TEXT) RE
         WHEN highway IN ('tertiary', 'tertiary_link') THEN 'tertiary'
         WHEN highway IN ('unclassified', 'residential', 'living_street', 'road') THEN 'minor'
         WHEN highway IN ('pedestrian', 'path', 'footway', 'cycleway', 'steps', 'bridleway', 'corridor') OR public_transport IN ('platform') THEN 'path'
-        WHEN highway IN ('service', 'track', 'raceway') THEN highway
+        WHEN highway IN ('service', 'track', 'raceway', 'construction') THEN highway
         ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE;

--- a/layers/transportation/class.sql
+++ b/layers/transportation/class.sql
@@ -9,7 +9,7 @@ $$ LANGUAGE SQL IMMUTABLE STRICT;
 
 -- The classes for highways are derived from the classes used in ClearTables
 -- https://github.com/ClearTables/ClearTables/blob/master/transportation.lua
-CREATE OR REPLACE FUNCTION highway_class(highway TEXT, public_transport TEXT) RETURNS TEXT AS $$
+CREATE OR REPLACE FUNCTION highway_class(highway TEXT, public_transport TEXT, construction TEXT) RETURNS TEXT AS $$
     SELECT CASE
         WHEN highway IN ('motorway', 'motorway_link') THEN 'motorway'
         WHEN highway IN ('trunk', 'trunk_link') THEN 'trunk'
@@ -18,7 +18,18 @@ CREATE OR REPLACE FUNCTION highway_class(highway TEXT, public_transport TEXT) RE
         WHEN highway IN ('tertiary', 'tertiary_link') THEN 'tertiary'
         WHEN highway IN ('unclassified', 'residential', 'living_street', 'road') THEN 'minor'
         WHEN highway IN ('pedestrian', 'path', 'footway', 'cycleway', 'steps', 'bridleway', 'corridor') OR public_transport IN ('platform') THEN 'path'
-        WHEN highway IN ('service', 'track', 'raceway', 'construction') THEN highway
+        WHEN highway IN ('service', 'track', 'raceway') THEN highway
+        WHEN highway = 'construction' THEN CASE
+          WHEN construction IN ('motorway', 'motorway_link') THEN 'motorway_construction'
+          WHEN construction IN ('trunk', 'trunk_link') THEN 'trunk_construction'
+          WHEN construction IN ('primary', 'primary_link') THEN 'primary_construction'
+          WHEN construction IN ('secondary', 'secondary_link') THEN 'secondary_construction'
+          WHEN construction IN ('tertiary', 'tertiary_link') THEN 'tertiary_construction'
+          WHEN construction IS NULL OR construction IN ('unclassified', 'residential', 'living_street', 'road') THEN 'minor_construction'
+          WHEN construction IN ('pedestrian', 'path', 'footway', 'cycleway', 'steps', 'bridleway', 'corridor') OR public_transport IN ('platform') THEN 'path_construction'
+          WHEN construction IN ('service', 'track', 'raceway') THEN CONCAT(highway, '_construction')
+          ELSE NULL
+        END
         ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE;

--- a/layers/transportation/layer.sql
+++ b/layers/transportation/layer.sql
@@ -330,7 +330,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_highway_polygon          ->  layer_transportation:z14_
         SELECT
             osm_id, geometry,
-            highway, NULL AS railway, NULL AS aerialway, NULL AS shipway,
+            highway, NULL AS construction, NULL AS railway, NULL AS aerialway, NULL AS shipway,
             public_transport, NULL AS service,
             CASE WHEN man_made IN ('bridge') THEN TRUE
                 ELSE FALSE

--- a/layers/transportation/layer.sql
+++ b/layers/transportation/layer.sql
@@ -12,7 +12,7 @@ indoor INT, surface TEXT) AS $$
     SELECT
         osm_id, geometry,
         CASE
-            WHEN NULLIF(highway, '') IS NOT NULL OR NULLIF(public_transport, '') IS NOT NULL THEN highway_class(highway, public_transport)
+            WHEN NULLIF(highway, '') IS NOT NULL OR NULLIF(public_transport, '') IS NOT NULL THEN highway_class(highway, public_transport, construction)
             WHEN NULLIF(railway, '') IS NOT NULL THEN railway_class(railway)
             WHEN NULLIF(aerialway, '') IS NOT NULL THEN aerialway
             WHEN NULLIF(shipway, '') IS NOT NULL THEN shipway
@@ -21,7 +21,7 @@ indoor INT, surface TEXT) AS $$
         CASE
             WHEN railway IS NOT NULL THEN railway
             WHEN (highway IS NOT NULL OR public_transport IS NOT NULL)
-                AND highway_class(highway, public_transport) = 'path'
+                AND highway_class(highway, public_transport, construction) = 'path'
                 THEN COALESCE(NULLIF(public_transport, ''), highway)
             ELSE NULL
         END AS subclass,
@@ -39,13 +39,13 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_transportation_merge_linestring_gen7 -> layer_transportation:z4
         SELECT
             osm_id, geometry,
-            highway, NULL AS railway, NULL AS aerialway, NULL AS shipway,
+            highway, construction, NULL AS railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, NULL AS service,
             NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel,
             NULL::boolean AS is_ford,
             NULL::boolean AS is_ramp, NULL::int AS is_oneway, NULL as man_made,
             NULL::int AS layer, NULL::int AS level, NULL::boolean AS indoor,
-	    NULL AS surface,
+	          NULL AS surface,
             z_order
         FROM osm_transportation_merge_linestring_gen7
         WHERE zoom_level = 4
@@ -54,7 +54,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_transportation_merge_linestring_gen6 -> layer_transportation:z5
         SELECT
             osm_id, geometry,
-            highway, NULL AS railway, NULL AS aerialway, NULL AS shipway,
+            highway, construction, NULL AS railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, NULL AS service,
             NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel,
             NULL::boolean AS is_ford,
@@ -68,7 +68,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_transportation_merge_linestring_gen5 -> layer_transportation:z6
         SELECT
             osm_id, geometry,
-            highway, NULL AS railway, NULL AS aerialway, NULL AS shipway,
+            highway, construction, NULL AS railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, NULL AS service,
             NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel,
             NULL::boolean AS is_ford,
@@ -82,7 +82,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_transportation_merge_linestring_gen4  ->  layer_transportation:z7
         SELECT
             osm_id, geometry,
-            highway, NULL AS railway, NULL AS aerialway, NULL AS shipway,
+            highway, construction, NULL AS railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, NULL AS service,
             NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel,
             NULL::boolean AS is_ford,
@@ -96,7 +96,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_transportation_merge_linestring_gen3  ->  layer_transportation:z8
         SELECT
             osm_id, geometry,
-            highway, NULL AS railway, NULL AS aerialway, NULL AS shipway,
+            highway, construction, NULL AS railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, NULL AS service,
             NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel,
             NULL::boolean AS is_ford,
@@ -111,7 +111,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_highway_linestring_gen2  ->  layer_transportation:z10
         SELECT
             osm_id, geometry,
-            highway, NULL AS railway, NULL AS aerialway, NULL AS shipway,
+            highway, construction, NULL AS railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, NULL AS service,
             NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel,
             NULL::boolean AS is_ford,
@@ -126,7 +126,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_highway_linestring_gen1  ->  layer_transportation:z11
         SELECT
             osm_id, geometry,
-            highway, NULL AS railway, NULL AS aerialway, NULL AS shipway,
+            highway, construction, NULL AS railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, NULL AS service,
             NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel,
             NULL::boolean AS is_ford,
@@ -143,7 +143,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_highway_linestring       ->  layer_transportation:z14_
         SELECT
             osm_id, geometry,
-            highway, NULL AS railway, NULL AS aerialway, NULL AS shipway,
+            highway, construction, NULL AS railway, NULL AS aerialway, NULL AS shipway,
             public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, man_made,
             layer,
@@ -158,12 +158,12 @@ indoor INT, surface TEXT) AS $$
         FROM osm_highway_linestring
         WHERE NOT is_area AND (
             zoom_level = 12 AND (
-                highway_class(highway, public_transport) NOT IN ('track', 'path', 'minor')
+                highway_class(highway, public_transport, construction) NOT IN ('track', 'path', 'minor')
                 OR highway IN ('unclassified', 'residential')
             ) AND man_made <> 'pier'
             OR zoom_level = 13
                 AND (
-                    highway_class(highway, public_transport) NOT IN ('track', 'path') AND man_made <> 'pier'
+                    highway_class(highway, public_transport, construction) NOT IN ('track', 'path') AND man_made <> 'pier'
                 OR
                     man_made = 'pier' AND NOT ST_IsClosed(geometry)
                 )
@@ -179,7 +179,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_railway_linestring_gen5  ->  layer_transportation:z8
         SELECT
             osm_id, geometry,
-            NULL AS highway, railway, NULL AS aerialway, NULL AS shipway,
+            NULL AS highway, NULL AS construction, railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, service_value(service) AS service,
             NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel,
             NULL::boolean AS is_ford,
@@ -194,7 +194,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_railway_linestring_gen4  ->  layer_transportation:z9
         SELECT
             osm_id, geometry,
-            NULL AS highway, railway, NULL AS aerialway, NULL AS shipway,
+            NULL AS highway, NULL AS construction, railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, service_value(service) AS service,
             NULL::boolean AS is_bridge, NULL::boolean AS is_tunnel,
             NULL::boolean AS is_ford,
@@ -209,7 +209,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_railway_linestring_gen3  ->  layer_transportation:z10
         SELECT
             osm_id, geometry,
-            NULL AS highway, railway, NULL AS aerialway, NULL AS shipway,
+            NULL AS highway, NULL AS construction, railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, NULL as man_made,
             layer, NULL::int AS level, NULL::boolean AS indoor,
@@ -222,7 +222,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_railway_linestring_gen2  ->  layer_transportation:z11
         SELECT
             osm_id, geometry,
-            NULL AS highway, railway, NULL AS aerialway, NULL AS shipway,
+            NULL AS highway, NULL AS construction, railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, NULL as man_made,
             layer, NULL::int AS level, NULL::boolean AS indoor,
@@ -235,7 +235,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_railway_linestring_gen1  ->  layer_transportation:z12
         SELECT
             osm_id, geometry,
-            NULL AS highway, railway, NULL AS aerialway, NULL AS shipway,
+            NULL AS highway, NULL AS construction, railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, NULL as man_made,
             layer, NULL::int AS level, NULL::boolean AS indoor,
@@ -249,7 +249,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_railway_linestring       ->  layer_transportation:z14_
         SELECT
             osm_id, geometry,
-            NULL AS highway, railway, NULL AS aerialway, NULL AS shipway,
+            NULL AS highway, NULL AS construction, railway, NULL AS aerialway, NULL AS shipway,
             NULL AS public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, NULL as man_made,
             layer, NULL::int AS level, NULL::boolean AS indoor,
@@ -263,7 +263,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_aerialway_linestring_gen1  ->  layer_transportation:z12
         SELECT
             osm_id, geometry,
-            NULL AS highway, NULL as railway, aerialway, NULL AS shipway,
+            NULL AS highway, NULL AS construction, NULL as railway, aerialway, NULL AS shipway,
             NULL AS public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, NULL as man_made,
             layer, NULL::int AS level, NULL::boolean AS indoor,
@@ -276,7 +276,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_aerialway_linestring       ->  layer_transportation:z14_
         SELECT
             osm_id, geometry,
-            NULL AS highway, NULL as railway, aerialway, NULL AS shipway,
+            NULL AS highway, NULL AS construction, NULL as railway, aerialway, NULL AS shipway,
             NULL AS public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, NULL as man_made,
             layer, NULL::int AS level, NULL::boolean AS indoor,
@@ -288,7 +288,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_shipway_linestring_gen2  ->  layer_transportation:z11
         SELECT
             osm_id, geometry,
-            NULL AS highway, NULL AS railway, NULL AS aerialway, shipway,
+            NULL AS highway, NULL AS construction, NULL AS railway, NULL AS aerialway, shipway,
             NULL AS public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, NULL as man_made,
             layer, NULL::int AS level, NULL::boolean AS indoor,
@@ -300,7 +300,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_shipway_linestring_gen1  ->  layer_transportation:z12
         SELECT
             osm_id, geometry,
-            NULL AS highway, NULL AS railway, NULL AS aerialway, shipway,
+            NULL AS highway, NULL AS construction, NULL AS railway, NULL AS aerialway, shipway,
             NULL AS public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, NULL as man_made,
             layer, NULL::int AS level, NULL::boolean AS indoor,
@@ -313,7 +313,7 @@ indoor INT, surface TEXT) AS $$
         -- etldoc: osm_shipway_linestring       ->  layer_transportation:z14_
         SELECT
             osm_id, geometry,
-            NULL AS highway, NULL AS railway, NULL AS aerialway, shipway,
+            NULL AS highway, NULL AS construction, NULL AS railway, NULL AS aerialway, shipway,
             NULL AS public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, NULL as man_made,
             layer, NULL::int AS level, NULL::boolean AS indoor,

--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -187,18 +187,18 @@ tables:
       - tertiary_link
       - unclassified
       - residential
-      - road
       - living_street
-      - raceway
-      - track
-      - service
-      - path
-      - cycleway
-      - bridleway
-      - footway
-      - corridor
+      - road
       - pedestrian
+      - path
+      - footway
+      - cycleway
       - steps
+      - bridleway
+      - corridor
+      - service
+      - track
+      - raceway
       public_transport:
       - platform
       man_made:

--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -199,6 +199,7 @@ tables:
       - service
       - track
       - raceway
+      - construction
       public_transport:
       - platform
       man_made:

--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -45,13 +45,13 @@ generalized_tables:
 # etldoc: imposm3 -> osm_highway_linestring_gen2
   highway_linestring_gen2:
     source: highway_linestring_gen1
-    sql_filter: highway IN ('motorway', 'trunk', 'primary', 'secondary', 'motorway_link', 'trunk_link', 'primary_link', 'secondary_link') AND NOT is_area
+    sql_filter: (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'motorway_link', 'trunk_link', 'primary_link', 'secondary_link') OR highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary', 'secondary', 'motorway_link', 'trunk_link', 'primary_link', 'secondary_link')) AND NOT is_area
     tolerance: ZRES11
 
 # etldoc: imposm3 -> osm_highway_linestring_gen1
   highway_linestring_gen1:
     source: highway_linestring
-    sql_filter: highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'motorway_link', 'trunk_link', 'primary_link', 'secondary_link', 'tertiary_link') AND NOT is_area AND ST_IsValid(geometry)
+    sql_filter: (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'motorway_link', 'trunk_link', 'primary_link', 'secondary_link', 'tertiary_link') OR highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'motorway_link', 'trunk_link', 'primary_link', 'secondary_link', 'tertiary_link')) AND NOT is_area AND ST_IsValid(geometry)
     tolerance: ZRES12
 
 name_field: &name
@@ -149,6 +149,9 @@ tables:
       type: geometry
     - name: highway
       key: highway
+      type: string
+    - name: construction
+      key: construction
       type: string
     - *ref
     - *network

--- a/layers/transportation/transportation.yaml
+++ b/layers/transportation/transportation.yaml
@@ -14,9 +14,10 @@ layer:
   fields:
     class:
       description: |
-          Distinguish between more and less important roads or railways.
+          Distinguish between more and less important roads or railways and roads under construction.
           Class is derived from the value of the
           [`highway`](http://wiki.openstreetmap.org/wiki/Key:highway),
+          [`construction`](http://wiki.openstreetmap.org/wiki/Key:construction),
           [`railway`](http://wiki.openstreetmap.org/wiki/Key:railway),
           [`aerialway`](http://wiki.openstreetmap.org/wiki/Key:aerialway),
           [`route`](http://wiki.openstreetmap.org/wiki/Key:route) tag (for
@@ -33,6 +34,16 @@ layer:
       - track
       - path
       - raceway
+      - motorway_construction
+      - trunk_construction
+      - primary_construction
+      - secondary_construction
+      - tertiary_construction
+      - minor_construction
+      - service_construction
+      - track_construction
+      - path_construction
+      - raceway_construction
       - rail
       - transit
       - cable_car

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -34,18 +34,18 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring AS (
     FROM (
       SELECT
           ST_LineMerge(ST_Collect(geometry)) AS geometry,
-          highway,
+          highway, construction,
           min(z_order) AS z_order
       FROM osm_highway_linestring
       WHERE (highway IN ('motorway','trunk', 'primary') OR highway = 'construction' AND construction IN ('motorway','trunk', 'primary'))
           AND ST_IsValid(geometry)
-      group by highway
+      group by highway, construction
     ) AS highway_union
 );
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_geometry_idx
   ON osm_transportation_merge_linestring USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_highway_partial_idx
-  ON osm_transportation_merge_linestring(highway)
+  ON osm_transportation_merge_linestring(highway, construction)
   WHERE highway IN ('motorway','trunk', 'primary', 'construction');
 
 -- etldoc: osm_transportation_merge_linestring -> osm_transportation_merge_linestring_gen3
@@ -58,7 +58,7 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen3 AS (
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen3_geometry_idx
   ON osm_transportation_merge_linestring_gen3 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen3_highway_partial_idx
-  ON osm_transportation_merge_linestring_gen3(highway)
+  ON osm_transportation_merge_linestring_gen3(highway, construction)
   WHERE highway IN ('motorway','trunk', 'primary', 'construction');
 
 -- etldoc: osm_transportation_merge_linestring_gen3 -> osm_transportation_merge_linestring_gen4
@@ -71,7 +71,7 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen4 AS (
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen4_geometry_idx
   ON osm_transportation_merge_linestring_gen4 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen4_highway_partial_idx
-  ON osm_transportation_merge_linestring_gen4(highway)
+  ON osm_transportation_merge_linestring_gen4(highway, construction)
   WHERE highway IN ('motorway','trunk', 'primary', 'construction');
 
 -- etldoc: osm_transportation_merge_linestring_gen4 -> osm_transportation_merge_linestring_gen5
@@ -84,7 +84,7 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen5 AS (
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen5_geometry_idx
   ON osm_transportation_merge_linestring_gen5 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen5_highway_partial_idx
-  ON osm_transportation_merge_linestring_gen5(highway)
+  ON osm_transportation_merge_linestring_gen5(highway, construction)
   WHERE highway IN ('motorway','trunk', 'construction');
 
 -- etldoc: osm_transportation_merge_linestring_gen5 -> osm_transportation_merge_linestring_gen6
@@ -96,7 +96,7 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen6 AS (
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen6_geometry_idx
   ON osm_transportation_merge_linestring_gen6 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen6_highway_partial_idx
-  ON osm_transportation_merge_linestring_gen6(highway)
+  ON osm_transportation_merge_linestring_gen6(highway, construction)
   WHERE highway IN ('motorway','trunk', 'construction');
 
 -- etldoc: osm_transportation_merge_linestring_gen6 -> osm_transportation_merge_linestring_gen7

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -22,14 +22,14 @@ CREATE INDEX IF NOT EXISTS osm_highway_linestring_highway_idx
 -- Improve performance of the sql below
 CREATE INDEX IF NOT EXISTS osm_highway_linestring_highway_partial_idx
   ON osm_highway_linestring(highway)
-  WHERE highway IN ('motorway','trunk', 'primary');
+  WHERE highway IN ('motorway','trunk', 'primary', 'construction');
 
   -- etldoc: osm_highway_linestring ->  osm_transportation_merge_linestring
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring AS (
     SELECT
         (ST_Dump(geometry)).geom AS geometry,
         NULL::bigint AS osm_id,
-        highway,
+        highway, construction,
         z_order
     FROM (
       SELECT
@@ -37,7 +37,8 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring AS (
           highway,
           min(z_order) AS z_order
       FROM osm_highway_linestring
-      WHERE highway IN ('motorway','trunk', 'primary') AND ST_IsValid(geometry)
+      WHERE (highway IN ('motorway','trunk', 'primary') OR highway = 'construction' AND construction IN ('motorway','trunk', 'primary'))
+          AND ST_IsValid(geometry)
       group by highway
     ) AS highway_union
 );
@@ -45,61 +46,64 @@ CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_geometry_idx
   ON osm_transportation_merge_linestring USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_highway_partial_idx
   ON osm_transportation_merge_linestring(highway)
-  WHERE highway IN ('motorway','trunk', 'primary');
+  WHERE highway IN ('motorway','trunk', 'primary', 'construction');
 
 -- etldoc: osm_transportation_merge_linestring -> osm_transportation_merge_linestring_gen3
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen3 AS (
-    SELECT ST_Simplify(geometry, 120) AS geometry, osm_id, highway, z_order
+    SELECT ST_Simplify(geometry, 120) AS geometry, osm_id, highway, construction, z_order
     FROM osm_transportation_merge_linestring
     WHERE highway IN ('motorway','trunk', 'primary')
+      OR highway = 'construction' AND construction IN ('motorway','trunk', 'primary')
 );
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen3_geometry_idx
   ON osm_transportation_merge_linestring_gen3 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen3_highway_partial_idx
   ON osm_transportation_merge_linestring_gen3(highway)
-  WHERE highway IN ('motorway','trunk', 'primary');
+  WHERE highway IN ('motorway','trunk', 'primary', 'construction');
 
 -- etldoc: osm_transportation_merge_linestring_gen3 -> osm_transportation_merge_linestring_gen4
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen4 AS (
-    SELECT ST_Simplify(geometry, 200) AS geometry, osm_id, highway, z_order
+    SELECT ST_Simplify(geometry, 200) AS geometry, osm_id, highway, construction, z_order
     FROM osm_transportation_merge_linestring_gen3
-    WHERE highway IN ('motorway','trunk', 'primary') AND ST_Length(geometry) > 50
+    WHERE (highway IN ('motorway','trunk', 'primary') OR highway = 'construction' AND construction IN ('motorway','trunk', 'primary'))
+        AND ST_Length(geometry) > 50
 );
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen4_geometry_idx
   ON osm_transportation_merge_linestring_gen4 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen4_highway_partial_idx
   ON osm_transportation_merge_linestring_gen4(highway)
-  WHERE highway IN ('motorway','trunk', 'primary');
+  WHERE highway IN ('motorway','trunk', 'primary', 'construction');
 
 -- etldoc: osm_transportation_merge_linestring_gen4 -> osm_transportation_merge_linestring_gen5
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen5 AS (
-    SELECT ST_Simplify(geometry, 500) AS geometry, osm_id, highway, z_order
+    SELECT ST_Simplify(geometry, 500) AS geometry, osm_id, highway, construction, z_order
     FROM osm_transportation_merge_linestring_gen4
-    WHERE highway IN ('motorway','trunk') AND ST_Length(geometry) > 100
+    WHERE (highway IN ('motorway','trunk') OR highway = 'construction' AND construction IN ('motorway','trunk'))
+        AND ST_Length(geometry) > 100
 );
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen5_geometry_idx
   ON osm_transportation_merge_linestring_gen5 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen5_highway_partial_idx
   ON osm_transportation_merge_linestring_gen5(highway)
-  WHERE highway IN ('motorway', 'trunk');
+  WHERE highway IN ('motorway','trunk', 'construction');
 
 -- etldoc: osm_transportation_merge_linestring_gen5 -> osm_transportation_merge_linestring_gen6
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen6 AS (
-    SELECT ST_Simplify(geometry, 1000) AS geometry, osm_id, highway, z_order
+    SELECT ST_Simplify(geometry, 1000) AS geometry, osm_id, highway, construction, z_order
     FROM osm_transportation_merge_linestring_gen5
-    WHERE highway IN ('motorway','trunk') AND ST_Length(geometry) > 500
+    WHERE (highway IN ('motorway','trunk') OR highway = 'construction' AND construction IN ('motorway','trunk')) AND ST_Length(geometry) > 500
 );
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen6_geometry_idx
   ON osm_transportation_merge_linestring_gen6 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen6_highway_partial_idx
   ON osm_transportation_merge_linestring_gen6(highway)
-  WHERE highway IN ('motorway','trunk');
+  WHERE highway IN ('motorway','trunk', 'construction');
 
 -- etldoc: osm_transportation_merge_linestring_gen6 -> osm_transportation_merge_linestring_gen7
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen7 AS (
-    SELECT ST_Simplify(geometry, 2000) AS geometry, osm_id, highway, z_order
+    SELECT ST_Simplify(geometry, 2000) AS geometry, osm_id, highway, construction, z_order
     FROM osm_transportation_merge_linestring_gen6
-    WHERE highway IN ('motorway') AND ST_Length(geometry) > 1000
+    WHERE (highway = 'motorway' OR highway = 'construction' AND construction = 'motorway') AND ST_Length(geometry) > 1000
 );
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen7_geometry_idx
   ON osm_transportation_merge_linestring_gen7 USING gist(geometry);

--- a/layers/transportation_name/layer.sql
+++ b/layers/transportation_name/layer.sql
@@ -19,9 +19,9 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text,
         when length(coalesce(ref, ''))>0
           then 'road'
       end as network,
-      highway_class(highway, '') AS class,
+      highway_class(highway, '', construction) AS class,
       CASE
-          WHEN highway IS NOT NULL AND highway_class(highway, '') = 'path'
+          WHEN highway IS NOT NULL AND highway_class(highway, '', construction) = 'path'
               THEN highway
           ELSE NULL
       END AS subclass,
@@ -70,6 +70,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text,
           "tags",
           ref,
           highway,
+          construction,
           network,
           z_order,
           layer,
@@ -78,7 +79,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text,
         FROM osm_transportation_name_linestring
         WHERE zoom_level = 12
             AND LineLabel(zoom_level, COALESCE(NULLIF(name, ''), ref), geometry)
-            AND highway_class(highway, '') NOT IN ('minor', 'track', 'path')
+            AND highway_class(highway, '', construction) NOT IN ('minor', 'track', 'path')
             AND NOT highway_is_link(highway)
         UNION ALL
 
@@ -92,6 +93,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text,
           "tags",
           ref,
           highway,
+          construction,
           network,
           z_order,
           layer,
@@ -100,7 +102,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text,
         FROM osm_transportation_name_linestring
         WHERE zoom_level = 13
             AND LineLabel(zoom_level, COALESCE(NULLIF(name, ''), ref), geometry)
-            AND highway_class(highway, '') NOT IN ('track', 'path')
+            AND highway_class(highway, '', construction) NOT IN ('track', 'path')
         UNION ALL
 
         -- etldoc: osm_transportation_name_linestring ->  layer_transportation_name:z14_
@@ -113,6 +115,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text,
           "tags",
           ref,
           highway,
+          construction,
           network,
           z_order,
           layer,

--- a/layers/transportation_name/transportation_name.yaml
+++ b/layers/transportation_name/transportation_name.yaml
@@ -29,7 +29,7 @@ layer:
       - road (default)
     class:
       description: |
-          Distinguish between more and less important roads.
+          Distinguish between more and less important roads and roads under construction.
       values:
       - motorway
       - trunk
@@ -41,6 +41,16 @@ layer:
       - track
       - path
       - raceway
+      - motorway_construction
+      - trunk_construction
+      - primary_construction
+      - secondary_construction
+      - tertiary_construction
+      - minor_construction
+      - service_construction
+      - track_construction
+      - path_construction
+      - raceway_construction
       - rail
       - transit
     subclass:


### PR DESCRIPTION
This PR adds roads under construction to the `transportation` and `transportation_name` layers. It is related to the issue https://github.com/openmaptiles/openmaptiles/issues/321.

I decided not to add a new property, e.g. boolean `is_under_construction`, because it would probably break backward compatibility in most of the styles. In such a case, all roads under construction would appear as normal ones. If we add a road with `class=motorway` and `is_under_construction=1` it would pass filters like `["==", "class", "motorway"]` and it would be painted as an ordinary motorway.

In my solution I created new classes `xxx_construction` for each original class of roads depending on the `construction` tag:
- `motorway_construction`
- `trunk_construction`
- `primary_construction`
- `secondary_construction`
- `tertiary_construction`
- `minor_construction`
- `service_construction`
- `track_construction`
- `raceway_construction`
- `path_construction`

There are quite many cases when roads with `highway=construction` tags are not given the `construction` tags to determine their classes. Such roads fall under the `minor_construction` class as a "generic road under construction".

The main motivation of this PR was to remove the emptiness and sudden breaks of roads in places where roads are being repaired.

This is how it looks before the roads under construction were added:

![Screenshot from 2019-10-08 11-24-13](https://user-images.githubusercontent.com/951364/66379936-17de9800-e9bf-11e9-9477-ce794ce824b3.png)

And after (some pieces of the road lack the `construction` tag, so they are painted with white color as "a generic road under construction"):

![Screenshot from 2019-10-08 11-25-10](https://user-images.githubusercontent.com/951364/66379976-2c229500-e9bf-11e9-9d1f-b1fe89dab213.png)

Some more examples (we draw roads under construction as dashed lines):

![Screenshot from 2019-10-08 11-32-30](https://user-images.githubusercontent.com/951364/66380093-62601480-e9bf-11e9-877e-50a0905c5189.png)
![Screenshot from 2019-10-08 11-31-55](https://user-images.githubusercontent.com/951364/66380100-67bd5f00-e9bf-11e9-98c2-7fd0902698da.png)
