### PR TITLE
More fail safe incremental update on water_lakeline and water_point

### DIFF
--- a/layers/water_name/update_water_lakeline.sql
+++ b/layers/water_name/update_water_lakeline.sql
@@ -66,7 +66,10 @@ BEGIN
     INSERT INTO osm_water_lakeline
     SELECT *
     FROM osm_water_lakeline_view
-    WHERE osm_water_lakeline_view.osm_id = NEW.osm_id;
+    WHERE osm_water_lakeline_view.osm_id = NEW.osm_id
+    -- May happen in case we replay update
+    ON CONFLICT ON CONSTRAINT osm_water_point_pk
+    DO NOTHING;
 
     RETURN NULL;
 END;

--- a/layers/water_name/update_water_point.sql
+++ b/layers/water_name/update_water_point.sql
@@ -66,7 +66,10 @@ BEGIN
     INSERT INTO osm_water_point
     SELECT *
     FROM osm_water_point_view
-    WHERE osm_water_point_view.osm_id = NEW.osm_id;
+    WHERE osm_water_point_view.osm_id = NEW.osm_id
+    -- May happen in case we replay update
+    ON CONFLICT ON CONSTRAINT osm_water_point_pk
+    DO NOTHING;
 
     RETURN NULL;
 END;


### PR DESCRIPTION
Improve 97216c5c191bf0df3705134cff234ed980f8ac78 and #853

In case of replay update it may fails because of already existing primary key on osm_id.

Add a on conflict clause to make it fail safe.