### PR TITLE
Migrate to new Wikidata importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@ quickstart.log
 # imput / output data
 data/*
 
-# input wikidata
-wikidata/*
-
 # generated source files
 build/*
 

--- a/Makefile
+++ b/Makefile
@@ -226,9 +226,10 @@ list:
 download-geofabrik-list:
 	docker-compose run $(DC_OPTS) import-osm  ./download-geofabrik-list.sh
 
-.PHONY: download-wikidata
-download-wikidata:
-	mkdir -p wikidata && docker-compose run $(DC_OPTS) --entrypoint /usr/src/app/download-gz.sh import-wikidata
+.PHONY: import-wikidata
+import-wikidata:
+	# FIXME:   switch to openmaptiles-tools after v3.2+ is published
+	docker-compose run $(DC_OPTS) openmaptiles-tools-latest import-wikidata openmaptiles.yaml
 
 .PHONY: psql-list-tables
 psql-list-tables:

--- a/README.md
+++ b/README.md
@@ -106,16 +106,6 @@ docker-compose run import-lakelines
 docker-compose run import-osmborder
 ```
 
-**[Optional]**
-Import latest Wikidata. If an OSM feature has [Key:wikidata](https://wiki.openstreetmap.org/wiki/Key:wikidata), OpenMapTiles check corresponding item in Wikidata and use its [labels](https://www.wikidata.org/wiki/Help:Label) for languages listed in [openmaptiles.yaml](openmaptiles.yaml). So the generated vector tiles includes multi-languages in name field.
-
-Beware that current [Wikidata dump](https://dumps.wikimedia.org/wikidatawiki/entities/latest-all.json.gz) is more than 55GB, it takes time to download and import it. If you just want to have a quickstart on OpenMapTiles, just skip this step.
-
-```bash
-make download-wikidata
-docker-compose run import-wikidata
-```
-
 [Download OpenStreetMap data extracts](http://download.geofabrik.de/) and store the PBF file in the `./data` directory.
 
 ```bash
@@ -128,6 +118,14 @@ wget http://download.geofabrik.de/europe/albania-latest.osm.pbf
 
 ```bash
 docker-compose run import-osm
+```
+
+Import latest Wikidata. If an OSM feature has [Key:wikidata](https://wiki.openstreetmap.org/wiki/Key:wikidata), OpenMapTiles check corresponding item in Wikidata and use its [labels](https://www.wikidata.org/wiki/Help:Label) for languages listed in [openmaptiles.yaml](openmaptiles.yaml). So the generated vector tiles includes multi-languages in name field.
+
+This step uses [Wikidata Query Service](https://query.wikidata.org) to download just the Wikidata IDs that already exist in the database.
+
+```bash
+make import-wikidata
 ```
 
 ### Work on Layers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,16 +78,18 @@ services:
     volumes:
       - .:/tileset
       - ./build:/sql
-  import-wikidata:
-    image: "openmaptiles/import-wikidata:${TOOLS_VERSION}"
+  openmaptiles-tools:
+    image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"
     env_file: .env
-    command: import-wikidata
     networks:
       - postgres_conn
     volumes:
-      - ./wikidata:/import
-  openmaptiles-tools:
-    image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"
+      - .:/tileset
+      - ./build:/sql
+  openmaptiles-tools-latest:
+    # This target exists for experimental tools that have not yet been published.
+    # Do not use this for production.
+    image: "openmaptiles/openmaptiles-tools:latest"
     env_file: .env
     networks:
       - postgres_conn

--- a/layers/park/mapping.yaml
+++ b/layers/park/mapping.yaml
@@ -52,6 +52,7 @@ tables:
   # etldoc: imposm3 -> osm_park_polygon
   park_polygon:
     type: polygon
+    _resolve_wikidata: false
     fields:
     - name: osm_id
       type: id

--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -158,6 +158,7 @@ tables:
 # etldoc: imposm3 -> osm_highway_linestring
   highway_linestring:
     type: linestring
+    _resolve_wikidata: false
     fields:
     - name: osm_id
       type: id
@@ -231,6 +232,7 @@ tables:
 # etldoc: imposm3 -> osm_railway_linestring
   railway_linestring:
     type: linestring
+    _resolve_wikidata: false
     fields:
     - name: osm_id
       type: id
@@ -273,6 +275,7 @@ tables:
 # etldoc: imposm3 -> osm_aerialway_linestring
   aerialway_linestring:
     type: linestring
+    _resolve_wikidata: false
     fields:
     - name: osm_id
       type: id
@@ -305,6 +308,7 @@ tables:
 # etldoc: imposm3 -> osm_shipway_linestring
   shipway_linestring:
     type: linestring
+    _resolve_wikidata: false
     fields:
     - name: osm_id
       type: id

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -134,7 +134,6 @@ echo "====> : Making directories - if they don't exist ( ./build ./data ./pgdata
 mkdir -p pgdata
 mkdir -p build
 mkdir -p data
-mkdir -p wikidata
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
@@ -239,14 +238,6 @@ docker-compose run $DC_OPTS import-osm
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
-echo "====> : Start importing Wikidata: ./wikidata/latest-all.json.gz -> PostgreSQL"
-echo "      : Source code: https://github.com/openmaptiles/openmaptiles-tools/tree/master/docker/import-wikidata "
-echo "      : The Wikidata license: https://www.wikidata.org/wiki/Wikidata:Database_download/en#License "
-echo "      : Thank you Wikidata Contributors ! "
-docker-compose run $DC_OPTS import-wikidata
-
-echo " "
-echo "-------------------------------------------------------------------------------------"
 echo "====> : Start SQL postprocessing:  ./build/tileset.sql -> PostgreSQL "
 echo "      : Source code: https://github.com/openmaptiles/openmaptiles-tools/tree/master/docker/import-sql "
 # If the output contains a WARNING, stop further processing
@@ -258,6 +249,13 @@ echo " "
 echo "-------------------------------------------------------------------------------------"
 echo "====> : Analyze PostgreSQL tables"
 make psql-analyze
+
+echo " "
+echo "-------------------------------------------------------------------------------------"
+echo "====> : Start importing Wikidata: Wikidata Query Service -> PostgreSQL"
+echo "      : The Wikidata license: CC0 - https://www.wikidata.org/wiki/Wikidata:Main_Page "
+echo "      : Thank you Wikidata Contributors ! "
+make import-wikidata
 
 echo " "
 echo "-------------------------------------------------------------------------------------"


### PR DESCRIPTION
Requires https://github.com/openmaptiles/openmaptiles/pull/731 (:heavy_check_mark: done)

Uses latest tools to populate the wd_names table
during the quickstart.  This can be merged already,
or we can wait for the next tools version.