### PR TITLE
[WIP] Cluster buildings

### DIFF
--- a/layers/building/building.sql
+++ b/layers/building/building.sql
@@ -1,14 +1,18 @@
+DROP TRIGGER IF EXISTS trigger_osm_building_relation_store ON osm_building_relation;
+DROP TRIGGER IF EXISTS trigger_osm_building_polygon_store ON osm_building_polygon;
+DROP TRIGGER IF EXISTS trigger_flag ON building_polygon.buildings;
+DROP TRIGGER IF EXISTS trigger_refresh ON building_polygon.updates;
+
 -- etldoc: layer_building[shape=record fillcolor=lightpink, style="rounded,filled",
 -- etldoc:     label="layer_building | <z13> z13 | <z14_> z14+ " ] ;
 
 CREATE INDEX IF NOT EXISTS osm_building_relation_building_idx ON osm_building_relation (building) WHERE building = '' AND ST_GeometryType(geometry) = 'ST_Polygon';
 CREATE INDEX IF NOT EXISTS osm_building_relation_member_idx ON osm_building_relation (member) WHERE role = 'outline';
 
-CREATE OR REPLACE VIEW osm_all_buildings AS
-(
-SELECT
+CREATE OR REPLACE VIEW osm_buildings_relation AS
     -- etldoc: osm_building_relation -> layer_building:z14_
     -- Buildings built from relations
+SELECT
     member AS osm_id,
     geometry,
     COALESCE(CleanNumeric(height), CleanNumeric(buildingheight)) AS height,
@@ -21,11 +25,12 @@ SELECT
 FROM osm_building_relation
 WHERE building = ''
   AND ST_GeometryType(geometry) = 'ST_Polygon'
-UNION ALL
+;
 
-SELECT
+CREATE OR REPLACE VIEW osm_buildings_standalone AS
     -- etldoc: osm_building_polygon -> layer_building:z14_
     -- Standalone buildings
+SELECT
     obp.osm_id,
     obp.geometry,
     COALESCE(CleanNumeric(obp.height), CleanNumeric(obp.buildingheight)) AS height,
@@ -41,7 +46,38 @@ FROM osm_building_polygon obp
         obr.member = obp.osm_id AND
         obr.role = 'outline'
 WHERE ST_GeometryType(obp.geometry) IN ('ST_Polygon', 'ST_MultiPolygon')
-    );
+;
+
+CREATE OR REPLACE VIEW osm_all_buildings AS
+SELECT *
+FROM osm_buildings_relation
+UNION ALL
+SELECT *
+FROM osm_buildings_standalone
+;
+
+DROP TABLE IF EXISTS osm_all_buildings_mat CASCADE;
+CREATE TABLE osm_all_buildings_mat AS (
+    SELECT
+        --max(osm_id) AS osm_id,
+        ST_Collect(geometry) AS geometry,
+        height,
+        min_height,
+        levels,
+        min_level,
+        material,
+        colour,
+        hide_3d
+    FROM (SELECT DISTINCT ON (osm_id) * FROM osm_all_buildings) AS t
+    GROUP BY
+        -- Cluster by windows to lower time and memory required.
+        -- 100: scale of a building block at 45° of latitude, optimized on Paris area.
+        (ST_XMin(geometry) / 100)::int,
+        (ST_YMin(geometry) / 100)::int,
+        height, min_height, levels, min_level, material, colour, hide_3d
+);
+
+CREATE INDEX osm_all_buildings_mat_geom ON osm_all_buildings_mat USING gist (geometry);
 
 CREATE OR REPLACE FUNCTION layer_building(bbox geometry, zoom_level int)
     RETURNS TABLE
