### PR TITLE
Removing webmerc_area field from mapping.yaml

### DIFF
--- a/layers/aeroway/mapping.yaml
+++ b/layers/aeroway/mapping.yaml
@@ -60,8 +60,6 @@ tables:
       type: mapping_value
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     mapping:
       aeroway: *aeroway_polygon_mapping
       "area:aeroway": *aeroway_polygon_mapping

--- a/layers/building/mapping.yaml
+++ b/layers/building/mapping.yaml
@@ -15,8 +15,6 @@ tables:
       type: validated_geometry
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     - name: material
       key: building:material
       type: string
@@ -78,8 +76,6 @@ tables:
       type: validated_geometry
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     - name: building
       key: building
       type: string
@@ -172,8 +168,6 @@ tables:
       type: validated_geometry
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     - name: building
       key: building
       type: string
@@ -266,8 +260,6 @@ tables:
       type: validated_geometry
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     - name: building
       key: building
       type: string
@@ -360,8 +352,6 @@ tables:
       type: validated_geometry
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     - name: building
       key: building
       type: string

--- a/layers/landcover/mapping.yaml
+++ b/layers/landcover/mapping.yaml
@@ -53,8 +53,6 @@ tables:
       type: validated_geometry
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     - name: subclass
       type: mapping_value
     - name: mapping_key

--- a/layers/landuse/mapping.yaml
+++ b/layers/landuse/mapping.yaml
@@ -51,8 +51,6 @@ tables:
       type: string
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     mapping:
       landuse:
       - railway

--- a/layers/park/mapping.yaml
+++ b/layers/park/mapping.yaml
@@ -79,8 +79,6 @@ tables:
       type: string
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     mapping:
       leisure:
       - nature_reserve

--- a/layers/place/mapping.yaml
+++ b/layers/place/mapping.yaml
@@ -77,8 +77,6 @@ tables:
       type: geometry
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     - *name
     - *name_en
     - *name_de

--- a/layers/water/mapping.yaml
+++ b/layers/water/mapping.yaml
@@ -56,8 +56,6 @@ tables:
       type: validated_geometry
     - name: area
       type: area
-    - name: webmerc_area
-      type: webmerc_area
     - key: name
       name: name
       type: string


### PR DESCRIPTION
https://github.com/openmaptiles/openmaptiles/issues/637

As `webmerc_area` is not used to sort fields, we can remove it to reduce tables' size and improve the speed.