### PR TITLE
Warning-check for `make import-sql`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,8 @@ import-borders: db-start
 
 .PHONY: import-sql
 import-sql: db-start all
-	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools import-sql
+	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools import-sql | \
+	  awk -v s=": WARNING:" '$$0~s{print; print "\n*** WARNING detected, aborting"; exit(1)} 1'
 
 .PHONY: generate-tiles
 ifneq ($(wildcard data/docker-compose-config.yml),)

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -222,8 +222,7 @@ echo "====> : Start SQL postprocessing:  ./build/sql/* -> PostgreSQL "
 echo "      : Source code: https://github.com/openmaptiles/openmaptiles-tools/blob/master/bin/import-sql"
 # If the output contains a WARNING, stop further processing
 # Adapted from https://unix.stackexchange.com/questions/307562
-make import-sql | \
-    awk -v s=": WARNING:" '$0~s{print; print "\n*** WARNING detected, aborting"; exit(1)} 1'
+make import-sql
 
 echo " "
 echo "-------------------------------------------------------------------------------------"


### PR DESCRIPTION
Always check `make import-sql` for warnings. Not only when invoked by `quickstart.sh`