@@ -96,14 +132,25 @@ FROM (
          UNION ALL
          SELECT
                                   -- etldoc: osm_building_polygon -> layer_building:z14_
-             DISTINCT ON (osm_id) osm_id,
+            --DISTINCT ON (osm_id)
+                                  osm_id,
                                   geometry,
                                   ceil(COALESCE(height, levels * 3.66, 5))::int AS render_height,
                                   floor(COALESCE(min_height, min_level * 3.66, 0))::int AS render_min_height,
                                   material,
                                   colour,
                                   hide_3d
-         FROM osm_all_buildings
+         FROM (SELECT NULL::bigint             AS osm_id,
+                      (ST_Dump(geometry)).geom AS geometry,
+                      height,
+                      min_height,
+                      levels,
+                      min_level,
+                      material,
+                      colour,
+                      hide_3d
+               FROM osm_all_buildings_mat
+               WHERE geometry && bbox) AS t
          WHERE (levels IS NULL OR levels < 1000)
            AND (min_level IS NULL OR min_level < 1000)
            AND (height IS NULL OR height < 3000)
@@ -118,3 +165,210 @@ $$ LANGUAGE SQL STABLE
                 ;
 
 -- not handled: where a building outline covers building parts
+
+-- Handle updates
+CREATE SCHEMA IF NOT EXISTS building_polygon;
+
+CREATE TABLE IF NOT EXISTS building_polygon.buildings
+(
+    id           serial PRIMARY KEY,
+    osm_id       bigint,
+    old_geometry geometry(Geometry, 3857),
+    new_geometry geometry(Geometry, 3857)
+);
+CREATE OR REPLACE FUNCTION building_polygon.store() RETURNS trigger AS
+$$
+BEGIN
+    IF (tg_op = 'DELETE') THEN
+        IF ST_GeometryType(OLD.geometry) IN ('ST_Polygon', 'ST_MultiPolygon') THEN
+            INSERT INTO building_polygon.buildings(osm_id, old_geometry, new_geometry)
+            VALUES (OLD.osm_id, OLD.geometry, NULL::geometry);
+        END IF;
+    ELSIF (tg_op = 'UPDATE') THEN
+        IF ST_GeometryType(OLD.geometry) IN ('ST_Polygon', 'ST_MultiPolygon') OR ST_GeometryType(NEW.geometry) IN ('ST_Polygon', 'ST_MultiPolygon') THEN
+            INSERT INTO building_polygon.buildings(osm_id, old_geometry, new_geometry)
+            VALUES (NEW.osm_id,
+                    CASE WHEN ST_GeometryType(OLD.geometry) IN ('ST_Polygon', 'ST_MultiPolygon') THEN OLD.geometry END,
+                    CASE WHEN ST_GeometryType(NEW.geometry) IN ('ST_Polygon', 'ST_MultiPolygon') THEN NEW.geometry END);
+        END IF;
+    ELSIF (tg_op = 'INSERT') THEN
+        IF ST_GeometryType(NEW.geometry) IN ('ST_Polygon', 'ST_MultiPolygon') THEN
+            INSERT INTO building_polygon.buildings(osm_id, old_geometry, new_geometry)
+            VALUES (NEW.osm_id, NULL::geometry, NEW.geometry);
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE IF NOT EXISTS building_polygon.updates
+(
+    id serial PRIMARY KEY,
+    t  text,
+    UNIQUE (t)
+);
+CREATE OR REPLACE FUNCTION building_polygon.flag() RETURNS trigger AS
+$$
+BEGIN
+    INSERT INTO building_polygon.updates(t) VALUES ('y') ON CONFLICT(t) DO NOTHING;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION building_polygon.refresh() RETURNS trigger AS
+$$
+BEGIN
+    RAISE LOG 'Update osm_all_buildings_mat';
+
+    -- Compact the change history to keep only the first and last version
+    CREATE TEMP TABLE old_new_buildings AS
+    SELECT DISTINCT ON (osm_id) osm_id,
+                                old_geometry,
+                                new_geometry
+    FROM (
+             SELECT osm_id,
+                    first_value(old_geometry) OVER (PARTITION BY osm_id ORDER BY id) AS old_geometry,
+                    last_value(new_geometry) OVER (PARTITION BY osm_id ORDER BY id)  AS new_geometry
+             FROM building_polygon.buildings
+         ) AS t;
+
+    -- Flatten old and new version of building
+    CREATE TEMP VIEW touched_buildings AS
+    SELECT DISTINCT(geometry) geometry
+    FROM (SELECT unnest(ARRAY [old_geometry, new_geometry]) AS geometry FROM old_new_buildings) AS t
+    WHERE geometry IS NOT NULL;
+
+    -- Seach for clusters of changed buildings
+    CREATE TEMP TABLE impacted_clusters AS
+    SELECT osm_all_buildings_mat.geometry,
+           height,
+           min_height,
+           levels,
+           min_level,
+           material,
+           colour,
+           hide_3d
+    FROM osm_all_buildings_mat
+             JOIN touched_buildings ON
+        touched_buildings.geometry && osm_all_buildings_mat.geometry;
+
+    -- Remove old version of impacted clusters
+    DELETE
+    FROM osm_all_buildings_mat
+        USING impacted_clusters
+    WHERE osm_all_buildings_mat.geometry && impacted_clusters.geometry
+      AND osm_all_buildings_mat.geometry = impacted_clusters.geometry;
+
+    CREATE TEMP TABLE old_buildings AS
+    SELECT old_geometry AS geometry FROM old_new_buildings WHERE old_geometry IS NOT NULL;
+    CREATE INDEX old_buildings_geom ON old_buildings USING gist (geometry);
+    CREATE TEMP VIEW new_buildings AS
+    SELECT new_geometry AS geometry FROM old_new_buildings WHERE new_geometry IS NOT NULL;
+
+    -- Get new version of buildings with full attributes
+    CREATE TEMP VIEW new_buildings_full AS
+    SELECT osm_buildings.*
+    FROM new_buildings
+             JOIN osm_buildings_relation AS osm_buildings ON
+            osm_buildings.geometry && new_buildings.geometry AND
+            osm_buildings.geometry = new_buildings.geometry
+    UNION ALL
+    SELECT osm_buildings.*
+    FROM new_buildings
+             JOIN osm_buildings_standalone AS osm_buildings ON
+            osm_buildings.geometry && new_buildings.geometry AND
+            osm_buildings.geometry = new_buildings.geometry;
+
+    -- Unpack impacted clusters
+    CREATE TEMP VIEW unclustered_buildings AS
+    SELECT (ST_Dump(geometry)).geom AS geometry,
+           height,
+           min_height,
+           levels,
+           min_level,
+           material,
+           colour,
+           hide_3d
+    FROM impacted_clusters;
+
+    -- Discart old buildings from clusters
+    CREATE TEMP VIEW untouched_buildings AS
+    SELECT unclustered_buildings.geometry,
+           height,
+           min_height,
+           levels,
+           min_level,
+           material,
+           colour,
+           hide_3d
+    FROM unclustered_buildings
+             LEFT JOIN old_buildings ON
+            old_buildings.geometry && unclustered_buildings.geometry AND
+            old_buildings.geometry = unclustered_buildings.geometry
+    WHERE old_buildings.geometry IS NULL;
+
+    -- Reassemble previous untouched buildings and new buildings
+    CREATE TEMP VIEW current_buildings AS
+    SELECT *
+    FROM untouched_buildings
+    UNION
+    SELECT geometry,
+           height,
+           min_height,
+           levels,
+           min_level,
+           material,
+           colour,
+           hide_3d
+    FROM new_buildings_full;
+
+    -- Build and save new clusters
+    INSERT INTO osm_all_buildings_mat
+    SELECT ST_Collect(geometry) AS geometry,
+           height,
+           min_height,
+           levels,
+           min_level,
+           material,
+           colour,
+           hide_3d
+    FROM current_buildings AS t
+    GROUP BY
+        -- Cluster by windows to lower time and memory required
+        (ST_XMin(geometry) / 100)::int,
+        (ST_YMin(geometry) / 100)::int,
+        height, min_height, levels, min_level, material, colour, hide_3d;
+
+    DELETE FROM building_polygon.buildings;
+    DELETE FROM building_polygon.updates;
+    DROP TABLE old_new_buildings CASCADE;
+    DROP TABLE impacted_clusters CASCADE;
+    DROP TABLE old_buildings CASCADE;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_osm_building_relation_store
+    AFTER INSERT OR UPDATE OR DELETE
+    ON osm_building_relation
+    FOR EACH ROW
+EXECUTE PROCEDURE building_polygon.store();
+
+CREATE TRIGGER trigger_osm_building_polygon_store
+    AFTER INSERT OR UPDATE OR DELETE
+    ON osm_building_polygon
+    FOR EACH ROW
+EXECUTE PROCEDURE building_polygon.store();
+
+CREATE TRIGGER trigger_flag
+    AFTER INSERT
+    ON building_polygon.buildings
+    FOR EACH STATEMENT
+EXECUTE PROCEDURE building_polygon.flag();
+
+CREATE CONSTRAINT TRIGGER trigger_refresh
+    AFTER INSERT
+    ON building_polygon.updates
+    INITIALLY DEFERRED
+    FOR EACH ROW
+EXECUTE PROCEDURE building_polygon.refresh();


### PR DESCRIPTION
The buildings layer on z14 is so far the heaviest one. It is particularly the case on dense urban area where the median time to generate tiles is about 5 000 ms.

Using materialized view of building reduce this median time to 3 200 ms. But still impracticable for real time tiles production.

Clustering the buildings using a grid highly reduce the number of objects to be fetched from database in dense area. The clustering is made using the other attributes to keep them.

Nevertheless clustering buildings requite a precomputation step and a storage to a table with index on geometry.

On Aquitaine, France

| Step | Original | With Clustering |
|-|-:|-:|
| Import time (import-osm + import-sql) | 4m42 | 10m27 |
| mbtiles export z0-z14 | 57m16 | 51m18 |
| Total | 61m58 | 61m45 |
| 1 day Database update avg | 44s | 58s |

On Europe

| Step | Original | With Clustering |
|-|-:|-:|
| Import time (import-osm + import-sql) | 11h25 | 16h19 |
| mbtiles export of z14  | na | na |
| Total | na | na |
| 1 day Database update avg | 3h00 | 4h30 |


The clustering take more time at preprocessing step, but less at tiles generation.

But the big change is on median time to produce z14 tiles in dense urban area, is now only at 225 ms.

At counter part, we lost the `osm_id` on clustering.

The table of buildings cluster take time to build and can be improved using differential update. Updating only cluster of changed buildings.

This is a work in progress.