### PR TITLE
Use _resolve_wikidata in layer mapping.yaml

### DIFF
--- a/layers/park/mapping.yaml
+++ b/layers/park/mapping.yaml
@@ -52,6 +52,7 @@ tables:
   # etldoc: imposm3 -> osm_park_polygon
   park_polygon:
     type: polygon
+    _resolve_wikidata: false
     fields:
     - name: osm_id
       type: id

--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -158,6 +158,7 @@ tables:
 # etldoc: imposm3 -> osm_highway_linestring
   highway_linestring:
     type: linestring
+    _resolve_wikidata: false
     fields:
     - name: osm_id
       type: id
@@ -231,6 +232,7 @@ tables:
 # etldoc: imposm3 -> osm_railway_linestring
   railway_linestring:
     type: linestring
+    _resolve_wikidata: false
     fields:
     - name: osm_id
       type: id
@@ -273,6 +275,7 @@ tables:
 # etldoc: imposm3 -> osm_aerialway_linestring
   aerialway_linestring:
     type: linestring
+    _resolve_wikidata: false
     fields:
     - name: osm_id
       type: id
@@ -305,6 +308,7 @@ tables:
 # etldoc: imposm3 -> osm_shipway_linestring
   shipway_linestring:
     type: linestring
+    _resolve_wikidata: false
     fields:
     - name: osm_id
       type: id


### PR DESCRIPTION
Mark all tables that should not be populated with the Wikidata
international labels with a special OMT-specific flag.

This should be ok to merge even before the new tools version
is used because imposm seems to ignore anything it doesn't understand.

The next tools version will remove it when generating imposm mapping file.