### PR TITLE
Filter building on polygons

### DIFF
--- a/layers/building/building.sql
+++ b/layers/building/building.sql
@@ -13,10 +13,10 @@ END;
 $$ STRICT
 LANGUAGE plpgsql IMMUTABLE;
 
-CREATE INDEX IF NOT EXISTS osm_building_relation_building_idx ON osm_building_relation(building);
+CREATE INDEX IF NOT EXISTS osm_building_relation_building_idx ON osm_building_relation(building) WHERE ST_GeometryType(geometry) = 'ST_Polygon';
 CREATE INDEX IF NOT EXISTS osm_building_relation_member_idx ON osm_building_relation(member);
---CREATE INDEX IF NOT EXISTS osm_building_associatedstreet_role_idx ON osm_building_associatedstreet(role);
---CREATE INDEX IF NOT EXISTS osm_building_street_role_idx ON osm_building_street(role);
+--CREATE INDEX IF NOT EXISTS osm_building_associatedstreet_role_idx ON osm_building_associatedstreet(role) WHERE ST_GeometryType(geometry) = 'ST_Polygon';
+--CREATE INDEX IF NOT EXISTS osm_building_street_role_idx ON osm_building_street(role) WHERE ST_GeometryType(geometry) = 'ST_Polygon';
 
 CREATE OR REPLACE VIEW osm_all_buildings AS (
          -- etldoc: osm_building_relation -> layer_building:z14_
@@ -30,7 +30,7 @@ CREATE OR REPLACE VIEW osm_all_buildings AS (
                   nullif(colour, '') AS colour,
                   FALSE as hide_3d
          FROM
-         osm_building_relation WHERE building = ''
+         osm_building_relation WHERE building = '' AND ST_GeometryType(geometry) = 'ST_Polygon'
          UNION ALL
 
          -- etldoc: osm_building_associatedstreet -> layer_building:z14_
@@ -44,7 +44,7 @@ CREATE OR REPLACE VIEW osm_all_buildings AS (
                   nullif(colour, '') AS colour,
                   FALSE as hide_3d
          FROM
-         osm_building_associatedstreet WHERE role = 'house'
+         osm_building_associatedstreet WHERE role = 'house' AND ST_GeometryType(geometry) = 'ST_Polygon'
          UNION ALL
          -- etldoc: osm_building_street -> layer_building:z14_
          -- Buildings in street relations
@@ -57,7 +57,7 @@ CREATE OR REPLACE VIEW osm_all_buildings AS (
                   nullif(colour, '') AS colour,
                   FALSE as hide_3d
          FROM
-         osm_building_street WHERE role = 'house'
+         osm_building_street WHERE role = 'house' AND ST_GeometryType(geometry) = 'ST_Polygon'
          UNION ALL
 
          -- etldoc: osm_building_multipolygon -> layer_building:z14_


### PR DESCRIPTION
The table osm_building_relation, osm_building_associatedstreet and osm_building_street are built from relation members and not filtered on polygons.

Thus tables contain polygons but also point and line, not desirable for buildings layer.
And can not be filtered at imposm import step.

This table are filled with more or less lines and points, depending if addresses are set using relation on building polygons or using dedicated address nodes.

This check can be done once at indexing time using a where clause on the index.
The SQL change on index have no measurable impact on creation time on my tests. But the index is now smallest.


Original, without filter on building geometry. Test made on Aquitaine, France, with z14 only

* Time to generate MBTiles : 54m44.543s
* MBtiles size : 179 871 744


Modified, with filter on building geometry

* Time to generate MBTiles : 54m27.697s
* MBtiles size : 178 827 264 (-0.58%)

Since Aquitaine is in France. And in France AssociatedStreert relations are used more than in other part of the world the gain is probably better.