### PR TITLE
Sanitize name and name_en from trailing a backslash

### DIFF
--- a/layers/place/update_city_point.sql
+++ b/layers/place/update_city_point.sql
@@ -20,16 +20,16 @@ BEGIN
              osm_city_point AS osm
         WHERE (
                 (osm.tags ? 'wikidata' AND osm.tags->'wikidata' = ne.wikidataid) OR
-                ne.name ILIKE osm.name OR
-                ne.name ILIKE osm.name_en OR
-                ne.namealt ILIKE osm.name OR
-                ne.namealt ILIKE osm.name_en OR
-                ne.meganame ILIKE osm.name OR
-                ne.meganame ILIKE osm.name_en OR
-                ne.gn_ascii ILIKE osm.name OR
-                ne.gn_ascii ILIKE osm.name_en OR
-                ne.nameascii ILIKE osm.name OR
-                ne.nameascii ILIKE osm.name_en OR
+                ne.name ILIKE replace(osm.name, '\', '\\') OR
+                ne.name ILIKE replace(osm.name_en, '\', '\\') OR
+                ne.namealt ILIKE replace(osm.name, '\', '\\') OR
+                ne.namealt ILIKE replace(osm.name_en, '\', '\\') OR
+                ne.meganame ILIKE replace(osm.name, '\', '\\') OR
+                ne.meganame ILIKE replace(osm.name_en, '\', '\\') OR
+                ne.gn_ascii ILIKE replace(osm.name, '\', '\\') OR
+                ne.gn_ascii ILIKE replace(osm.name_en, '\', '\\') OR
+                ne.nameascii ILIKE replace(osm.name, '\', '\\') OR
+                ne.nameascii ILIKE replace(osm.name_en, '\', '\\') OR
                 ne.name = unaccent(osm.name)
             )
           AND osm.place IN ('city', 'town', 'village')

--- a/layers/place/update_city_point.sql
+++ b/layers/place/update_city_point.sql
@@ -20,16 +20,16 @@ BEGIN
              osm_city_point AS osm
         WHERE (
                 (osm.tags ? 'wikidata' AND osm.tags->'wikidata' = ne.wikidataid) OR
-                ne.name ILIKE replace(osm.name, '\', '\\') OR
-                ne.name ILIKE replace(osm.name_en, '\', '\\') OR
-                ne.namealt ILIKE replace(osm.name, '\', '\\') OR
-                ne.namealt ILIKE replace(osm.name_en, '\', '\\') OR
-                ne.meganame ILIKE replace(osm.name, '\', '\\') OR
-                ne.meganame ILIKE replace(osm.name_en, '\', '\\') OR
-                ne.gn_ascii ILIKE replace(osm.name, '\', '\\') OR
-                ne.gn_ascii ILIKE replace(osm.name_en, '\', '\\') OR
-                ne.nameascii ILIKE replace(osm.name, '\', '\\') OR
-                ne.nameascii ILIKE replace(osm.name_en, '\', '\\') OR
+                ne.name ILIKE TRIM(TRAILING '\' FROM osm.name) OR
+                ne.name ILIKE TRIM(TRAILING '\' FROM osm.name_en) OR
+                ne.namealt ILIKE TRIM(TRAILING '\' FROM osm.name) OR
+                ne.namealt ILIKE TRIM(TRAILING '\' FROM osm.name_en)OR
+                ne.meganame ILIKE TRIM(TRAILING '\' FROM osm.name) OR
+                ne.meganame ILIKE TRIM(TRAILING '\' FROM osm.name_en) OR
+                ne.gn_ascii ILIKE TRIM(TRAILING '\' FROM osm.name) OR
+                ne.gn_ascii ILIKE TRIM(TRAILING '\' FROM osm.name_en) OR
+                ne.nameascii ILIKE TRIM(TRAILING '\' FROM osm.name) OR
+                ne.nameascii ILIKE TRIM(TRAILING '\' FROM osm.name_en) OR
                 ne.name = unaccent(osm.name)
             )
           AND osm.place IN ('city', 'town', 'village')


### PR DESCRIPTION
This PR sanitizes name and name_en from trailing a backslash.

While importing sql for the whole planet, make failed with following error:

```
Time: 2.565 ms
psql:/sql/parallel/place.sql:757: ERROR:  LIKE pattern must not end with escape character
CONTEXT:  SQL function "update_osm_city_point" statement 1
Time: 5254.250 ms (00:05.254)
Makefile:358: recipe for target 'import-sql' failed
make: *** [import-sql] Error 123
```

Searched in db and there were 3 entries with a trailing backslash:

![image](https://user-images.githubusercontent.com/3989428/89410256-adec6780-d723-11ea-882f-9074bf22f9f7.png)

