### PR TITLE
Make more simple incremental update

### DIFF
--- a/layers/aerodrome_label/update_aerodrome_label_point.sql
+++ b/layers/aerodrome_label/update_aerodrome_label_point.sql
@@ -1,25 +1,44 @@
 DROP TRIGGER IF EXISTS trigger_flag ON osm_aerodrome_label_point;
+DROP TRIGGER IF EXISTS trigger_store ON osm_aerodrome_label_point;
 DROP TRIGGER IF EXISTS trigger_refresh ON aerodrome_label.updates;
 
+CREATE SCHEMA IF NOT EXISTS aerodrome_label;
+
+CREATE TABLE IF NOT EXISTS aerodrome_label.osm_ids
+(
+    osm_id bigint
+);
+
 -- etldoc: osm_aerodrome_label_point -> osm_aerodrome_label_point
-CREATE OR REPLACE FUNCTION update_aerodrome_label_point() RETURNS void AS
+CREATE OR REPLACE FUNCTION update_aerodrome_label_point(full_update boolean) RETURNS void AS
 $$
-BEGIN
     UPDATE osm_aerodrome_label_point
     SET geometry = ST_Centroid(geometry)
-    WHERE ST_GeometryType(geometry) <> 'ST_Point';
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM aerodrome_label.osm_ids))
+        AND ST_GeometryType(geometry) <> 'ST_Point';
 
     UPDATE osm_aerodrome_label_point
     SET tags = update_tags(tags, geometry)
-    WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
-END;
-$$ LANGUAGE plpgsql;
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM aerodrome_label.osm_ids))
+        AND COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL
+        AND tags = update_tags(tags, geometry);
+$$ LANGUAGE SQL;
 
-SELECT update_aerodrome_label_point();
+SELECT update_aerodrome_label_point(true);
 
 -- Handle updates
 
-CREATE SCHEMA IF NOT EXISTS aerodrome_label;
+CREATE OR REPLACE FUNCTION aerodrome_label.store() RETURNS trigger AS
+$$
+BEGIN
+    IF (tg_op = 'DELETE') THEN
+        INSERT INTO aerodrome_label.osm_ids VALUES (OLD.osm_id);
+    ELSE
+        INSERT INTO aerodrome_label.osm_ids VALUES (NEW.osm_id);
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
 
 CREATE TABLE IF NOT EXISTS aerodrome_label.updates
 (
@@ -39,12 +58,20 @@ CREATE OR REPLACE FUNCTION aerodrome_label.refresh() RETURNS trigger AS
 $$
 BEGIN
     RAISE LOG 'Refresh aerodrome_label';
-    PERFORM update_aerodrome_label_point();
+    PERFORM update_aerodrome_label_point(false);
+    -- noinspection SqlWithoutWhere
+    DELETE FROM aerodrome_label.osm_ids;
     -- noinspection SqlWithoutWhere
     DELETE FROM aerodrome_label.updates;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_store
+    AFTER INSERT OR UPDATE OR DELETE
+    ON osm_aerodrome_label_point
+    FOR EACH ROW
+EXECUTE PROCEDURE aerodrome_label.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE OR DELETE

--- a/layers/mountain_peak/update_peak_point.sql
+++ b/layers/mountain_peak/update_peak_point.sql
@@ -1,32 +1,82 @@
-DROP TRIGGER IF EXISTS trigger_update_point ON osm_peak_point;
-
--- etldoc:  osm_peak_point ->  osm_peak_point
-CREATE OR REPLACE FUNCTION update_osm_peak_point(new_osm_id bigint) RETURNS void AS
-$$
-UPDATE osm_peak_point
-SET tags = update_tags(tags, geometry)
-WHERE (new_osm_id IS NULL OR osm_id = new_osm_id)
-  AND COALESCE(tags -> 'name:latin', tags -> 'name:nonlatin', tags -> 'name_int') IS NULL
-  AND tags != update_tags(tags, geometry)
-$$ LANGUAGE SQL;
-
-SELECT update_osm_peak_point(NULL);
-
--- Handle updates
+DROP TRIGGER IF EXISTS trigger_flag ON osm_peak_point;
+DROP TRIGGER IF EXISTS trigger_store ON osm_peak_point;
+DROP TRIGGER IF EXISTS trigger_refresh ON mountain_peak_point.updates;
 
 CREATE SCHEMA IF NOT EXISTS mountain_peak_point;
 
-CREATE OR REPLACE FUNCTION mountain_peak_point.update() RETURNS trigger AS
+CREATE TABLE IF NOT EXISTS mountain_peak_point.osm_ids
+(
+    osm_id bigint
+);
+
+-- etldoc:  osm_peak_point ->  osm_peak_point
+CREATE OR REPLACE FUNCTION update_osm_peak_point(full_update boolean) RETURNS void AS
+$$
+    UPDATE osm_peak_point
+    SET tags = update_tags(tags, geometry)
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM mountain_peak_point.osm_ids))
+      AND COALESCE(tags -> 'name:latin', tags -> 'name:nonlatin', tags -> 'name_int') IS NULL
+      AND tags != update_tags(tags, geometry)
+$$ LANGUAGE SQL;
+
+SELECT update_osm_peak_point(true);
+
+-- Handle updates
+
+CREATE OR REPLACE FUNCTION mountain_peak_point.store() RETURNS trigger AS
 $$
 BEGIN
