### PR TITLE
Add state labels at low zoom levels

### DIFF
--- a/layers/place/layer.sql
+++ b/layers/place/layer.sql
@@ -77,11 +77,6 @@ FROM (
          FROM osm_state_point
          WHERE geometry && bbox
            AND name <> ''
-           AND ("rank" + 2 <= zoom_level)
-           AND (
-                 zoom_level >= 5 OR
-                 is_in_country IN ('United Kingdom', 'USA', 'Россия', 'Brasil', 'China', 'India') OR
-                 is_in_country_code IN ('AU', 'CN', 'IN', 'BR', 'US'))
 
          UNION ALL
 

--- a/layers/place/layer.sql
+++ b/layers/place/layer.sql
@@ -77,6 +77,7 @@ FROM (
          FROM osm_state_point
          WHERE geometry && bbox
            AND name <> ''
+           AND zoom_level > 1
 
          UNION ALL
 


### PR DESCRIPTION
Fixes #953

## Motivation

If we check Bright, Positron, or Dark styles, they all show a huge lack of data about states and regions. At zoom 2, for big countries like Canada, Brazil, China or Australia there are big patches of white space (aka cartographer's *horror vacui* 😅)

![Untitled](https://user-images.githubusercontent.com/188264/91316810-8f750b80-e7b9-11ea-9fc5-049c191c9d20.png)


At zoom 3 state labels start appearing, along with relevant cities. It's arguable if cities provide more geospatial context to readers than state names (I would prefer states over cities, though), but that would be a discussion for the styles repositories. My concern is that the current pipeline, at low zoom levels (2 to 5) gives too few labels. Compare US versus Oceania:

|   ![Untitled 1](https://user-images.githubusercontent.com/188264/91316836-969c1980-e7b9-11ea-90f7-8dd9831fc619.png)	|   ![Untitled 2](https://user-images.githubusercontent.com/188264/91316848-99970a00-e7b9-11ea-83d0-0b14bc5bcf35.png)	|
|---	|---	|

### Data pipeline

A [quick check](https://sophox.org/#SELECT%20%2a%20WHERE%20%7B%0A%20%20%3FosmId%20osmm%3Atype%20%27n%27%3B%0A%20%20%20%20%20%20%20%20%20osmt%3Aplace%20%27state%27%3B%0A%20%20%20%20%20%20%20%20%20osmt%3Aname%20%3Fname.%0A%7D) to OSM data returns there are around **1700** nodes with `place=state`. That's the main condition to generate the `osm_state_point` table in the `place` layer.

There's later an [update](https://github.com/openmaptiles/openmaptiles/blob/master/layers/place/update_state_point.sql#L10-L50) on that table that augments the dataset with ranking information coming from the [Natural Earth regions dataset](https://www.naturalearthdata.com/downloads/10m-cultural-vectors/10m-admin-1-states-provinces/), removing all points that are not considered important. This currently leaves around **200 labels** in this table.

BTW, there are around **5000 regions** in the world, and they change every year. In fact, Natural Earth dataset is quite outdated. At Elastic, we've been improving it fo our own users, fixing around a hundred countries' data. You can learn about the work we did on [these slides](https://drive.google.com/file/d/1Lncv7Tk80NfG-vrjnfeDBKlXRVWBrBSX/view) from a presentation @nickpeihl did recently.

### Tile processing

With the data stored in `osm_state_point`, the SQL layer function controls which data is delivered to final users per zoom level. This `WHERE` condition leaves for zoom 3 only state labels ranked as `1`. For example, Australia states are ranked as 3 so they need to *wait* to **zoom level 5**.

![Untitled 3](https://user-images.githubusercontent.com/188264/91316877-a1ef4500-e7b9-11ea-9d37-af62333aa119.png)

## Proposal

The current proposal is to remove the rank filtering of the data on the table and leave to styles to decide if they want to render state labels from zoom 2. I feel we would also want to increase the quality of the ranking data to provide even more data, but I leave that outside of the scope of this change.

The change in the final planet `mbtiles` file size for this change in the layer function is minimal as discussed at #953, but will also need accompanying changes in styles that render data from this table to adjust the amount of information they want to show at low zoom levels. I'm opening a PR also to the `OSM Bright` style to adapt it to this change.

Some screenshots of the default situation with a raw style

|  ![Untitled 4](https://user-images.githubusercontent.com/188264/91316905-aae01680-e7b9-11ea-892b-e5849b29c903.png) 	|  ![Untitled 5](https://user-images.githubusercontent.com/188264/91316914-addb0700-e7b9-11ea-8bdd-7ea715607089.png) 	| ![Untitled 6](https://user-images.githubusercontent.com/188264/91316924-b16e8e00-e7b9-11ea-93d0-df43ac4a4ef8.png)  	|
|---	|---	|---	|


After applying the proposal, at zoom level 2 will show the **~200 label** points.

![Untitled 7](https://user-images.githubusercontent.com/188264/91316936-b59aab80-e7b9-11ea-9407-2d83ac7bc746.png)

I understand the spread of labels is quite odd, and maybe we can work more on this PR to help including more labels. Maybe we can include again the country filter, to just get labels for the big countries of the world were states are large enough to need representation, in comparison for example with European countries where equivalent hierarchy boundaries are way smaller. Maybe that criteria can be something parametrizable using Natural Earth augmented data like area or population.

Please let me know what you think.
