### PR TITLE
Print generated metadata during quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,10 @@ import-sql: all start-db-nowait
 	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools sh -c 'pgwait && import-sql' | \
 	  awk -v s=": WARNING:" '$$0~s{print; print "\n*** WARNING detected, aborting"; exit(1)} 1'
 
+.PHONY: show-metadata
+show-metadata: init-dirs
+	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools mbtiles-tools meta-all ./data/tiles.mbtiles
+
 .PHONY: generate-tiles
 ifneq ($(wildcard data/docker-compose-config.yml),)
   DC_CONFIG_TILES:=-f docker-compose.yml -f ./data/docker-compose-config.yml

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -309,6 +309,11 @@ make stop-db
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
+echo "====> : Show generated metadata"
+make show-metadata
+
+echo " "
+echo "-------------------------------------------------------------------------------------"
 echo "====> : Inputs - Outputs md5sum for debugging "
 rm -f ./data/quickstart_checklist.chk
 {


### PR DESCRIPTION
Add a new `show-metadata` target to show all settings
in the .mbtiles file.