### PR TITLE
TravisCI should raise error on fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ services:
   - docker
 
 script:
+  - set -e
   - TEST_MODE=yes make generate-devdoc
   - ./quickstart.sh


### PR DESCRIPTION
Added missing `set -e` to travis script
so that if the first line fails, it stops
