### PR TITLE
Avoid long repeated text in poi mapping file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ build/openmaptiles.tm2source/data.yml: build
 	docker-compose run --rm openmaptiles-tools generate-tm2source openmaptiles.yaml --host="postgres" --port=5432 --database="openmaptiles" --user="openmaptiles" --password="openmaptiles" > build/openmaptiles.tm2source/data.yml
 
 build/mvt/maketile_func.sql:
-	mkdir -p build/mvt && generate-sqltomvt openmaptiles.yaml --mask-layer=water --mask-level=8 > build/mvt/maketile_func.sql
+	mkdir -p build/mvt && generate-sqltomvt openmaptiles.yaml --mask-layer=water --mask-zoom=8 > build/mvt/maketile_func.sql
 
 build/mvt/maketile_prep.sql:
-	mkdir -p build/mvt && generate-sqltomvt openmaptiles.yaml --mask-layer=water --mask-level=8 --prepared > build/mvt/maketile_prep.sql
+	mkdir -p build/mvt && generate-sqltomvt openmaptiles.yaml --mask-layer=water --mask-zoom=8 --prepared > build/mvt/maketile_prep.sql
 
 build/mapping.yaml: build
 	docker-compose run --rm openmaptiles-tools generate-imposm3 openmaptiles.yaml > build/mapping.yaml

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build:
 	mkdir -p build
 
 build/openmaptiles.tm2source/data.yml: build
-	mkdir -p build/openmaptiles.tm2source
+	mkdir -p build/openmaptiles.tm2source 
 	docker-compose run --rm openmaptiles-tools generate-tm2source openmaptiles.yaml --host="postgres" --port=5432 --database="openmaptiles" --user="openmaptiles" --password="openmaptiles" > build/openmaptiles.tm2source/data.yml
 
 build/mvt/maketile_func.sql:
@@ -127,7 +127,7 @@ start-tileserver:
 	@echo " "
 	docker run -it --rm --name tileserver-gl -v $$(pwd)/data:/data -p 8080:80 klokantech/tileserver-gl
 
-start-postserve: db-start
+start-postserve:
 	@echo " "
 	@echo "***********************************************************"
 	@echo "* "
@@ -151,25 +151,25 @@ start-postserve: db-start
 generate-qareports:
 	./qa/run.sh
 
