### PR TITLE
Stitch `transportation_name` by all language tags

### DIFF
--- a/layers/transportation_name/layer.sql
+++ b/layers/transportation_name/layer.sql
@@ -23,11 +23,11 @@ AS
 $$
 SELECT osm_id,
        geometry,
-       NULLIF(name, '') AS name,
-       COALESCE(NULLIF(name_en, ''), name) AS name_en,
-       COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
+       name,
+       COALESCE(name_en, name) AS name_en,
+       COALESCE(name_de, name, name_en) AS name_de,
        tags,
-       NULLIF(ref, ''),
+       ref,
        NULLIF(LENGTH(ref), 0) AS ref_length,
        --TODO: The road network of the road is not yet implemented
        CASE
@@ -101,7 +101,7 @@ FROM (
                 indoor
          FROM osm_transportation_name_linestring
          WHERE zoom_level = 12
-           AND LineLabel(zoom_level, COALESCE(NULLIF(name, ''), ref), geometry)
+           AND LineLabel(zoom_level, COALESCE(name, ref), geometry)
            AND highway_class(highway, '', construction) NOT IN ('minor', 'track', 'path')
            AND NOT highway_is_link(highway)
          UNION ALL
@@ -123,7 +123,7 @@ FROM (
                 indoor
          FROM osm_transportation_name_linestring
          WHERE zoom_level = 13
-           AND LineLabel(zoom_level, COALESCE(NULLIF(name, ''), ref), geometry)
+           AND LineLabel(zoom_level, COALESCE(name, ref), geometry)
            AND highway_class(highway, '', construction) NOT IN ('track', 'path')
          UNION ALL
 

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -9,15 +9,15 @@
 CREATE TABLE IF NOT EXISTS osm_transportation_name_network AS
 SELECT hl.geometry,
        hl.osm_id,
-       CASE WHEN length(hl.name) > 15 THEN osml10n_street_abbrev_all(hl.name) ELSE hl.name END AS "name",
-       CASE WHEN length(hl.name_en) > 15 THEN osml10n_street_abbrev_en(hl.name_en) ELSE hl.name_en END AS "name_en",
-       CASE WHEN length(hl.name_de) > 15 THEN osml10n_street_abbrev_de(hl.name_de) ELSE hl.name_de END AS "name_de",
+       CASE WHEN length(hl.name) > 15 THEN osml10n_street_abbrev_all(hl.name) ELSE NULLIF(hl.name, '') END AS "name",
+       CASE WHEN length(hl.name_en) > 15 THEN osml10n_street_abbrev_en(hl.name_en) ELSE NULLIF(hl.name_en, '') END AS "name_en",
+       CASE WHEN length(hl.name_de) > 15 THEN osml10n_street_abbrev_de(hl.name_de) ELSE NULLIF(hl.name_de, '') END AS "name_de",
        slice_language_tags(hl.tags) AS tags,
        rm.network_type,
        CASE
-           WHEN rm.network_type IS NOT NULL AND nullif(rm.ref::text, '') IS NOT NULL
+           WHEN rm.network_type IS NOT NULL AND NULLIF(rm.ref::text, '') IS NOT NULL
                THEN rm.ref::text
-           ELSE hl.ref
+           ELSE NULLIF(hl.ref, '')
            END AS ref,
        hl.highway,
        hl.construction,
@@ -236,15 +236,15 @@ BEGIN
     INSERT INTO osm_transportation_name_network
     SELECT hl.geometry,
            hl.osm_id,
-           CASE WHEN length(hl.name) > 15 THEN osml10n_street_abbrev_all(hl.name) ELSE hl.name END AS "name",
-           CASE WHEN length(hl.name_en) > 15 THEN osml10n_street_abbrev_en(hl.name_en) ELSE hl.name_en END AS "name_en",
-           CASE WHEN length(hl.name_de) > 15 THEN osml10n_street_abbrev_de(hl.name_de) ELSE hl.name_de END AS "name_de",
+           CASE WHEN length(hl.name) > 15 THEN osml10n_street_abbrev_all(hl.name) ELSE NULLIF(hl.name, '') END AS "name",
+           CASE WHEN length(hl.name_en) > 15 THEN osml10n_street_abbrev_en(hl.name_en) ELSE NULLIF(hl.name_en, '') END AS "name_en",
+           CASE WHEN length(hl.name_de) > 15 THEN osml10n_street_abbrev_de(hl.name_de) ELSE NULLIF(hl.name_de, '') END AS "name_de",
            slice_language_tags(hl.tags) AS tags,
            rm.network_type,
            CASE
-               WHEN rm.network_type IS NOT NULL AND nullif(rm.ref::text, '') IS NOT NULL
+               WHEN rm.network_type IS NOT NULL AND NULLIF(rm.ref::text, '') IS NOT NULL
                    THEN rm.ref::text
-               ELSE hl.ref
+               ELSE NULLIF(hl.ref, '')
                END AS ref,
            hl.highway,
            hl.construction,

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -60,7 +60,7 @@ FROM (
                 name_en,
                 name_de,
                 tags || hstore( -- store results of osml10n_street_abbrev_* above
-                               ARRAY ['name', name, 'name:en', name_en, 'name:de', name_de]) AS "tags",
+                               ARRAY ['name', name, 'name:en', name_en, 'name:de', name_de]) AS tags,
                 ref,
                 highway,
                 construction,

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -239,7 +239,7 @@ BEGIN
            CASE WHEN length(hl.name) > 15 THEN osml10n_street_abbrev_all(hl.name) ELSE hl.name END AS "name",
            CASE WHEN length(hl.name_en) > 15 THEN osml10n_street_abbrev_en(hl.name_en) ELSE hl.name_en END AS "name_en",
            CASE WHEN length(hl.name_de) > 15 THEN osml10n_street_abbrev_de(hl.name_de) ELSE hl.name_de END AS "name_de",
-           hl.tags,
+           slice_language_tags(hl.tags) AS tags,
            rm.network_type,
            CASE
                WHEN rm.network_type IS NOT NULL AND nullif(rm.ref::text, '') IS NOT NULL


### PR DESCRIPTION
When OSM roads in the `transportation_name` layer are stitched together, their grouping does not consider all `name:*` tags.
As a result, roads with different `name:*` tags may be stitched together.

The `waterway` layer performs the grouping properly, for the same purpose:
https://github.com/openmaptiles/openmaptiles/blob/1685eaccbd0ab9f8e4b32bcd4f4a20fd502a5d13/layers/waterway/update_important_waterway.sql#L34