### PR TITLE
Move where condition from osm_transportation_name_linestring to materialized view osm_transportation_name_network

### DIFF
--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -46,10 +46,10 @@ FROM (
     FROM osm_highway_linestring hl
             LEFT JOIN osm_route_member rm ON
         rm.member = hl.osm_id
+    WHERE (hl.name <> '' OR hl.ref <> '')
+      AND NULLIF(hl.highway, '') IS NOT NULL
 ) AS t
-WHERE ("rank" = 1 OR "rank" IS NULL)
-  AND (name <> '' OR ref <> '')
-  AND NULLIF(highway, '') IS NOT NULL;
+WHERE ("rank" = 1 OR "rank" IS NULL);
 CREATE INDEX IF NOT EXISTS osm_transportation_name_network_osm_id_idx ON osm_transportation_name_network (osm_id);
 CREATE INDEX IF NOT EXISTS osm_transportation_name_network_geometry_idx ON osm_transportation_name_network USING gist (geometry);
 


### PR DESCRIPTION
Reduce the size of the materialized view osm_transportation_name_network by moving the weare clause.

osm_transportation_name_network is only used for osm_transportation_name_linestring.