### PR TITLE
Use import-borders script instead of docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,11 @@ list:
 download-geofabrik-list:
 	docker-compose run $(DC_OPTS) import-osm  ./download-geofabrik-list.sh
 
+.PHONY: import-borders
+import-borders:
+	# FIXME:   switch to openmaptiles-tools after v3.2+ is published
+	docker-compose run $(DC_OPTS) openmaptiles-tools-latest import-borders
+
 .PHONY: import-wikidata
 import-wikidata:
 	# FIXME:   switch to openmaptiles-tools after v3.2+ is published

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Import external data from [OpenStreetMapData](http://osmdata.openstreetmap.de/),
 docker-compose run import-water
 docker-compose run import-natural-earth
 docker-compose run import-lakelines
-docker-compose run import-osmborder
+make import-borders
 ```
 
 [Download OpenStreetMap data extracts](http://download.geofabrik.de/) and store the PBF file in the `./data` directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,11 +38,6 @@ services:
       - ./data:/import
       - ./build:/mapping
       - cache:/cache
-  import-osmborder:
-    image: "openmaptiles/import-osmborder:${TOOLS_VERSION}"
-    env_file: .env
-    networks:
-      - postgres_conn
   import-osm-diff:
     image: "openmaptiles/import-osm:${TOOLS_VERSION}"
     env_file: .env

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -205,10 +205,10 @@ docker-compose run $DC_OPTS import-water
 echo " "
 echo "-------------------------------------------------------------------------------------"
 echo "====> : Start importing border data from http://openstreetmap.org into PostgreSQL "
-echo "      : Source code:  https://github.com/openmaptiles/openmaptiles-tools/tree/master/docker/import-osmborder"
+echo "      : Source code:  https://github.com/openmaptiles/openmaptiles-tools/tree/master/bin/import-borders"
 echo "      : Data license: http://www.openstreetmap.org/copyright"
-echo "      : Thank you: https://github.com/pnorman/osmborder "
-docker-compose run $DC_OPTS import-osmborder
+echo "      : Thank you: https://github.com/pnorman/osmborder"
+make import-borders
 
 echo " "
 echo "-------------------------------------------------------------------------------------"


### PR DESCRIPTION
Switch to the new import-borders script, works on the same data
as used for importing, and makes more streamlined build process.

This can be merged at any time, without waiting for OMT tools
release. Later we can switch from omt-tools-latest to omt-tools.