### PR TITLE
Bug: Fix start-tileserver makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ start-tileserver: init-dirs
 	@echo "* "
 	@echo "***********************************************************"
 	@echo " "
-	docker run $(DC_OPTS) -it --name tileserver-gl -v $$(pwd)/data:/data -p 8080:80 klokantech/tileserver-gl
+	docker run $(DC_OPTS) -it --name tileserver-gl -v $$(pwd)/data:/data -p 8080:8080 klokantech/tileserver-gl --port 8080
 
 .PHONY: start-postserve
 start-postserve: db-start


### PR DESCRIPTION
It is not possible to open port 80 without ROOT inside docker container.
Change default port for start-tileserver target to use port 8080.

Documented in https://github.com/maptiler/tileserver-gl/issues/439

Another solution would be to not use `--user` when starting the container,
but running docker as root is not recommended.