### PR TITLE
aerodrome_label: Remove unused function parameter

### DIFF
--- a/layers/aerodrome_label/aerodrome_label.yaml
+++ b/layers/aerodrome_label/aerodrome_label.yaml
@@ -41,7 +41,7 @@ layer:
     key_field: osm_id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, iata, icao, ele, ele_ft FROM layer_aerodrome_label (!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, iata, icao, ele, ele_ft FROM layer_aerodrome_label(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./update_aerodrome_label_point.sql
   - ./layer.sql

--- a/layers/aerodrome_label/layer.sql
+++ b/layers/aerodrome_label/layer.sql
@@ -1,8 +1,8 @@
+
 -- etldoc: layer_aerodrome_label[shape=record fillcolor=lightpink, style="rounded,filled", label="layer_aerodrome_label | <z10_> z10+" ] ;
 
 CREATE OR REPLACE FUNCTION layer_aerodrome_label(bbox geometry,
-                                                 zoom_level integer,
-                                                 pixel_width numeric)
+                                                 zoom_level integer)
     RETURNS TABLE
             (
                 osm_id   bigint,


### PR DESCRIPTION
Minor optimization - in function `layer_aerodrome_label(bbox, zoom_level, pixel_width)` last parameter is not being used, so removing.