-build/devdoc:
+build/devdoc: 
 	mkdir -p ./build/devdoc
 
 layers = $(notdir $(wildcard layers/*)) # all layers
 
-etl-graph:
+etl-graph: 
 	@echo 'Use'
 	@echo '   make etl-graph-[layer]	to generate etl graph for [layer]'
 	@echo '   example: make etl-graph-poi'
 	@echo 'Valid layers: $(layers)'
 
 # generate etl graph for a certain layer, e.g. etl-graph-building, etl-graph-place
-etl-graph-%: layers/% build/devdoc
+etl-graph-%: layers/% build/devdoc 
 	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/$*/$*.yaml ./build/devdoc
 
 mappingLayers = $(notdir $(patsubst %/mapping.yaml,%, $(wildcard layers/*/mapping.yaml))) # layers with mapping.yaml
 
 # generate mapping graph for a certain layer, e.g. mapping-graph-building, mapping-graph-place
-mapping-graph:
+mapping-graph: 
 	@echo 'Use'
 	@echo '   make mapping-graph-[layer]	to generate mapping graph for [layer]'
 	@echo '   example: make mapping-graph-poi'
@@ -178,7 +178,7 @@ mapping-graph:
 mapping-graph-%: ./layers/%/mapping.yaml build/devdoc
 	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-mapping-graph layers/$*/$*.yaml ./build/devdoc/mapping-diagram-$*
 
-# generate all etl and mapping graphs
+# generate all etl and mapping graphs 
 generate-devdoc: $(addprefix etl-graph-,$(layers)) $(addprefix mapping-graph-,$(mappingLayers))
 
 import-sql-dev:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: build/openmaptiles.tm2source/data.yml build/mapping.yaml build/tileset.sql
+all: build/openmaptiles.tm2source/data.yml build/gettile.sql build/mapping.yaml build/tileset.sql
 
 help:
 	@echo "=============================================================================="
@@ -44,6 +44,9 @@ build/openmaptiles.tm2source/data.yml: build
 	mkdir -p build/openmaptiles.tm2source
 	docker-compose run --rm openmaptiles-tools generate-tm2source openmaptiles.yaml --host="postgres" --port=5432 --database="openmaptiles" --user="openmaptiles" --password="openmaptiles" > build/openmaptiles.tm2source/data.yml
 
+build/gettile.sql:
+	mkdir -p build && generate-sqlgettile openmaptiles.yaml > build/gettile.sql
+
 build/mapping.yaml: build
 	docker-compose run --rm openmaptiles-tools generate-imposm3 openmaptiles.yaml > build/mapping.yaml
 
@@ -51,7 +54,7 @@ build/tileset.sql: build
 	docker-compose run --rm openmaptiles-tools generate-sql openmaptiles.yaml > build/tileset.sql
 
 clean:
-	rm -f build/openmaptiles.tm2source/data.yml && rm -f build/mapping.yaml && rm -f build/tileset.sql
+	rm -f build/openmaptiles.tm2source/data.yml && rm -f build/gettile.sql && rm -f build/mapping.yaml && rm -f build/tileset.sql
 
 clean-docker:
 	docker-compose down -v --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build:
 	mkdir -p build
 
 build/openmaptiles.tm2source/data.yml: build
-	mkdir -p build/openmaptiles.tm2source 
+	mkdir -p build/openmaptiles.tm2source
 	docker-compose run --rm openmaptiles-tools generate-tm2source openmaptiles.yaml --host="postgres" --port=5432 --database="openmaptiles" --user="openmaptiles" --password="openmaptiles" > build/openmaptiles.tm2source/data.yml
 
 build/mvt/maketile_func.sql:
@@ -127,7 +127,7 @@ start-tileserver:
 	@echo " "
 	docker run -it --rm --name tileserver-gl -v $$(pwd)/data:/data -p 8080:80 klokantech/tileserver-gl
 
-start-postserve:
+start-postserve: db-start
 	@echo " "
 	@echo "***********************************************************"
 	@echo "* "
@@ -151,25 +151,25 @@ start-postserve:
 generate-qareports:
 	./qa/run.sh
 
-build/devdoc: 
+build/devdoc:
 	mkdir -p ./build/devdoc
 
 layers = $(notdir $(wildcard layers/*)) # all layers
 
-etl-graph: 
+etl-graph:
 	@echo 'Use'
 	@echo '   make etl-graph-[layer]	to generate etl graph for [layer]'
 	@echo '   example: make etl-graph-poi'
 	@echo 'Valid layers: $(layers)'
 
 # generate etl graph for a certain layer, e.g. etl-graph-building, etl-graph-place
-etl-graph-%: layers/% build/devdoc 
+etl-graph-%: layers/% build/devdoc
 	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-etlgraph layers/$*/$*.yaml ./build/devdoc
 
 mappingLayers = $(notdir $(patsubst %/mapping.yaml,%, $(wildcard layers/*/mapping.yaml))) # layers with mapping.yaml
 
 # generate mapping graph for a certain layer, e.g. mapping-graph-building, mapping-graph-place
-mapping-graph: 
+mapping-graph:
 	@echo 'Use'
 	@echo '   make mapping-graph-[layer]	to generate mapping graph for [layer]'
 	@echo '   example: make mapping-graph-poi'
@@ -178,7 +178,7 @@ mapping-graph:
 mapping-graph-%: ./layers/%/mapping.yaml build/devdoc
 	docker run --rm -v $$(pwd):/tileset openmaptiles/openmaptiles-tools generate-mapping-graph layers/$*/$*.yaml ./build/devdoc/mapping-diagram-$*
 
-# generate all etl and mapping graphs 
+# generate all etl and mapping graphs
 generate-devdoc: $(addprefix etl-graph-,$(layers)) $(addprefix mapping-graph-,$(mappingLayers))
 
 import-sql-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
     networks:
      - postgres_conn
     ports:
-     - "localhost:8090:8090"  # Tighten security - prevent non-local access to the port
+     - "127.0.0.1:8090:8090"  # Tighten security - prevent non-local access to the port
     volumes:
      - ./build:/mapping
     command: /mapping/maketile_prep.sql -p 8090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
   cache:
 services:
   postgres:
-    image: "openmaptiles/postgis:2.9"
+    image: "openmaptiles/postgis:latest"
     volumes:
     - pgdata:/var/lib/postgresql/data
     networks:
@@ -28,7 +28,7 @@ services:
     networks:
     - postgres_conn
   import-osm:
-    image: "openmaptiles/import-osm:0.5"
+    image: "openmaptiles/import-osm:latest"
     env_file: .env
     environment:
       DIFF_MODE: ${DIFF_MODE}
@@ -44,7 +44,7 @@ services:
     networks:
     - postgres_conn
   import-osm-diff:
-    image: "openmaptiles/import-osm:0.5"
+    image: "openmaptiles/import-osm:latest"
     env_file: .env
     command: ./import_diff.sh
     environment:
@@ -56,7 +56,7 @@ services:
      - ./build:/mapping
      - cache:/cache
   update-osm:
-    image: "openmaptiles/import-osm:0.5"
+    image: "openmaptiles/import-osm:latest"
     env_file: .env
     environment:
       DIFF_MODE: ${DIFF_MODE}
@@ -83,7 +83,7 @@ services:
     volumes:
      - ./wikidata:/import
   openmaptiles-tools:
-    image: "openmaptiles/openmaptiles-tools:0.9.2"
+    image: "openmaptiles/openmaptiles-tools:latest"
     env_file: .env
     networks:
     - postgres_conn
@@ -114,15 +114,15 @@ services:
       MIN_ZOOM: ${MIN_ZOOM}
       MAX_ZOOM: ${MAX_ZOOM}
   postserve:
-    image: "openmaptiles/postserve:0.2"
+    image: "openmaptiles/postserve:latest"
     env_file: .env
     networks:
      - postgres_conn
     ports:
-    - "8090:8080"
+     - "localhost:8090:8090"  # Tighten security - prevent non-local access to the port
     volumes:
-     - ./build/openmaptiles.tm2source:/mapping
-
+     - ./build:/mapping
+    command: /mapping/maketile_prep.sql -p 8090
 networks:
   postgres_conn:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
   cache:
 services:
   postgres:
-    image: "openmaptiles/postgis:latest"
+    image: "openmaptiles/postgis:2.9"
     volumes:
     - pgdata:/var/lib/postgresql/data
     networks:
@@ -28,7 +28,7 @@ services:
     networks:
     - postgres_conn
   import-osm:
-    image: "openmaptiles/import-osm:latest"
+    image: "openmaptiles/import-osm:0.5"
     env_file: .env
     environment:
       DIFF_MODE: ${DIFF_MODE}
@@ -44,7 +44,7 @@ services:
     networks:
     - postgres_conn
   import-osm-diff:
-    image: "openmaptiles/import-osm:latest"
+    image: "openmaptiles/import-osm:0.5"
     env_file: .env
     command: ./import_diff.sh
     environment:
@@ -56,7 +56,7 @@ services:
      - ./build:/mapping
      - cache:/cache
   update-osm:
-    image: "openmaptiles/import-osm:latest"
+    image: "openmaptiles/import-osm:0.5"
     env_file: .env
     environment:
       DIFF_MODE: ${DIFF_MODE}
@@ -83,7 +83,7 @@ services:
     volumes:
      - ./wikidata:/import
   openmaptiles-tools:
-    image: "openmaptiles/openmaptiles-tools:latest"
+    image: "openmaptiles/openmaptiles-tools:0.9.2"
     env_file: .env
     networks:
     - postgres_conn
@@ -114,15 +114,15 @@ services:
       MIN_ZOOM: ${MIN_ZOOM}
       MAX_ZOOM: ${MAX_ZOOM}
   postserve:
-    image: "openmaptiles/postserve:latest"
+    image: "openmaptiles/postserve:0.2"
     env_file: .env
     networks:
      - postgres_conn
     ports:
-     - "127.0.0.1:8090:8090"  # Tighten security - prevent non-local access to the port
+    - "8090:8080"
     volumes:
-     - ./build:/mapping
-    command: /mapping/maketile_prep.sql -p 8090
+     - ./build/openmaptiles.tm2source:/mapping
+
 networks:
   postgres_conn:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
   cache:
 services:
   postgres:
-    image: "openmaptiles/postgis:2.9"
+    image: "openmaptiles/postgis:latest"
     volumes:
     - pgdata:/var/lib/postgresql/data
     networks:
@@ -28,7 +28,7 @@ services:
     networks:
     - postgres_conn
   import-osm:
-    image: "openmaptiles/import-osm:0.5"
+    image: "openmaptiles/import-osm:latest"
     env_file: .env
     environment:
       DIFF_MODE: ${DIFF_MODE}
@@ -44,7 +44,7 @@ services:
     networks:
     - postgres_conn
   import-osm-diff:
-    image: "openmaptiles/import-osm:0.5"
+    image: "openmaptiles/import-osm:latest"
     env_file: .env
     command: ./import_diff.sh
     environment:
@@ -56,7 +56,7 @@ services:
      - ./build:/mapping
      - cache:/cache
   update-osm:
-    image: "openmaptiles/import-osm:0.5"
+    image: "openmaptiles/import-osm:latest"
     env_file: .env
     environment:
       DIFF_MODE: ${DIFF_MODE}
@@ -83,7 +83,7 @@ services:
     volumes:
      - ./wikidata:/import
   openmaptiles-tools:
-    image: "openmaptiles/openmaptiles-tools:0.9.2"
+    image: "openmaptiles/openmaptiles-tools:latest"
     env_file: .env
     networks:
     - postgres_conn
@@ -114,15 +114,15 @@ services:
       MIN_ZOOM: ${MIN_ZOOM}
       MAX_ZOOM: ${MAX_ZOOM}
   postserve:
-    image: "openmaptiles/postserve:0.2"
+    image: "openmaptiles/postserve:latest"
     env_file: .env
     networks:
      - postgres_conn
     ports:
-    - "8090:8080"
+     - "127.0.0.1:8090:8090"  # Tighten security - prevent non-local access to the port
     volumes:
-     - ./build/openmaptiles.tm2source:/mapping
-
+     - ./build:/mapping
+    command: /mapping/maketile_prep.sql -p 8090
 networks:
   postgres_conn:
     driver: bridge

--- a/layers/aerodrome_label/aerodrome_label.yaml
+++ b/layers/aerodrome_label/aerodrome_label.yaml
@@ -27,6 +27,8 @@ layer:
     ele_ft: Elevation (`ele`) in feets.
   datasource:
     geometry_field: geometry
+    key_field: osm_id
+    key_field_as_attribute: no
     srid: 900913
     query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, iata, icao, ele, ele_ft FROM layer_aerodrome_label (!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:

--- a/layers/mountain_peak/mountain_peak.yaml
+++ b/layers/mountain_peak/mountain_peak.yaml
@@ -8,7 +8,7 @@ layer:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Key:name) value of the peak.
     name_en: English name `name:en` if available, otherwise `name`.
     name_de: German name `name:de` if available, otherwise `name` or `name:en`.
-    class: 
+    class:
       description: |
         Use the **class** to differentiate between mountain peak and volcano.
       values:
@@ -19,6 +19,8 @@ layer:
     rank: Rank of the peak within one tile (starting at 1 that is the most important peak).
   datasource:
     geometry_field: geometry
+    key_field: osm_id
+    key_field_as_attribute: no
     srid: 900913
     query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, ele, ele_ft, rank FROM layer_mountain_peak(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:

--- a/layers/poi/mapping.yaml
+++ b/layers/poi/mapping.yaml
@@ -314,134 +314,78 @@ def_poi_mapping_tourism: &poi_mapping_tourism
 def_poi_mapping_waterway: &poi_mapping_waterway
   - dock
 
+def_poi_fields: &poi_fields
+  - name: osm_id
+    type: id
+  - name: geometry
+    type: geometry
+  - name: name
+    key: name
+    type: string
+  - name: name_en
+    key: name:en
+    type: string
+  - name: name_de
+    key: name:de
+    type: string
+  - name: tags
+    type: hstore_tags
+  - name: subclass
+    type: mapping_value
+  - name: mapping_key
+    type: mapping_key
+  - name: station
+    key: station
+    type: string
+  - name: funicular
+    key: funicular
+    type: string
+  - name: information
+    key: information
+    type: string
+  - name: uic_ref
+    key: uic_ref
+    type: string
+  - name: religion
+    key: religion
+    type: string
+  - name: level
+    key: level
+    type: integer
+  - name: indoor
+    key: indoor
+    type: bool
+  - name: layer
+    key: layer
+    type: integer
+  - name: sport
+    key: sport
+    type: string
+
+def_poi_mapping: &poi_mapping
+  aerialway: *poi_mapping_aerialway
+  amenity: *poi_mapping_amenity
+  barrier: *poi_mapping_barrier
+  building: *poi_mapping_building
+  highway: *poi_mapping_highway
+  historic: *poi_mapping_historic
+  landuse: *poi_mapping_landuse
+  leisure: *poi_mapping_leisure
+  railway: *poi_mapping_railway
+  shop: *poi_mapping_shop
+  sport: *poi_mapping_sport
+  tourism: *poi_mapping_tourism
+  waterway: *poi_mapping_waterway
+
 tables:
   # etldoc: imposm3 -> osm_poi_point
   poi_point:
     type: point
-    fields:
-    - name: osm_id
-      type: id
-    - name: geometry
-      type: geometry
-    - name: name
-      key: name
-      type: string
-    - name: name_en
-      key: name:en
-      type: string
-    - name: name_de
-      key: name:de
-      type: string
-    - name: tags
-      type: hstore_tags
-    - name: subclass
-      type: mapping_value
-    - name: mapping_key
-      type: mapping_key
-    - name: station
-      key: station
-      type: string
-    - name: funicular
-      key: funicular
-      type: string
-    - name: information
-      key: information
-      type: string
-    - name: uic_ref
-      key: uic_ref
-      type: string
-    - name: religion
-      key: religion
-      type: string
-    - name: level
-      key: level
-      type: integer
-    - name: indoor
-      key: indoor
-      type: bool
-    - name: layer
-      key: layer
-      type: integer
-    - name: sport
-      key: sport
-      type: string
-    mapping:
-      aerialway: *poi_mapping_aerialway
-      amenity: *poi_mapping_amenity
-      barrier: *poi_mapping_barrier
-      building: *poi_mapping_building
-      highway: *poi_mapping_highway
-      historic: *poi_mapping_historic
-      landuse: *poi_mapping_landuse
-      leisure: *poi_mapping_leisure
-      railway: *poi_mapping_railway
-      shop: *poi_mapping_shop
-      sport: *poi_mapping_sport
-      tourism: *poi_mapping_tourism
-      waterway: *poi_mapping_waterway
-
+    fields: *poi_fields
+    mapping: *poi_mapping
 
   # etldoc: imposm3 -> osm_poi_polygon
   poi_polygon:
     type: polygon
-    fields:
-    - name: osm_id
-      type: id
-    - name: geometry
-      type: geometry
-    - name: name
-      key: name
-      type: string
-    - name: name_en
-      key: name:en
-      type: string
-    - name: name_de
-      key: name:de
-      type: string
-    - name: tags
-      type: hstore_tags
-    - name: subclass
-      type: mapping_value
-    - name: mapping_key
-      type: mapping_key
-    - name: station
-      key: station
-      type: string
-    - name: funicular
-      key: funicular
-      type: string
-    - name: information
-      key: information
-      type: string
-    - name: uic_ref
-      key: uic_ref
-      type: string
-    - name: religion
-      key: religion
-      type: string
-    - name: level
-      key: level
-      type: integer
-    - name: indoor
-      key: indoor
-      type: bool
-    - name: layer
-      key: layer
-      type: integer
-    - name: sport
-      key: sport
-      type: string
-    mapping:
-      aerialway: *poi_mapping_aerialway
-      amenity: *poi_mapping_amenity
-      barrier: *poi_mapping_barrier
-      building: *poi_mapping_building
-      highway: *poi_mapping_highway
-      historic: *poi_mapping_historic
-      landuse: *poi_mapping_landuse
-      leisure: *poi_mapping_leisure
-      railway: *poi_mapping_railway
-      shop: *poi_mapping_shop
-      sport: *poi_mapping_sport
-      tourism: *poi_mapping_tourism
-      waterway: *poi_mapping_waterway
+    fields: *poi_fields
+    mapping: *poi_mapping

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -289,7 +289,8 @@ rm -f ./data/quickstart_checklist.chk
 md5sum build/mapping.yaml                     >> ./data/quickstart_checklist.chk
 md5sum build/tileset.sql                      >> ./data/quickstart_checklist.chk
 md5sum build/openmaptiles.tm2source/data.yml  >> ./data/quickstart_checklist.chk
-md5sum build/gettile.sql                      >> ./data/quickstart_checklist.chk
+md5sum build/mvt/maketile_func.sql            >> ./data/quickstart_checklist.chk
+md5sum build/mvt/maketile_prep.sql            >> ./data/quickstart_checklist.chk
 md5sum ./data/${testdata}                     >> ./data/quickstart_checklist.chk
 md5sum ./data/tiles.mbtiles                   >> ./data/quickstart_checklist.chk
 md5sum ./data/docker-compose-config.yml       >> ./data/quickstart_checklist.chk

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -289,6 +289,7 @@ rm -f ./data/quickstart_checklist.chk
 md5sum build/mapping.yaml                     >> ./data/quickstart_checklist.chk
 md5sum build/tileset.sql                      >> ./data/quickstart_checklist.chk
 md5sum build/openmaptiles.tm2source/data.yml  >> ./data/quickstart_checklist.chk
+md5sum build/gettile.sql                      >> ./data/quickstart_checklist.chk
 md5sum ./data/${testdata}                     >> ./data/quickstart_checklist.chk
 md5sum ./data/tiles.mbtiles                   >> ./data/quickstart_checklist.chk
 md5sum ./data/docker-compose-config.yml       >> ./data/quickstart_checklist.chk


### PR DESCRIPTION
Manual merge of the original #611

The fields and mapping sections for poi_point and poi_polygon are the same, and must be the same for the SQL to work properly.

Using definitions avoids repetition and the need to make each change in these sections twice, as was already done for the subsections of mapping.