### PR TITLE
Reorder POI data update and trigger

### DIFF
--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -146,10 +146,10 @@ layer:
     query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, layer, level, indoor, rank FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:
   - ./public_transport_stop_type.sql
-  - ./update_poi_polygon.sql
-  - ./update_poi_point.sql
   - ./class.sql
   - ./poi_stop_agg.sql
+  - ./update_poi_polygon.sql
+  - ./update_poi_point.sql
   - ./layer.sql
 datasources:
   - type: imposm3

--- a/layers/poi/poi_stop_agg.sql
+++ b/layers/poi/poi_stop_agg.sql
@@ -33,6 +33,3 @@ CREATE MATERIALIZED VIEW osm_poi_stop_rank AS (
 		subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
 	ORDER BY p.uic_ref, rk
 ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
-
-ALTER TABLE osm_poi_point ADD COLUMN IF NOT EXISTS agg_stop INTEGER DEFAULT NULL;
-SELECT update_osm_poi_point_agg();

--- a/layers/poi/update_poi_point.sql
+++ b/layers/poi/update_poi_point.sql
@@ -43,6 +43,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+ALTER TABLE osm_poi_point ADD COLUMN IF NOT EXISTS agg_stop INTEGER DEFAULT NULL;
+SELECT update_osm_poi_point_agg();
+
 -- Handle updates
 
 CREATE SCHEMA IF NOT EXISTS poi_point;


### PR DESCRIPTION
Reorder POI data update and trigger creation to avoid refresh of materialized view after update done by initial import.

I checked the other updates and there are OK.