-    PERFORM update_osm_peak_point(new.osm_id);
+    IF (tg_op = 'DELETE') THEN
+        INSERT INTO mountain_peak_point.osm_ids VALUES (OLD.osm_id);
+    ELSE
+        INSERT INTO mountain_peak_point.osm_ids VALUES (NEW.osm_id);
+    END IF;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE CONSTRAINT TRIGGER trigger_update_point
-    AFTER INSERT OR UPDATE
+CREATE TABLE IF NOT EXISTS mountain_peak_point.updates
+(
+    id serial PRIMARY KEY,
+    t  text,
+    UNIQUE (t)
+);
+CREATE OR REPLACE FUNCTION mountain_peak_point.flag() RETURNS trigger AS
+$$
+BEGIN
+    INSERT INTO mountain_peak_point.updates(t) VALUES ('y') ON CONFLICT(t) DO NOTHING;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION mountain_peak_point.refresh() RETURNS trigger AS
+$$
+BEGIN
+    RAISE LOG 'Refresh mountain_peak_point';
+    PERFORM update_osm_peak_point(false);
+    -- noinspection SqlWithoutWhere
+    DELETE FROM mountain_peak_point.osm_ids;
+    -- noinspection SqlWithoutWhere
+    DELETE FROM mountain_peak_point.updates;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_store
+    AFTER INSERT OR UPDATE OR DELETE
     ON osm_peak_point
+    FOR EACH ROW
+EXECUTE PROCEDURE mountain_peak_point.store();
+
+CREATE TRIGGER trigger_flag
+    AFTER INSERT OR UPDATE OR DELETE
+    ON osm_peak_point
+    FOR EACH STATEMENT
+EXECUTE PROCEDURE mountain_peak_point.flag();
+
+CREATE CONSTRAINT TRIGGER trigger_refresh
+    AFTER INSERT
+    ON mountain_peak_point.updates
     INITIALLY DEFERRED
     FOR EACH ROW
-EXECUTE PROCEDURE mountain_peak_point.update();
+EXECUTE PROCEDURE mountain_peak_point.refresh();

--- a/layers/place/update_continent_point.sql
+++ b/layers/place/update_continent_point.sql
@@ -1,22 +1,39 @@
 DROP TRIGGER IF EXISTS trigger_flag ON osm_continent_point;
+DROP TRIGGER IF EXISTS trigger_store ON osm_continent_point;
 DROP TRIGGER IF EXISTS trigger_refresh ON place_continent_point.updates;
 
+CREATE SCHEMA IF NOT EXISTS place_continent_point;
+
+CREATE TABLE IF NOT EXISTS place_continent_point.osm_ids
+(
+    osm_id bigint
+);
+
 -- etldoc:  osm_continent_point ->  osm_continent_point
