### PR TITLE
Remove trailing whitespace in openmaptiles.yaml

### DIFF
--- a/openmaptiles.yaml
+++ b/openmaptiles.yaml
@@ -28,7 +28,7 @@ tileset:
   pixel_scale: 256
   languages:
     - am # Amharic
-    - ar # Arabic  
+    - ar # Arabic
     - az # Azerbaijani, Latin
     - be # Belarusian
     - bg # Bulgarian


### PR DESCRIPTION
There is trailing whitespace in openmaptiles.yaml, and it does generate unnecessary diff if eg. your editor automatically removes trailing whitespaces on edit.