### PR TITLE
Noop: tag sql MAT VIEWS with a special comment

### DIFF
--- a/layers/poi/poi_stop_agg.sql
+++ b/layers/poi/poi_stop_agg.sql
@@ -13,7 +13,7 @@ CREATE MATERIALIZED VIEW osm_poi_stop_centroid AS (
 		uic_ref
 	HAVING
 		count(*) > 1
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 
 DROP MATERIALIZED VIEW IF EXISTS osm_poi_stop_rank CASCADE;
 CREATE MATERIALIZED VIEW osm_poi_stop_rank AS (
@@ -33,7 +33,7 @@ CREATE MATERIALIZED VIEW osm_poi_stop_rank AS (
 	WHERE
 		subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
 	ORDER BY p.uic_ref, rk
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 
 ALTER TABLE osm_poi_point ADD COLUMN IF NOT EXISTS agg_stop INTEGER DEFAULT NULL;
 SELECT update_osm_poi_point_agg();

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -41,7 +41,7 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring AS (
           AND ST_IsValid(geometry)
       group by highway, construction
     ) AS highway_union
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_geometry_idx
   ON osm_transportation_merge_linestring USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_highway_partial_idx
@@ -54,7 +54,7 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen3 AS (
     FROM osm_transportation_merge_linestring
     WHERE highway IN ('motorway','trunk', 'primary')
       OR highway = 'construction' AND construction IN ('motorway','trunk', 'primary')
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen3_geometry_idx
   ON osm_transportation_merge_linestring_gen3 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen3_highway_partial_idx
@@ -67,7 +67,7 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen4 AS (
     FROM osm_transportation_merge_linestring_gen3
     WHERE (highway IN ('motorway','trunk', 'primary') OR highway = 'construction' AND construction IN ('motorway','trunk', 'primary'))
         AND ST_Length(geometry) > 50
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen4_geometry_idx
   ON osm_transportation_merge_linestring_gen4 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen4_highway_partial_idx
@@ -80,7 +80,7 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen5 AS (
     FROM osm_transportation_merge_linestring_gen4
     WHERE (highway IN ('motorway','trunk') OR highway = 'construction' AND construction IN ('motorway','trunk'))
         AND ST_Length(geometry) > 100
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen5_geometry_idx
   ON osm_transportation_merge_linestring_gen5 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen5_highway_partial_idx
@@ -92,7 +92,7 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen6 AS (
     SELECT ST_Simplify(geometry, 1000) AS geometry, osm_id, highway, construction, z_order
     FROM osm_transportation_merge_linestring_gen5
     WHERE (highway IN ('motorway','trunk') OR highway = 'construction' AND construction IN ('motorway','trunk')) AND ST_Length(geometry) > 500
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen6_geometry_idx
   ON osm_transportation_merge_linestring_gen6 USING gist(geometry);
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen6_highway_partial_idx
@@ -104,7 +104,7 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen7 AS (
     SELECT ST_Simplify(geometry, 2000) AS geometry, osm_id, highway, construction, z_order
     FROM osm_transportation_merge_linestring_gen6
     WHERE (highway = 'motorway' OR highway = 'construction' AND construction = 'motorway') AND ST_Length(geometry) > 1000
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen7_geometry_idx
   ON osm_transportation_merge_linestring_gen7 USING gist(geometry);
 

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -39,7 +39,7 @@ CREATE MATERIALIZED VIEW osm_transportation_name_network AS (
       hl.z_order
   FROM osm_highway_linestring hl
   left join osm_route_member rm on (rm.member = hl.osm_id)
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_name_network_geometry_idx ON osm_transportation_name_network USING gist(geometry);
 
 
@@ -82,7 +82,7 @@ CREATE MATERIALIZED VIEW osm_transportation_name_linestring AS (
         AND NULLIF(highway, '') IS NOT NULL
       group by name, name_en, name_de, ref, highway, construction, "level", layer, indoor, network_type
     ) AS highway_union
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_geometry_idx ON osm_transportation_name_linestring USING gist(geometry);
 
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_highway_partial_idx
@@ -94,7 +94,7 @@ CREATE MATERIALIZED VIEW osm_transportation_name_linestring_gen1 AS (
     SELECT ST_Simplify(geometry, 50) AS geometry, osm_id, name, name_en, name_de, tags, ref, highway, construction, network, z_order
     FROM osm_transportation_name_linestring
     WHERE (highway IN ('motorway','trunk') OR highway = 'construction' AND construction IN ('motorway','trunk'))  AND ST_Length(geometry) > 8000
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen1_geometry_idx ON osm_transportation_name_linestring_gen1 USING gist(geometry);
 
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen1_highway_partial_idx
@@ -106,7 +106,7 @@ CREATE MATERIALIZED VIEW osm_transportation_name_linestring_gen2 AS (
     SELECT ST_Simplify(geometry, 120) AS geometry, osm_id, name, name_en, name_de, tags, ref, highway, construction, network, z_order
     FROM osm_transportation_name_linestring_gen1
     WHERE (highway IN ('motorway','trunk') OR highway = 'construction' AND construction IN ('motorway','trunk'))  AND ST_Length(geometry) > 14000
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen2_geometry_idx ON osm_transportation_name_linestring_gen2 USING gist(geometry);
 
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen2_highway_partial_idx
@@ -118,7 +118,7 @@ CREATE MATERIALIZED VIEW osm_transportation_name_linestring_gen3 AS (
     SELECT ST_Simplify(geometry, 200) AS geometry, osm_id, name, name_en, name_de, tags, ref, highway, construction, network, z_order
     FROM osm_transportation_name_linestring_gen2
     WHERE (highway = 'motorway' OR highway = 'construction' AND construction = 'motorway') AND ST_Length(geometry) > 20000
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen3_geometry_idx ON osm_transportation_name_linestring_gen3 USING gist(geometry);
 
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen3_highway_partial_idx
@@ -130,7 +130,7 @@ CREATE MATERIALIZED VIEW osm_transportation_name_linestring_gen4 AS (
     SELECT ST_Simplify(geometry, 500) AS geometry, osm_id, name, name_en, name_de, tags, ref, highway, construction, network, z_order
     FROM osm_transportation_name_linestring_gen3
     WHERE (highway = 'motorway' OR highway = 'construction' AND construction = 'motorway') AND ST_Length(geometry) > 20000
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen4_geometry_idx ON osm_transportation_name_linestring_gen4 USING gist(geometry);
 
 -- Handle updates

--- a/layers/water_name/update_water_lakeline.sql
+++ b/layers/water_name/update_water_lakeline.sql
@@ -15,7 +15,7 @@ CREATE MATERIALIZED VIEW osm_water_lakeline AS (
     FROM osm_water_polygon AS wp
     INNER JOIN lake_centerline ll ON wp.osm_id = ll.osm_id
     WHERE wp.name <> '' AND ST_IsValid(wp.geometry)
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_water_lakeline_geometry_idx ON osm_water_lakeline USING gist(geometry);
 
 -- Handle updates

--- a/layers/water_name/update_water_point.sql
+++ b/layers/water_name/update_water_point.sql
@@ -15,7 +15,7 @@ CREATE MATERIALIZED VIEW osm_water_point AS (
     FROM osm_water_polygon AS wp
     LEFT JOIN lake_centerline ll ON wp.osm_id = ll.osm_id
     WHERE ll.osm_id IS NULL AND wp.name <> ''
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_water_point_geometry_idx ON osm_water_point USING gist (geometry);
 
 -- Handle updates

--- a/layers/waterway/update_important_waterway.sql
+++ b/layers/waterway/update_important_waterway.sql
@@ -30,7 +30,7 @@ CREATE MATERIALIZED VIEW osm_important_waterway_linestring AS (
         WHERE name <> '' AND waterway = 'river' AND ST_IsValid(geometry)
         GROUP BY name, name_en, name_de, slice_language_tags(tags)
     ) AS waterway_union
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_important_waterway_linestring_geometry_idx ON osm_important_waterway_linestring USING gist(geometry);
 
 -- etldoc: osm_important_waterway_linestring -> osm_important_waterway_linestring_gen1
@@ -38,7 +38,7 @@ CREATE MATERIALIZED VIEW osm_important_waterway_linestring_gen1 AS (
     SELECT ST_Simplify(geometry, 60) AS geometry, name, name_en, name_de, tags
     FROM osm_important_waterway_linestring
     WHERE ST_Length(geometry) > 1000
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_important_waterway_linestring_gen1_geometry_idx ON osm_important_waterway_linestring_gen1 USING gist(geometry);
 
 -- etldoc: osm_important_waterway_linestring_gen1 -> osm_important_waterway_linestring_gen2
@@ -46,7 +46,7 @@ CREATE MATERIALIZED VIEW osm_important_waterway_linestring_gen2 AS (
     SELECT ST_Simplify(geometry, 100) AS geometry, name, name_en, name_de, tags
     FROM osm_important_waterway_linestring_gen1
     WHERE ST_Length(geometry) > 4000
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_important_waterway_linestring_gen2_geometry_idx ON osm_important_waterway_linestring_gen2 USING gist(geometry);
 
 -- etldoc: osm_important_waterway_linestring_gen2 -> osm_important_waterway_linestring_gen3
@@ -54,7 +54,7 @@ CREATE MATERIALIZED VIEW osm_important_waterway_linestring_gen3 AS (
     SELECT ST_Simplify(geometry, 200) AS geometry, name, name_en, name_de, tags
     FROM osm_important_waterway_linestring_gen2
     WHERE ST_Length(geometry) > 8000
-);
+) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_important_waterway_linestring_gen3_geometry_idx ON osm_important_waterway_linestring_gen3 USING gist(geometry);
 
 -- Handle updates


### PR DESCRIPTION
Tag all SQL materialized views with a machine-readable comment
to indicate that this materialized view can be created without
data:

   `/* DELAY_MATERIALIZED_VIEW_CREATION */`

In the next version of tools this comment can be optionally
replaced with the "WITH NO DATA" parameter, thus allowing
a much faster execution of the SQL script. All materialized
viewes will be populated with data in parallel afterwards
using the `refresh-views` tools script.
