### PR TITLE
Update UPDATE.md: add tile list merge script, update imposm3 behavior info

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -28,8 +28,12 @@ docker-compose run import-osm-diff
 
 ## Generate Changed Tiles
 
-After the import has finished **imposm3** will store a list of tiles in text format in the `diffdir`.
-Copy the as `tiles.txt` to the import folder.
+After the import has finished **imposm3** will store lists of tiles in text format in subfolders of the `diffdir`,
+named for the date(s) on which the import took place (`YYYYMMDD`).
+Copy and merge the files to `tiles.txt` in the import folder (`data`), either manually or with the following command, which also removes duplicate tiles so they are only generated once:  
+```
+cd data && sort ./*/*.tiles | uniq > tiles.txt
+```
 
 Now run the command to read the tilelist and write the vector tiles for it to a new MBTiles.
 


### PR DESCRIPTION
Add a one-liner script to take the tile lists from the dated subfolders, merge and deduplicate them, and write it out to tiles.txt.  
Also update docs to reflect current behavior of `docker-compose run update-osm`.