### PR TITLE
auto-build master-tools branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ name: OpenMapTiles CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, master-tools ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
`master-tools` branch is the same as `master` branch, except that it uses `latest` from the tools repo. This allows us to quickly track if master is compiling correct.