### PR TITLE
Remove unused import-sql image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,17 +67,6 @@ services:
       - ./data:/import
       - ./build:/mapping
       - cache:/cache
-  import-sql:
-    # This target is obsolete, and was left for backwards compatibility
-    # Use openmaptiles-tools target instead
-    image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"
-    command: import-sql
-    env_file: .env
-    networks:
-      - postgres_conn
-    volumes:
-      - .:/tileset
-      - ./build:/sql
   openmaptiles-tools:
     image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"
     env_file: .env

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -239,7 +239,7 @@ docker-compose run $DC_OPTS import-osm
 echo " "
 echo "-------------------------------------------------------------------------------------"
 echo "====> : Start SQL postprocessing:  ./build/tileset.sql -> PostgreSQL "
-echo "      : Source code: https://github.com/openmaptiles/openmaptiles-tools/tree/master/docker/import-sql "
+echo "      : Source code: https://github.com/openmaptiles/openmaptiles-tools/blob/master/bin/import-sql"
 # If the output contains a WARNING, stop further processing
 # Adapted from https://unix.stackexchange.com/questions/307562
 docker-compose run $DC_OPTS openmaptiles-tools import-sql | \


### PR DESCRIPTION
import-sql image is not used anywhere in OMT, deleting.