-CREATE OR REPLACE FUNCTION update_osm_continent_point() RETURNS void AS
+CREATE OR REPLACE FUNCTION update_osm_continent_point(full_update boolean) RETURNS void AS
 $$
-BEGIN
     UPDATE osm_continent_point
     SET tags = update_tags(tags, geometry)
-    WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM place_continent_point.osm_ids))
+      AND COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL
+      AND tags != update_tags(tags, geometry);
+$$ LANGUAGE SQL;
 
-END;
-$$ LANGUAGE plpgsql;
-
-SELECT update_osm_continent_point();
+SELECT update_osm_continent_point(true);
 
 -- Handle updates
 
-CREATE SCHEMA IF NOT EXISTS place_continent_point;
+CREATE OR REPLACE FUNCTION place_continent_point.store() RETURNS trigger AS
+$$
+BEGIN
+    IF (tg_op = 'DELETE') THEN
+        INSERT INTO place_continent_point.osm_ids VALUES (OLD.osm_id);
+    ELSE
+        INSERT INTO place_continent_point.osm_ids VALUES (NEW.osm_id);
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
 
 CREATE TABLE IF NOT EXISTS place_continent_point.updates
 (
@@ -36,12 +53,20 @@ CREATE OR REPLACE FUNCTION place_continent_point.refresh() RETURNS trigger AS
 $$
 BEGIN
     RAISE LOG 'Refresh place_continent_point';
-    PERFORM update_osm_continent_point();
+    PERFORM update_osm_continent_point(false);
+    -- noinspection SqlWithoutWhere
+    DELETE FROM place_continent_point.osm_ids;
     -- noinspection SqlWithoutWhere
     DELETE FROM place_continent_point.updates;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_store
+    AFTER INSERT OR UPDATE OR DELETE
+    ON osm_continent_point
+    FOR EACH ROW
+EXECUTE PROCEDURE place_continent_point.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE OR DELETE

--- a/layers/place/update_country_point.sql
+++ b/layers/place/update_country_point.sql
@@ -1,9 +1,6 @@
 DROP TRIGGER IF EXISTS trigger_flag ON osm_country_point;
 DROP TRIGGER IF EXISTS trigger_refresh ON place_country.updates;
 
-ALTER TABLE osm_country_point
-    DROP CONSTRAINT IF EXISTS osm_country_point_rank_constraint;
-
 -- etldoc: ne_10m_admin_0_countries   -> osm_country_point
 -- etldoc: osm_country_point          -> osm_country_point
 
@@ -86,7 +83,6 @@ $$ LANGUAGE plpgsql;
 
 SELECT update_osm_country_point();
 
--- ALTER TABLE osm_country_point ADD CONSTRAINT osm_country_point_rank_constraint CHECK("rank" BETWEEN 1 AND 6);
 CREATE INDEX IF NOT EXISTS osm_country_point_rank_idx ON osm_country_point ("rank");
 
 -- Handle updates

--- a/layers/place/update_state_point.sql
+++ b/layers/place/update_state_point.sql
@@ -1,9 +1,6 @@
 DROP TRIGGER IF EXISTS trigger_flag ON osm_state_point;
 DROP TRIGGER IF EXISTS trigger_refresh ON place_state.updates;
 
-ALTER TABLE osm_state_point
-    DROP CONSTRAINT IF EXISTS osm_state_point_rank_constraint;
-
 -- etldoc: ne_10m_admin_1_states_provinces   -> osm_state_point
 -- etldoc: osm_state_point                       -> osm_state_point
 
@@ -51,7 +48,6 @@ $$ LANGUAGE plpgsql;
 
 SELECT update_osm_state_point();
 
--- ALTER TABLE osm_state_point ADD CONSTRAINT osm_state_point_rank_constraint CHECK("rank" BETWEEN 1 AND 6);
 CREATE INDEX IF NOT EXISTS osm_state_point_rank_idx ON osm_state_point ("rank");
 
 -- Handle updates

--- a/layers/place/update_state_point.sql
+++ b/layers/place/update_state_point.sql
@@ -1,13 +1,19 @@
 DROP TRIGGER IF EXISTS trigger_flag ON osm_state_point;
+DROP TRIGGER IF EXISTS trigger_store ON osm_state_point;
 DROP TRIGGER IF EXISTS trigger_refresh ON place_state.updates;
+
+CREATE SCHEMA IF NOT EXISTS place_state;
+
+CREATE TABLE IF NOT EXISTS place_state.osm_ids
+(
+    osm_id bigint
+);
 
 -- etldoc: ne_10m_admin_1_states_provinces   -> osm_state_point
 -- etldoc: osm_state_point                       -> osm_state_point
 
-CREATE OR REPLACE FUNCTION update_osm_state_point() RETURNS void AS
+CREATE OR REPLACE FUNCTION update_osm_state_point(full_update boolean) RETURNS void AS
 $$
-BEGIN
-
     WITH important_state_point AS (
         SELECT osm.geometry,
                osm.osm_id,
@@ -30,29 +36,45 @@ BEGIN
         -- Normalize both scalerank and labelrank into a ranking system from 1 to 6.
     SET "rank" = LEAST(6, CEILING((scalerank + labelrank + datarank) / 3.0))
     FROM important_state_point AS ne
-    WHERE osm.osm_id = ne.osm_id;
+    WHERE (full_update OR osm.osm_id IN (SELECT osm_id FROM place_state.osm_ids))
+      AND rank IS NULL
+      AND osm.osm_id = ne.osm_id;
 
     -- TODO: This shouldn't be necessary? The rank function makes something wrong...
     UPDATE osm_state_point AS osm
     SET "rank" = 1
-    WHERE "rank" = 0;
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM place_state.osm_ids))
+      AND "rank" = 0;
 
