### PR TITLE
noop: Remove unneeded "else null" in conditions

### DIFF
--- a/layers/building/building.sql
+++ b/layers/building/building.sql
@@ -112,7 +112,7 @@ RETURNS TABLE(geometry geometry, osm_id bigint, render_height int, render_min_he
            WHEN 'sandstone' THEN '#b4a995' -- same as stone
            WHEN 'clay' THEN '#9d8b75' -- same as mud
        END) AS colour,
-      CASE WHEN hide_3d THEN TRUE ELSE NULL::boolean END AS hide_3d
+      CASE WHEN hide_3d THEN TRUE END AS hide_3d
     FROM (
         -- etldoc: osm_building_polygon_gen1 -> layer_building:z13
         SELECT

--- a/layers/landcover/landcover.sql
+++ b/layers/landcover/landcover.sql
@@ -20,7 +20,6 @@ CREATE OR REPLACE FUNCTION landcover_class(subclass VARCHAR) RETURNS TEXT AS $$
         WHEN subclass IN ('wetland', 'bog', 'swamp', 'wet_meadow', 'marsh', 'reedbed',
                           'saltern', 'tidalflat', 'saltmarsh', 'mangrove') THEN 'wetland'
         WHEN subclass IN ('beach', 'sand', 'dune') THEN 'sand'
-        ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE;
 

--- a/layers/place/capital.sql
+++ b/layers/place/capital.sql
@@ -3,6 +3,5 @@ RETURNS INT AS $$
     SELECT CASE
         WHEN capital IN ('yes', '2') THEN 2
         WHEN capital = '4' THEN 4
-        ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE STRICT;

--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -21,7 +21,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de
         agg_stop,
         NULLIF(layer, 0) AS layer,
         "level",
-        CASE WHEN indoor=TRUE THEN 1 ELSE NULL END as indoor,
+        CASE WHEN indoor=TRUE THEN 1 END as indoor,
         row_number() OVER (
             PARTITION BY LabelGrid(geometry, 100 * pixel_width)
             ORDER BY CASE WHEN name = '' THEN 2000 ELSE poi_class_rank(poi_class(subclass, mapping_key)) END ASC

--- a/layers/poi/poi_stop_agg.sql
+++ b/layers/poi/poi_stop_agg.sql
@@ -3,8 +3,7 @@ CREATE MATERIALIZED VIEW osm_poi_stop_centroid AS (
   SELECT
       uic_ref,
       count(*) as count,
-			CASE WHEN count(*) > 2 THEN ST_Centroid(ST_UNION(geometry))
-			ELSE NULL END AS centroid
+      CASE WHEN count(*) > 2 THEN ST_Centroid(ST_UNION(geometry)) END AS centroid
   FROM osm_poi_point
 	WHERE
 		nullif(uic_ref, '') IS NOT NULL

--- a/layers/poi/update_poi_point.sql
+++ b/layers/poi/update_poi_point.sql
@@ -27,7 +27,6 @@ BEGIN
   SET agg_stop = CASE
       WHEN p.subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
         THEN 1
-      ELSE NULL
   END;
 
   UPDATE osm_poi_point p
@@ -36,7 +35,6 @@ BEGIN
         WHEN p.subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
             AND r.rk IS NULL OR r.rk = 1
           THEN 1
-        ELSE NULL
       END)
     FROM osm_poi_stop_rank r
     WHERE p.osm_id = r.osm_id

--- a/layers/transportation/class.sql
+++ b/layers/transportation/class.sql
@@ -3,7 +3,6 @@ CREATE OR REPLACE FUNCTION brunnel(is_bridge BOOL, is_tunnel BOOL, is_ford BOOL)
         WHEN is_bridge THEN 'bridge'
         WHEN is_tunnel THEN 'tunnel'
         WHEN is_ford THEN 'ford'
-        ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE STRICT;
 
@@ -28,9 +27,7 @@ CREATE OR REPLACE FUNCTION highway_class(highway TEXT, public_transport TEXT, co
           WHEN construction = '' OR construction IN ('unclassified', 'residential', 'living_street', 'road') THEN 'minor_construction'
           WHEN construction IN ('pedestrian', 'path', 'footway', 'cycleway', 'steps', 'bridleway', 'corridor') OR public_transport IN ('platform') THEN 'path_construction'
           WHEN construction IN ('service', 'track', 'raceway') THEN CONCAT(highway, '_construction')
-          ELSE NULL
         END
-        ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE;
 
@@ -40,7 +37,6 @@ CREATE OR REPLACE FUNCTION railway_class(railway TEXT) RETURNS TEXT AS $$
     SELECT CASE
         WHEN railway IN ('rail', 'narrow_gauge', 'preserved', 'funicular') THEN 'rail'
         WHEN railway IN ('subway', 'light_rail', 'monorail', 'tram') THEN 'transit'
-        ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE STRICT;
 
@@ -49,7 +45,6 @@ $$ LANGUAGE SQL IMMUTABLE STRICT;
 CREATE OR REPLACE FUNCTION service_value(service TEXT) RETURNS TEXT AS $$
     SELECT CASE
         WHEN service IN ('spur', 'yard', 'siding', 'crossover', 'driveway', 'alley', 'parking_aisle') THEN service
-        ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE STRICT;
 
@@ -59,6 +54,5 @@ CREATE OR REPLACE FUNCTION surface_value(surface TEXT) RETURNS TEXT AS $$
     SELECT CASE
         WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'concrete', 'concrete:lanes', 'concrete:plates', 'metal', 'paving_stones', 'sett', 'unhewn_cobblestone', 'wood') THEN 'paved'
         WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'gravel_turf', 'ground', 'ice', 'mud', 'pebblestone', 'salt', 'sand', 'snow', 'woodchips') THEN 'unpaved'
-        ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE STRICT;

--- a/layers/transportation/layer.sql
+++ b/layers/transportation/layer.sql
@@ -23,7 +23,6 @@ indoor INT, bicycle TEXT, foot TEXT, horse TEXT, mtb_scale TEXT, surface TEXT) A
             WHEN (highway IS NOT NULL OR public_transport IS NOT NULL)
                 AND highway_class(highway, public_transport, construction) = 'path'
                 THEN COALESCE(NULLIF(public_transport, ''), highway)
