### PR TITLE
minor CI fix to handle no PRs

### DIFF
--- a/.github/workflows/pr-updater.yml
+++ b/.github/workflows/pr-updater.yml
@@ -47,14 +47,19 @@ jobs:
              "$1"
           }
 
+          # Get all open pull requests, most recently updated first
+          # (this way we don't need to page through all of them)
+          OPEN_PULL_REQUESTS="$(crl "$GITHUB_API/pulls?state=open&sort=updated&direction=desc")"
+
+          if [ $(jq 'length' <( echo "$OPEN_PULL_REQUESTS" ) ) -eq 0 ]; then
+            echo "There are no open pull requests. Exiting."
+            exit
+          fi
+
           # Resolve workflow name into workflow ID
           WORKFLOW_ID="$(crl "$GITHUB_API/actions/workflows" \
               | jq ".workflows[] | select(.name == \"$WORKFLOW_NAME\") | .id")"
           echo "WORKFLOW_NAME='$WORKFLOW_NAME' ==> WORKFLOW_ID=${WORKFLOW_ID}"
-
-          # Get all open pull requests, most recently updated first
-          # (this way we don't need to page through all of them)
-          OPEN_PULL_REQUESTS="$(crl "$GITHUB_API/pulls?state=open&sort=updated&direction=desc")"
 
           # Get all workflow runs that were triggered by pull requests
           WORKFLOW_PR_RUNS="$(crl "$GITHUB_API/actions/workflows/${WORKFLOW_ID}/runs?event=pull_request")"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,12 +163,6 @@ jobs:
             rm results.json
             mv pr-results.json ../artifacts/
 
-            # Convert multiline output into a single long string.
-            # See https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
-            OUTPUT="${OUTPUT//'%'/'%25'}"
-            OUTPUT="${OUTPUT//$'\n'/'%0A'}"
-            OUTPUT="${OUTPUT//$'\r'/'%0D'}"
-
             # Split into two parts -- before and after the ===== SUMMARY =====
             OUT_SUMMARY="${OUTPUT##*========}"
             OUT_DETAILS="${OUTPUT%%========*}"


### PR DESCRIPTION
* delete output escaping (forgot to remove it -- was used for the older system)
* stop early if there are no pull requests (e.g. in case this is a fork)