### PR TITLE
Save DB schema during test run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,6 +196,7 @@ jobs:
             else
               DB_SIZE_MB=$(docker-compose run --rm -u $(id -u):$(id -g) openmaptiles-tools psql.sh -qtAc 'select pg_database_size(current_database())/1024/1024;')
             fi
+            docker-compose run --rm -u $(id -u):$(id -g) openmaptiles-tools pg_dump --schema-only > "${PROFILE_DIR}/schema.sql"
             echo "$DB_SIZE_MB" > "${PROFILE_DIR}/db_size.tsv"
           }
 


### PR DESCRIPTION
Places the output of `pg_dump --schema-only` into the saved build artifact as `schema.sql`

See content of the `performance_results.zip` file.

Closes #877