### PR TITLE
Expose COPY_CONCURRENCY to users

### DIFF
--- a/.env
+++ b/.env
@@ -44,3 +44,6 @@ BORDERS_CSV_FILE=data/borders/lines.csv
 
 # Number of parallel processes to use when importing sql files
 MAX_PARALLEL_PSQL=5
+
+# Number of parallel threads to use when generating vector map tiles
+COPY_CONCURRENCY=10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,8 @@ services:
     environment:
       FILTER_MAPNIK_OUTPUT: ${FILTER_MAPNIK_OUTPUT}
       MBTILES_NAME: ${MBTILES_FILE}
+      # Control tilelive-copy threads
+      COPY_CONCURRENCY: ${COPY_CONCURRENCY}
 
   generate-vectortiles:
     image: "openmaptiles/generate-vectortiles:${TOOLS_VERSION}"
@@ -80,6 +82,9 @@ services:
       BBOX: ${BBOX}
       MIN_ZOOM: ${MIN_ZOOM}
       MAX_ZOOM: ${MAX_ZOOM}
+      # Control tilelive-copy threads
+      COPY_CONCURRENCY: ${COPY_CONCURRENCY}
+      #
 
   postserve:
     image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"


### PR DESCRIPTION
Allow users to override how the number of threads used when generating map vector tiles.