### PR TITLE
Use new import-data image

### DIFF
--- a/.env
+++ b/.env
@@ -1,12 +1,16 @@
+# This file defines default environment variables for all images
+
+TOOLS_VERSION=4.1.0
+
 POSTGRES_DB=openmaptiles
 POSTGRES_USER=openmaptiles
 POSTGRES_PASSWORD=openmaptiles
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
+
 QUICKSTART_MIN_ZOOM=0
 QUICKSTART_MAX_ZOOM=7
 DIFF_MODE=false
-TOOLS_VERSION=4.1.0
 
 BBOX=-180.0,-85.0511,180.0,85.0511
 MIN_ZOOM=0

--- a/.github/workflows/omt_ci.yml
+++ b/.github/workflows/omt_ci.yml
@@ -1,4 +1,4 @@
-# MapTiler OpenMapTiles 
+# MapTiler OpenMapTiles
 #######################
 
 # Workflow to validate OMT`s new Pull Requests and commits pushed into OMT repo
@@ -28,16 +28,16 @@ jobs:
     # Named steps
     - name: generate all zooms
       run: sed -i 's/QUICKSTART_MAX_ZOOM=7/QUICKSTART_MAX_ZOOM=14/g' .env
-    
-    # Runs quickstart  
+
+    # Runs quickstart
     - name: quickstart
       env:
         area: northamptonshire
       run:  bash ./quickstart.sh $area
-      
+
     - name: generate devdoc
       run: TEST_MODE=yes make generate-devdoc
-    
+
     # todo: use artifact to store result of tests
     #- uses: actions/upload-artifact@v1
     #  with:

--- a/README.md
+++ b/README.md
@@ -100,9 +100,7 @@ make db-start
 Import external data from [OpenStreetMapData](http://osmdata.openstreetmap.de/), [Natural Earth](http://www.naturalearthdata.com/) and [OpenStreetMap Lake Labels](https://github.com/lukasmartinelli/osm-lakelines).
 
 ```bash
-make import-water
-make import-natural-earth
-make import-lakelines
+make import-data
 ```
 
 [Download OpenStreetMap data extracts](http://download.geofabrik.de/) and store the PBF file in the `./data` directory.
@@ -119,7 +117,7 @@ make download-geofabrik area=albania
 ```
 
 [Import OpenStreetMap data](https://github.com/openmaptiles/openmaptiles-tools/tree/master/docker/import-osm) with the mapping rules from
-`build/mapping.yaml` (which has been created by `make`). Run after any change in layers definiton.  Also create borders table using extra processing with [osmborder](https://github.com/pnorman/osmborder) tool.
+`build/mapping.yaml` (which has been created by `make`). Run after any change in layers definition.  Also create borders table using extra processing with [osmborder](https://github.com/pnorman/osmborder) tool.
 
 ```bash
 make import-osm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,15 @@
-version: "2"
+# This version must match the MAKE_DC_VERSION value below
+version: "2.3"
+
 volumes:
   pgdata:
+
+networks:
+  postgres_conn:
+    driver: bridge
+
 services:
+
   postgres:
     image: "openmaptiles/postgis:${TOOLS_VERSION}"
     volumes:
@@ -11,21 +19,13 @@ services:
     ports:
       - "5432"
     env_file: .env
-  import-natural-earth:
-    image: "openmaptiles/import-natural-earth:${TOOLS_VERSION}"
+
+  import-data:
+    image: "openmaptiles/import-data:${TOOLS_VERSION}"
     env_file: .env
     networks:
       - postgres_conn
-  import-water:
-    image: "openmaptiles/import-water:${TOOLS_VERSION}"
-    env_file: .env
-    networks:
-      - postgres_conn
-  import-lakelines:
-    image: "openmaptiles/import-lakelines:${TOOLS_VERSION}"
-    env_file: .env
-    networks:
-      - postgres_conn
+
   import-osm:
     image: "openmaptiles/import-osm:${TOOLS_VERSION}"
     env_file: .env
@@ -37,6 +37,7 @@ services:
       - ./data:/import
       - ./build:/mapping
       - ./cache:/cache
+
   import-osm-diff:
     image: "openmaptiles/import-osm:${TOOLS_VERSION}"
     env_file: .env
@@ -49,6 +50,7 @@ services:
       - ./data:/import
       - ./build:/mapping
       - ./cache:/cache
+
   update-osm:
     image: "openmaptiles/import-osm:${TOOLS_VERSION}"
     env_file: .env
@@ -61,26 +63,21 @@ services:
       - ./data:/import
       - ./build:/mapping
       - ./cache:/cache
+
   openmaptiles-tools:
     image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"
     env_file: .env
+    environment:
+      # Must match the version of this file (first line)
+      # download-osm will use it when generating a composer file
+      MAKE_DC_VERSION: "2.3"
     networks:
       - postgres_conn
     volumes:
       - .:/tileset
       - ./data:/import
       - ./build:/sql
-  openmaptiles-tools-latest:
-    # This target exists for experimental tools that have not yet been published.
-    # Do not use this for production.
-    image: "openmaptiles/openmaptiles-tools:latest"
-    env_file: .env
-    networks:
-      - postgres_conn
-    volumes:
-      - .:/tileset
-      - ./data:/import
-      - ./build:/sql
+
   generate-changed-vectortiles:
     image: "openmaptiles/generate-vectortiles:${TOOLS_VERSION}"
     command: ./export-list.sh
@@ -90,6 +87,7 @@ services:
     networks:
       - postgres_conn
     env_file: .env
+
   generate-vectortiles:
     image: "openmaptiles/generate-vectortiles:${TOOLS_VERSION}"
     volumes:
@@ -102,6 +100,7 @@ services:
       BBOX: ${BBOX}
       MIN_ZOOM: ${MIN_ZOOM}
       MAX_ZOOM: ${MAX_ZOOM}
+
   postserve:
     image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"
     command: postserve openmaptiles.yaml --verbose
@@ -112,7 +111,3 @@ services:
       - "8090:8090"
     volumes:
       - .:/tileset
-
-networks:
-  postgres_conn:
-    driver: bridge


### PR DESCRIPTION
This is a partial migration of https://github.com/openmaptiles/openmaptiles/pull/785

* Use `import-data` instead of `import-lakelines`, `import-water`, and `import-natural-earth`
* Upgrade docker-compose.yml to version 2.3 (allows some extra env var usage in yaml file itself)
* Remove `openmaptiles-tools:latest` usage -- no longer needed, can use current version 4.1
* `db-start` does not do a container recreation in case docker-compose.yml definition has changed.
* a few minor cleanups in quickstart.sh
