### PR TITLE
Remove large unused index osm_highway_linestring_highway_idx

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -16,10 +16,6 @@ DROP TRIGGER IF EXISTS trigger_refresh ON transportation.updates;
 
 
 -- Improve performance of the sql in transportation_name/network_type.sql
-CREATE INDEX IF NOT EXISTS osm_highway_linestring_highway_idx
-    ON osm_highway_linestring (highway);
-
--- Improve performance of the sql below
 CREATE INDEX IF NOT EXISTS osm_highway_linestring_highway_partial_idx
     ON osm_highway_linestring (highway)
     WHERE highway IN ('motorway', 'trunk', 'primary', 'construction');


### PR DESCRIPTION
The index `osm_highway_linestring_highway_idx` is not used. There is also a used partial index `osm_highway_linestring_highway_partial_idx`.

I cross check the usage of the index from postgres query stats and all SQL query code where the table `osm_highway_linestring` is refered.

This index is relatively big.