### PR TITLE
Clean output of `list-views` and `list-table`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,12 +466,12 @@ reset-db-stats: init-dirs
 .PHONY: list-views
 list-views: init-dirs
 	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools psql.sh -v ON_ERROR_STOP=1 -A -F"," -P pager=off -P footer=off \
-		-c "select schemaname, viewname from pg_views where schemaname='public' order by viewname;"
+		-c "select viewname from pg_views where schemaname='public' order by viewname;"
 
 .PHONY: list-tables
 list-tables: init-dirs
 	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools psql.sh -v ON_ERROR_STOP=1 -A -F"," -P pager=off -P footer=off \
-		-c "select schemaname, tablename from pg_tables where schemaname='public' order by tablename;"
+		-c "select tablename from pg_tables where schemaname='public' order by tablename;"
 
 .PHONY: psql-list-tables
 psql-list-tables: init-dirs


### PR DESCRIPTION
Avoid printing a fixed `public,` prefix in the output of `make list-views` and `make list-table`.
As `make help` says, `list-views` and `list-table` list only the public schema views and tables.

New output:

```
viewname
boundary_z0
boundary_z1
boundary_z10
boundary_z11
boundary_z12
boundary_z13
boundary_z3
boundary_z4
boundary_z5
boundary_z6
boundary_z7
boundary_z8
boundary_z9
geography_columns
geometry_columns
...
```

Existing output:

```
schemaname,viewname
public,boundary_z0
public,boundary_z1
public,boundary_z10
public,boundary_z11
public,boundary_z12
public,boundary_z13
public,boundary_z3
public,boundary_z4
public,boundary_z5
public,boundary_z6
public,boundary_z7
public,boundary_z8
public,boundary_z9
public,geography_columns
public,geometry_columns
...
```