### PR TITLE
Add `requires` to 2 layer definitions

### DIFF
--- a/layers/transportation_name/transportation_name.yaml
+++ b/layers/transportation_name/transportation_name.yaml
@@ -1,5 +1,7 @@
 layer:
   id: "transportation_name"
+  # transportation_name relies on the function highway_class() defined in transportation layer
+  requires: "transportation"
   description: |
       This is the layer for labelling the highways. Only highways that are named `name=*` and are long enough
       to place text upon appear. The OSM roads are stitched together if they contain the same name

--- a/layers/waterway/waterway.yaml
+++ b/layers/waterway/waterway.yaml
@@ -1,5 +1,7 @@
 layer:
   id: "waterway"
+  # waterway relies on the function waterway_brunnel() defined in water layer
+  requires: "water"
   description: |
       OpenStreetMap [waterways](https://wiki.openstreetmap.org/wiki/Waterways) for higher zoom levels (z9 and more)
       and Natural Earth rivers and lake centerlines for low zoom levels (z3 - z8).


### PR DESCRIPTION
Mark waterway and transoprtation_name as having a dependency on another layer.
This is currently an unused parameter, but tools will use it later for faster
sql code generation.

Closes #796
