### PR TITLE
Remove parallel safe on layer_building for now

### DIFF
--- a/layers/building/building.sql
+++ b/layers/building/building.sql
@@ -102,7 +102,6 @@ RETURNS TABLE(geometry geometry, osm_id bigint, render_height int, render_min_he
     ) AS zoom_levels
     ORDER BY render_height ASC, ST_YMin(geometry) DESC;
 $$
-LANGUAGE SQL IMMUTABLE
-PARALLEL SAFE;
+LANGUAGE SQL IMMUTABLE;
 
 -- not handled: where a building outline covers building parts


### PR DESCRIPTION
layer_building uses osm_all_buildings, which uses a
non-parallel-safe as_numeric.  Marking it as non-parallel safe
for now until we switch to CleanNumeric later.