### PR TITLE
MVT: use gzip and generate for v3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,9 @@ build/mapping.yaml: init-dirs
 build-sql: init-dirs
 	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools bash -c \
 		'generate-sql openmaptiles.yaml --dir ./build/sql \
-		&& generate-sqltomvt openmaptiles.yaml --key --postgis-ver 2.4.8 --function --fname=getmvt >> "./build/sql/run_last.sql"'
+		&& generate-sqltomvt openmaptiles.yaml \
+							 --key --gzip --postgis-ver 3.0.1 \
+							 --function --fname=getmvt >> "./build/sql/run_last.sql"'
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This only changes the generated `getmvt(...)` function used by mvt users.

Beginning with tools 5.1, postgis docker images uses postgis v3.0, and includes gzip extension