-            ELSE NULL
         END AS subclass,
         -- All links are considered as ramps as well
         CASE WHEN highway_is_link(highway) OR highway = 'steps'
@@ -33,7 +32,7 @@ indoor INT, bicycle TEXT, foot TEXT, horse TEXT, mtb_scale TEXT, surface TEXT) A
         NULLIF(service, '') AS service,
         NULLIF(layer, 0) AS layer,
         "level",
-        CASE WHEN indoor=TRUE THEN 1 ELSE NULL END as indoor,
+        CASE WHEN indoor=TRUE THEN 1 END as indoor,
         NULLIF(bicycle, '') AS bicycle,
         NULLIF(foot, '') AS foot,
         NULLIF(horse, '') AS horse,
@@ -157,12 +156,8 @@ indoor INT, bicycle TEXT, foot TEXT, horse TEXT, mtb_scale TEXT, surface TEXT) A
             public_transport, service_value(service) AS service,
             is_bridge, is_tunnel, is_ford, is_ramp, is_oneway, man_made,
             layer,
-            CASE WHEN highway IN ('footway', 'steps') THEN "level"
-                ELSE NULL::int
-            END AS "level",
-            CASE WHEN highway IN ('footway', 'steps') THEN indoor
-                ELSE NULL::boolean
-            END AS indoor,
+            CASE WHEN highway IN ('footway', 'steps') THEN "level" END AS "level",
+            CASE WHEN highway IN ('footway', 'steps') THEN indoor END AS indoor,
             bicycle, foot, horse, mtb_scale,
             surface_value(surface) AS "surface",
             z_order

--- a/layers/transportation_name/layer.sql
+++ b/layers/transportation_name/layer.sql
@@ -23,11 +23,10 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text,
       CASE
           WHEN highway IS NOT NULL AND highway_class(highway, '', construction) = 'path'
               THEN highway
-          ELSE NULL
       END AS subclass,
       NULLIF(layer, 0) AS layer,
       "level",
-      CASE WHEN indoor=TRUE THEN 1 ELSE NULL END as indoor
+      CASE WHEN indoor=TRUE THEN 1 END as indoor
     FROM (
 
         -- etldoc: osm_transportation_name_linestring_gen4 ->  layer_transportation_name:z6

--- a/layers/transportation_name/update_route_member.sql
+++ b/layers/transportation_name/update_route_member.sql
@@ -56,7 +56,6 @@ BEGIN
           THEN 'ca-transcanada'::route_network_type
         WHEN network = 'omt-gb-motorway' THEN 'gb-motorway'::route_network_type
         WHEN network = 'omt-gb-trunk' THEN 'gb-trunk'::route_network_type
-        ELSE NULL
       END
   ;
 

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -25,15 +25,9 @@ CREATE MATERIALIZED VIEW osm_transportation_name_network AS (
       end as ref,
       hl.highway,
       hl.construction,
-      CASE WHEN highway IN ('footway', 'steps') THEN layer
-          ELSE NULL::int
-      END AS layer,
-      CASE WHEN highway IN ('footway', 'steps') THEN "level"
-          ELSE NULL::int
-      END AS "level",
-      CASE WHEN highway IN ('footway', 'steps') THEN indoor
-          ELSE NULL::boolean
-      END AS indoor,
+      CASE WHEN highway IN ('footway', 'steps') THEN layer END AS layer,
+      CASE WHEN highway IN ('footway', 'steps') THEN "level" END AS "level",
+      CASE WHEN highway IN ('footway', 'steps') THEN indoor END AS indoor,
       ROW_NUMBER() OVER(PARTITION BY hl.osm_id
                                    ORDER BY rm.network_type) AS "rank",
       hl.z_order

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -12,7 +12,6 @@ CREATE OR REPLACE FUNCTION waterway_brunnel(is_bridge BOOL, is_tunnel BOOL) RETU
     SELECT CASE
         WHEN is_bridge THEN 'bridge'
         WHEN is_tunnel THEN 'tunnel'
-        ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE STRICT;
 

--- a/layers/waterway/waterway.sql
+++ b/layers/waterway/waterway.sql
@@ -2,7 +2,6 @@ CREATE OR REPLACE FUNCTION waterway_brunnel(is_bridge BOOL, is_tunnel BOOL) RETU
     SELECT CASE
         WHEN is_bridge THEN 'bridge'
         WHEN is_tunnel THEN 'tunnel'
-        ELSE NULL
     END;
 $$ LANGUAGE SQL IMMUTABLE STRICT;
 


### PR DESCRIPTION
Minor code cleanup:
SQL already returns NULL in the "WHEN" condition
if it is not matched by any of the cases.
