### PR TITLE
Use tools v5.2

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # This file defines default environment variables for all images
 
 # Use 3-part patch version to ignore patch updates, e.g. 5.0.0
-TOOLS_VERSION=5.1
+TOOLS_VERSION=5.2
 
 # Make sure these values are in sync with the ones in .env-postgres file
 PGDATABASE=openmaptiles

--- a/Makefile
+++ b/Makefile
@@ -203,10 +203,6 @@ import-sql: all start-db-nowait
 	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools sh -c 'pgwait && import-sql' | \
 	  awk -v s=": WARNING:" '$$0~s{print; print "\n*** WARNING detected, aborting"; exit(1)} 1'
 
-.PHONY: show-metadata
-show-metadata: init-dirs
-	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools mbtiles-tools meta-all ./data/tiles.mbtiles
-
 .PHONY: generate-tiles
 ifneq ($(wildcard data/docker-compose-config.yml),)
   DC_CONFIG_TILES:=-f docker-compose.yml -f ./data/docker-compose-config.yml
@@ -216,7 +212,8 @@ generate-tiles: all start-db
 	echo "Generating tiles ..."; \
 	$(DOCKER_COMPOSE) $(DC_CONFIG_TILES) run $(DC_OPTS) generate-vectortiles
 	@echo "Updating generated tile metadata ..."
-	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools generate-metadata ./data/tiles.mbtiles
+	$(DOCKER_COMPOSE) $(DC_CONFIG_TILES) run $(DC_OPTS) openmaptiles-tools \
+			mbtiles-tools meta-generate ./data/tiles.mbtiles ./openmaptiles.yaml --auto-minmax --show-ranges
 
 .PHONY: start-tileserver
 start-tileserver: init-dirs

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -306,11 +306,6 @@ make stop-db
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
-echo "====> : Show generated metadata"
-make show-metadata
-
-echo " "
-echo "-------------------------------------------------------------------------------------"
 echo "====> : Inputs - Outputs md5sum for debugging "
 rm -f ./data/quickstart_checklist.chk
 {


### PR DESCRIPTION
* Use [tools v5.2](https://github.com/openmaptiles/openmaptiles-tools/releases/tag/v5.2.0)
* Use `mbtiles-tools meta-generate` instead of the removed `generate-metadata` script.
* Remove `show-metadata` make target - it was just added and is not needed.

## Relevant changes
* Upgrade [osml10n PG extension](https://github.com/giggls/mapnik-german-l10n) to the faster v2.5.9 (significant performance improvements merged upstream by @nyurik)