### PR TITLE
Detect sql warnings and abort quickstart

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -251,7 +251,10 @@ echo " "
 echo "-------------------------------------------------------------------------------------"
 echo "====> : Start SQL postprocessing:  ./build/tileset.sql -> PostgreSQL "
 echo "      : Source code: https://github.com/openmaptiles/openmaptiles-tools/tree/master/docker/import-sql "
-docker-compose run $DC_OPTS openmaptiles-tools import-sql
+# If the output contains a WARNING, stop further processing
+# Adapted from https://unix.stackexchange.com/questions/307562
+docker-compose run $DC_OPTS openmaptiles-tools import-sql | \
+    awk -v s=": WARNING:" '$0~s{print; print "\n*** WARNING detected, aborting"; exit(1)} 1'
 
 echo " "
 echo "-------------------------------------------------------------------------------------"


### PR DESCRIPTION
If quickstart generates an SQL `WARNING` while running
the import-sql script, abort.

This should be merged after https://github.com/openmaptiles/openmaptiles/issues/742 is resolved. TravisCI correctly detected that there is currently a problem:
![image](https://user-images.githubusercontent.com/1641515/70846150-7cd1c680-1e24-11ea-858e-6c9de597b08c.png)
