### PR TITLE
Added missing key_field to the aerodrome_label & mountain_peak def

### DIFF
--- a/layers/aerodrome_label/aerodrome_label.yaml
+++ b/layers/aerodrome_label/aerodrome_label.yaml
@@ -27,6 +27,8 @@ layer:
     ele_ft: Elevation (`ele`) in feets.
   datasource:
     geometry_field: geometry
+    key_field: osm_id
+    key_field_as_attribute: no
     srid: 900913
     query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, iata, icao, ele, ele_ft FROM layer_aerodrome_label (!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:

--- a/layers/mountain_peak/mountain_peak.yaml
+++ b/layers/mountain_peak/mountain_peak.yaml
@@ -8,7 +8,7 @@ layer:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Key:name) value of the peak.
     name_en: English name `name:en` if available, otherwise `name`.
     name_de: German name `name:de` if available, otherwise `name` or `name:en`.
-    class: 
+    class:
       description: |
         Use the **class** to differentiate between mountain peak and volcano.
       values:
@@ -19,6 +19,8 @@ layer:
     rank: Rank of the peak within one tile (starting at 1 that is the most important peak).
   datasource:
     geometry_field: geometry
+    key_field: osm_id
+    key_field_as_attribute: no
     srid: 900913
     query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, ele, ele_ft, rank FROM layer_mountain_peak(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:


### PR DESCRIPTION
aerodrome_label & mountain_peak queries return `osm_id`, but they
are not declared in the data source.  I think we should either remove
the `osm_id` from the query result, or declare the data source.

@klokan or @lukasmartinelli - can the `osm_id` be simply removed from the query output?