### PR TITLE
layers/poi: new weight function to consider page views

### DIFF
--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -1,3 +1,35 @@
+-- Compute the weight of an OSM POI, primarily this function relies on the
+-- count of page views for the Wikipedia pages of this POI.
+CREATE OR REPLACE FUNCTION poi_display_weight(
+    name varchar,
+    subclass varchar,
+    mapping_key varchar,
+    tags hstore
+)
+RETURNS REAL AS $$
+    DECLARE
+        max_views CONSTANT REAL := 1e6;
+        min_views CONSTANT REAL := 50.;
+        views_count real;
+    BEGIN
+        SELECT INTO views_count
+            COALESCE(MAX(wm_stats.views)::real, 0)
+            FROM wm_stats
+            JOIN wd_sitelinks ON (wm_stats.title = wd_sitelinks.title
+                              AND wm_stats.lang = wd_sitelinks.lang)
+            WHERE wd_sitelinks.id = tags->'wikidata';
+        RETURN CASE
+            WHEN views_count > min_views THEN
+                0.5 * (1 + LOG(LEAST(max_views, views_count)) / LOG(max_views))
+            WHEN name = '' THEN
+                0.0
+            ELSE
+                0.5 * (
+                    1 - poi_class_rank(poi_class(subclass, mapping_key))::real / 2000
+                )
+        END;
+    END
+$$ LANGUAGE plpgsql IMMUTABLE;
 
 -- etldoc: layer_poi[shape=record fillcolor=lightpink, style="rounded,filled",
 -- etldoc:     label="layer_poi | <z12> z12 | <z13> z13 | <z14_> z14+" ] ;
@@ -24,7 +56,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de
         CASE WHEN indoor=TRUE THEN 1 ELSE NULL END as indoor,
         row_number() OVER (
             PARTITION BY LabelGrid(geometry, 100 * pixel_width)
-            ORDER BY CASE WHEN name = '' THEN 2000 ELSE poi_class_rank(poi_class(subclass, mapping_key)) END ASC
+            ORDER BY poi_display_weight(name, subclass, mapping_key, tags) DESC
         )::int AS "rank"
     FROM (
         -- etldoc: osm_poi_point ->  layer_poi:z12


### PR DESCRIPTION
The rank of a POI is computed through a weight function now primarily based on page views of its corresponding Wikipedia page, if any, otherwise it will use a similar ranking to the previous method.