### PR TITLE
simplify travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,9 @@
 sudo: required
 
-dist: trusty
-
 language: bash
 
 services:
   - docker
 
-before_install:
-  - sudo rm -f /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/1.7.1/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-  - sudo service docker restart
-  - docker-compose -v
-  - docker -v
-
 script:
-  - sudo service docker restart
-  - docker-compose config
-  - sudo ./quickstart.sh
+  - ./quickstart.sh


### PR DESCRIPTION
Use default travis-ci build env for running quickstart.sh - we no longer seem to need any
extras like sudo or a custom docker-compose.