### PR TITLE
Do not wait for integrity test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,9 +43,6 @@ jobs:
   performance:
     name: Evaluate performance
     runs-on: self-hosted
-    # Even though we technically don't need to wait for integrity test to finish,
-    # there is no point to run long perf test until we know the code is OK
-    needs: integrity_test
     env:
       ## Smaller tests (runs everything in about 30 minutes)
       ## Two test areas:  equatorial-guinea  and  liechtenstein


### PR DESCRIPTION
It's ok if integrity test fails -- makes the whole testing process faster by 10 minutes at a cost of some extra CPU cycles.