-    DELETE FROM osm_state_point WHERE "rank" IS NULL;
+    DELETE FROM osm_state_point
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM place_state.osm_ids))
+      AND "rank" IS NULL;
 
     UPDATE osm_state_point
     SET tags = update_tags(tags, geometry)
-    WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM place_state.osm_ids))
+      AND COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL
+      AND tags != update_tags(tags, geometry);
 
-END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE SQL;
 
-SELECT update_osm_state_point();
+SELECT update_osm_state_point(true);
 
 CREATE INDEX IF NOT EXISTS osm_state_point_rank_idx ON osm_state_point ("rank");
 
 -- Handle updates
 
-CREATE SCHEMA IF NOT EXISTS place_state;
+CREATE OR REPLACE FUNCTION place_state.store() RETURNS trigger AS
+$$
+BEGIN
+    IF (tg_op = 'DELETE') THEN
+        INSERT INTO place_state.osm_ids VALUES (OLD.osm_id);
+    ELSE
+        INSERT INTO place_state.osm_ids VALUES (NEW.osm_id);
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
 
 CREATE TABLE IF NOT EXISTS place_state.updates
 (
@@ -72,12 +94,20 @@ CREATE OR REPLACE FUNCTION place_state.refresh() RETURNS trigger AS
 $$
 BEGIN
     RAISE LOG 'Refresh place_state rank';
-    PERFORM update_osm_state_point();
+    PERFORM update_osm_state_point(false);
+    -- noinspection SqlWithoutWhere
+    DELETE FROM place_state.osm_ids;
     -- noinspection SqlWithoutWhere
     DELETE FROM place_state.updates;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_store
+    AFTER INSERT OR UPDATE OR DELETE
+    ON osm_state_point
+    FOR EACH ROW
+EXECUTE PROCEDURE place_state.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE OR DELETE

--- a/layers/poi/update_poi_polygon.sql
+++ b/layers/poi/update_poi_polygon.sql
@@ -1,11 +1,18 @@
 DROP TRIGGER IF EXISTS trigger_flag ON osm_poi_polygon;
+DROP TRIGGER IF EXISTS trigger_store ON osm_poi_polygon;
 DROP TRIGGER IF EXISTS trigger_refresh ON poi_polygon.updates;
+
+CREATE SCHEMA IF NOT EXISTS poi_polygon;
+
+CREATE TABLE IF NOT EXISTS poi_polygon.osm_ids
+(
+    osm_id bigint
+);
 
 -- etldoc:  osm_poi_polygon ->  osm_poi_polygon
 
-CREATE OR REPLACE FUNCTION update_poi_polygon() RETURNS void AS
+CREATE OR REPLACE FUNCTION update_poi_polygon(full_update boolean) RETURNS void AS
 $$
-BEGIN
     UPDATE osm_poi_polygon
     SET geometry =
             CASE
@@ -13,31 +20,44 @@ BEGIN
                     THEN ST_Centroid(geometry)
                 ELSE ST_PointOnSurface(geometry)
                 END
-    WHERE ST_GeometryType(geometry) <> 'ST_Point';
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM poi_polygon.osm_ids))
+      AND ST_GeometryType(geometry) <> 'ST_Point';
 
     UPDATE osm_poi_polygon
     SET subclass = 'subway'
