### PR TITLE
remove useless sql selection

### DIFF
--- a/layers/landuse/landuse.sql
+++ b/layers/landuse/landuse.sql
@@ -1,61 +1,61 @@
 -- etldoc: ne_50m_urban_areas -> landuse_z4
 CREATE OR REPLACE VIEW landuse_z4 AS (
-    SELECT NULL::bigint AS osm_id, geometry, 'residential'::text AS landuse, NULL::text AS amenity, NULL::text AS leisure, NULL::text AS tourism, NULL::text AS place, NULL::text AS waterway, scalerank
+    SELECT NULL::bigint AS osm_id, geometry, 'residential'::text AS landuse, NULL::text AS amenity, NULL::text AS leisure, NULL::text AS tourism, NULL::text AS place, NULL::text AS waterway
     FROM ne_50m_urban_areas
     WHERE scalerank <= 2
 );
 
 -- etldoc: ne_50m_urban_areas -> landuse_z5
 CREATE OR REPLACE VIEW landuse_z5 AS (
-    SELECT NULL::bigint AS osm_id, geometry, 'residential'::text AS landuse, NULL::text AS amenity, NULL::text AS leisure, NULL::text AS tourism, NULL::text AS place, NULL::text AS waterway, scalerank
+    SELECT NULL::bigint AS osm_id, geometry, 'residential'::text AS landuse, NULL::text AS amenity, NULL::text AS leisure, NULL::text AS tourism, NULL::text AS place, NULL::text AS waterway
     FROM ne_50m_urban_areas
 );
 
 -- etldoc: osm_landuse_polygon_gen7 -> landuse_z6
 CREATE OR REPLACE VIEW landuse_z6 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway
     FROM osm_landuse_polygon_gen7
 );
 
 -- etldoc: osm_landuse_polygon_gen6 -> landuse_z8
 CREATE OR REPLACE VIEW landuse_z8 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway
     FROM osm_landuse_polygon_gen6
 );
 
 -- etldoc: osm_landuse_polygon_gen5 -> landuse_z9
 CREATE OR REPLACE VIEW landuse_z9 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway
     FROM osm_landuse_polygon_gen5
 );
 
 -- etldoc: osm_landuse_polygon_gen4 -> landuse_z10
 CREATE OR REPLACE VIEW landuse_z10 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway
     FROM osm_landuse_polygon_gen4
 );
 
 -- etldoc: osm_landuse_polygon_gen3 -> landuse_z11
 CREATE OR REPLACE VIEW landuse_z11 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway
     FROM osm_landuse_polygon_gen3
 );
 
 -- etldoc: osm_landuse_polygon_gen2 -> landuse_z12
 CREATE OR REPLACE VIEW landuse_z12 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway
     FROM osm_landuse_polygon_gen2
 );
 
 -- etldoc: osm_landuse_polygon_gen1 -> landuse_z13
 CREATE OR REPLACE VIEW landuse_z13 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway
     FROM osm_landuse_polygon_gen1
 );
 
 -- etldoc: osm_landuse_polygon -> landuse_z14
 CREATE OR REPLACE VIEW landuse_z14 AS (
-    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway, NULL::int as scalerank
+    SELECT osm_id, geometry, landuse, amenity, leisure, tourism, place, waterway
     FROM osm_landuse_polygon
 );
 

--- a/layers/park/layer.sql
+++ b/layers/park/layer.sql
@@ -11,47 +11,47 @@ RETURNS TABLE(osm_id bigint, geometry geometry, class text, name text, name_en t
         NULL::int as rank
         FROM (
         -- etldoc: osm_park_polygon_gen8 -> layer_park:z6
-        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary
         FROM osm_park_polygon_gen8
         WHERE zoom_level = 6 AND geometry && bbox
         UNION ALL
         -- etldoc: osm_park_polygon_gen7 -> layer_park:z7
-        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary
         FROM osm_park_polygon_gen7
         WHERE zoom_level = 7 AND geometry && bbox
         UNION ALL
         -- etldoc: osm_park_polygon_gen6 -> layer_park:z8
-        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary
         FROM osm_park_polygon_gen6
         WHERE zoom_level = 8 AND geometry && bbox
         UNION ALL
         -- etldoc: osm_park_polygon_gen5 -> layer_park:z9
-        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary
         FROM osm_park_polygon_gen5
         WHERE zoom_level = 9 AND geometry && bbox
         UNION ALL
         -- etldoc: osm_park_polygon_gen4 -> layer_park:z10
-        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary
         FROM osm_park_polygon_gen4
         WHERE zoom_level = 10 AND geometry && bbox
         UNION ALL
         -- etldoc: osm_park_polygon_gen3 -> layer_park:z11
-        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary
         FROM osm_park_polygon_gen3
         WHERE zoom_level = 11 AND geometry && bbox
         UNION ALL
         -- etldoc: osm_park_polygon_gen2 -> layer_park:z12
-        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary
         FROM osm_park_polygon_gen2
         WHERE zoom_level = 12 AND geometry && bbox
         UNION ALL
         -- etldoc: osm_park_polygon_gen1 -> layer_park:z13
-        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary
         FROM osm_park_polygon_gen1
         WHERE zoom_level = 13 AND geometry && bbox
         UNION ALL
         -- etldoc: osm_park_polygon -> layer_park:z14
-        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary, NULL::int as scalerank
+        SELECT osm_id, geometry, name, name_en, name_de, tags, leisure, boundary
         FROM osm_park_polygon
         WHERE zoom_level >= 14 AND geometry && bbox
     ) AS park_polygon


### PR DESCRIPTION
Hi team, 
here is a small modification which removes unnecessary sql selection on landuses and parks layers.

- in landuse.sql: `scalerank` is not used nor returned in function `layer_landuse`
- in park.sql: `scalerank` is only used for the point subselection
 