### PR TITLE
Do insensitive case compare using lower() and not ILIKE

### DIFF
--- a/layers/place/update_city_point.sql
+++ b/layers/place/update_city_point.sql
@@ -20,16 +20,16 @@ BEGIN
              osm_city_point AS osm
         WHERE (
                 (osm.tags ? 'wikidata' AND osm.tags->'wikidata' = ne.wikidataid) OR
-                ne.name ILIKE osm.name OR
-                ne.name ILIKE osm.name_en OR
-                ne.namealt ILIKE osm.name OR
-                ne.namealt ILIKE osm.name_en OR
-                ne.meganame ILIKE osm.name OR
-                ne.meganame ILIKE osm.name_en OR
-                ne.gn_ascii ILIKE osm.name OR
-                ne.gn_ascii ILIKE osm.name_en OR
-                ne.nameascii ILIKE osm.name OR
-                ne.nameascii ILIKE osm.name_en OR
+                lower(ne.name) = lower(osm.name) OR
+                lower(ne.name) = lower(osm.name_en) OR
+                lower(ne.namealt) = lower(osm.name) OR
+                lower(ne.namealt) = lower(osm.name_en) OR
+                lower(ne.meganame) = lower(osm.name) OR
+                lower(ne.meganame) = lower(osm.name_en) OR
+                lower(ne.gn_ascii) = lower(osm.name) OR
+                lower(ne.gn_ascii) = lower(osm.name_en) OR
+                lower(ne.nameascii) = lower(osm.name) OR
+                lower(ne.nameascii) = lower(osm.name_en) OR
                 ne.name = unaccent(osm.name)
             )
           AND osm.place IN ('city', 'town', 'village')

--- a/layers/place/update_city_point.sql
+++ b/layers/place/update_city_point.sql
@@ -20,16 +20,8 @@ BEGIN
              osm_city_point AS osm
         WHERE (
                 (osm.tags ? 'wikidata' AND osm.tags->'wikidata' = ne.wikidataid) OR
-                lower(ne.name) = lower(osm.name) OR
-                lower(ne.name) = lower(osm.name_en) OR
-                lower(ne.namealt) = lower(osm.name) OR
-                lower(ne.namealt) = lower(osm.name_en) OR
-                lower(ne.meganame) = lower(osm.name) OR
-                lower(ne.meganame) = lower(osm.name_en) OR
-                lower(ne.gn_ascii) = lower(osm.name) OR
-                lower(ne.gn_ascii) = lower(osm.name_en) OR
-                lower(ne.nameascii) = lower(osm.name) OR
-                lower(ne.nameascii) = lower(osm.name_en) OR
+                lower(osm.name) IN (lower(ne.name), lower(ne.namealt), lower(ne.meganame), lower(ne.gn_ascii), lower(ne.nameascii)) OR
+                lower(osm.name_en) IN (lower(ne.name), lower(ne.namealt), lower(ne.meganame), lower(ne.gn_ascii), lower(ne.nameascii)) OR
                 ne.name = unaccent(osm.name)
             )
           AND osm.place IN ('city', 'town', 'village')

--- a/layers/water_name/update_marine_point.sql
+++ b/layers/water_name/update_marine_point.sql
@@ -16,10 +16,10 @@ BEGIN
         SELECT osm.geometry, osm.osm_id, osm.name, osm.name_en, ne.scalerank, osm.is_intermittent
         FROM ne_10m_geography_marine_polys AS ne,
              osm_marine_point AS osm
-        WHERE trim(regexp_replace(ne.name, '\\s+', ' ', 'g')) ILIKE osm.name
-           OR trim(regexp_replace(ne.name, '\\s+', ' ', 'g')) ILIKE osm.tags->'name:en'
-           OR trim(regexp_replace(ne.name, '\\s+', ' ', 'g')) ILIKE osm.tags->'name:es'
-           OR osm.name ILIKE trim(regexp_replace(ne.name, '\\s+', ' ', 'g')) || ' %'
+        WHERE lower(trim(regexp_replace(ne.name, '\\s+', ' ', 'g'))) = lower(osm.name)
+           OR lower(trim(regexp_replace(ne.name, '\\s+', ' ', 'g'))) = lower(osm.tags->'name:en')
+           OR lower(trim(regexp_replace(ne.name, '\\s+', ' ', 'g'))) = lower(osm.tags->'name:es')
+           OR substring(lower(trim(regexp_replace(ne.name, '\\s+', ' ', 'g'))) FROM 1 FOR length(lower(osm.name))) = lower(osm.name)
     )
     UPDATE osm_marine_point AS osm
     SET "rank" = scalerank

--- a/layers/water_name/update_marine_point.sql
+++ b/layers/water_name/update_marine_point.sql
@@ -16,9 +16,7 @@ BEGIN
         SELECT osm.geometry, osm.osm_id, osm.name, osm.name_en, ne.scalerank, osm.is_intermittent
         FROM ne_10m_geography_marine_polys AS ne,
              osm_marine_point AS osm
-        WHERE lower(trim(regexp_replace(ne.name, '\\s+', ' ', 'g'))) = lower(osm.name)
-           OR lower(trim(regexp_replace(ne.name, '\\s+', ' ', 'g'))) = lower(osm.tags->'name:en')
-           OR lower(trim(regexp_replace(ne.name, '\\s+', ' ', 'g'))) = lower(osm.tags->'name:es')
+        WHERE lower(trim(regexp_replace(ne.name, '\\s+', ' ', 'g'))) IN (lower(osm.name), lower(osm.tags->'name:en'), lower(osm.tags->'name:es'))
            OR substring(lower(trim(regexp_replace(ne.name, '\\s+', ' ', 'g'))) FROM 1 FOR length(lower(osm.name))) = lower(osm.name)
     )
     UPDATE osm_marine_point AS osm


### PR DESCRIPTION
Some name compare are done with ILIKE, it is not done for this usage and can be wrong on special character and raise error on invalid escape char. See https://github.com/makina-maps/makina-maps/issues/23

Replace `ILIKE` by comparing on `lower() = lower()`, then do refactoring using `IN`.