-    WHERE station = 'subway'
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM poi_polygon.osm_ids))
+      AND station = 'subway'
       AND subclass = 'station';
 
     UPDATE osm_poi_polygon
     SET subclass = 'halt'
-    WHERE funicular = 'yes'
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM poi_polygon.osm_ids))
+      AND funicular = 'yes'
       AND subclass = 'station';
 
     UPDATE osm_poi_polygon
     SET tags = update_tags(tags, geometry)
-    WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
+    WHERE (full_update OR osm_id IN (SELECT osm_id FROM poi_polygon.osm_ids))
+      AND COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL
+      AND tags != update_tags(tags, geometry);
 
-    ANALYZE osm_poi_polygon;
-END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE SQL;
 
-SELECT update_poi_polygon();
+SELECT update_poi_polygon(true);
 
 -- Handle updates
 
-CREATE SCHEMA IF NOT EXISTS poi_polygon;
+CREATE OR REPLACE FUNCTION poi_polygon.store() RETURNS trigger AS
+$$
+BEGIN
+    IF (tg_op = 'DELETE') THEN
+        INSERT INTO poi_polygon.osm_ids VALUES (OLD.osm_id);
+    ELSE
+        INSERT INTO poi_polygon.osm_ids VALUES (NEW.osm_id);
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
 
 CREATE TABLE IF NOT EXISTS poi_polygon.updates
 (
@@ -57,12 +77,20 @@ CREATE OR REPLACE FUNCTION poi_polygon.refresh() RETURNS trigger AS
 $$
 BEGIN
     RAISE LOG 'Refresh poi_polygon';
-    PERFORM update_poi_polygon();
+    PERFORM update_poi_polygon(false);
+    -- noinspection SqlWithoutWhere
+    DELETE FROM poi_polygon.osm_ids;
     -- noinspection SqlWithoutWhere
     DELETE FROM poi_polygon.updates;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_store
+    AFTER INSERT OR UPDATE OR DELETE
+    ON osm_poi_polygon
+    FOR EACH ROW
+EXECUTE PROCEDURE poi_polygon.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE OR DELETE


### PR DESCRIPTION
Replacing update on the whole table with an update only on changed rows.

The goal is to update more quickly by just updating the changing content.
The update now focus on osm_id of changed rows, it use index. Add a where clause tags != update_tags(tags, geometry) en ensure only update when changed.

It requires one more trigger and a table to store changed osm_id.

The UPDATE is keep in a function to be reusable for initial setup and trigger update.

I try many code layout before done it in this way with the goal to keep the code for initial pass and for update. It should have low impact on initial data load. Better performance for row update can be achieve with BEFORE UPDATE, but require to duplicate the logic.

It is not based on the already merged https://github.com/openmaptiles/openmaptiles/pull/896 because calling and update within a function for each updated row was not efficient for larger table (like housenumber).

It addresses #814.