### PR TITLE
Expose MAX_PARALLEL_PSQL to users

### DIFF
--- a/.env
+++ b/.env
@@ -38,3 +38,6 @@ IMPOSM_CONFIG_FILE=/usr/src/app/config/repl_config.json
 BORDERS_CLEANUP_FILE=data/borders/cleanup.pbf
 BORDERS_PBF_FILE=data/borders/filtered.pbf
 BORDERS_CSV_FILE=data/borders/lines.csv
+
+# Number of parallel processes to use when importing sql files
+MAX_PARALLEL_PSQL=5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       BORDERS_CLEANUP_FILE: ${BORDERS_CLEANUP_FILE}
       BORDERS_PBF_FILE: ${BORDERS_PBF_FILE}
       BORDERS_CSV_FILE: ${BORDERS_CSV_FILE}
+      # Control import-sql processes
+      MAX_PARALLEL_PSQL: ${MAX_PARALLEL_PSQL}
     networks:
       - postgres_conn
     volumes:


### PR DESCRIPTION
Allow users to override how many import-sql files are loaded in parallel at the same time.

This change should be a noop