### PR TITLE
this image has moved.  its now maptiler.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ help:
 	@echo " "
 	@echo "Hints for designers:"
 	@echo "  make start-postserve                 # start Postserver + Maputnik Editor [ see $(OMT_HOST):8088 ] "
-	@echo "  make start-tileserver                # start klokantech/tileserver-gl     [ see $(OMT_HOST):8080 ] "
+	@echo "  make start-tileserver                # start maptiler/tileserver-gl       [ see $(OMT_HOST):8080 ] "
 	@echo " "
 	@echo "Hints for developers:"
 	@echo "  make                                 # build source code"
@@ -172,21 +172,21 @@ start-tileserver: init-dirs
 	@echo " "
 	@echo "***********************************************************"
 	@echo "* "
-	@echo "* Download/refresh klokantech/tileserver-gl docker image"
-	@echo "* see documentation: https://github.com/klokantech/tileserver-gl"
+	@echo "* Download/refresh maptiler/tileserver-gl docker image"
+	@echo "* see documentation: https://github.com/maptiler/tileserver-gl"
 	@echo "* "
 	@echo "***********************************************************"
 	@echo " "
-	docker pull klokantech/tileserver-gl
+	docker pull maptiler/tileserver-gl
 	@echo " "
 	@echo "***********************************************************"
 	@echo "* "
-	@echo "* Start klokantech/tileserver-gl "
+	@echo "* Start maptiler/tileserver-gl "
 	@echo "*       ----------------------------> check $(OMT_HOST):8080 "
 	@echo "* "
 	@echo "***********************************************************"
 	@echo " "
-	docker run $(DC_OPTS) -it --name tileserver-gl -v $$(pwd)/data:/data -p 8080:80 klokantech/tileserver-gl
+	docker run $(DC_OPTS) -it --name tileserver-gl -v $$(pwd)/data:/data -p 8080:80 maptiler/tileserver-gl
 
 .PHONY: start-postserve
 start-postserve: db-start
@@ -285,7 +285,7 @@ remove-docker-images:
 	@$(DOCKER_COMPOSE) down
 	@docker images "openmaptiles/*" -q                | $(XARGS) docker rmi -f
 	@docker images "maputnik/editor" -q               | $(XARGS) docker rmi -f
-	@docker images "klokantech/tileserver-gl" -q      | $(XARGS) docker rmi -f
+	@docker images "maptiler/tileserver-gl" -q        | $(XARGS) docker rmi -f
 
 .PHONY: docker-unnecessary-clean
 docker-unnecessary-clean:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -415,7 +415,7 @@ Hints for testing areas
 
 Hints for designers:
   make start-postserve                 # start Postserver + Maputnik Editor [ see localhost:8088 ]
-  make start-tileserver                # start klokantech/tileserver-gl [ see localhost:8080 ]
+  make start-tileserver                # start maptiler/tileserver-gl [ see localhost:8080 ]
 
 Hints for developers:
   make                                 # build source code


### PR DESCRIPTION
image has moved.

https://github.com/klokantech/tileserver-gl directs to https://github.com/maptiler/tileserver-gl

(as of writing) this updates the version of tileserver-gl from 2.6.0 to 3.0.0.