### PR TITLE
Add protocol to postserve --serve paramter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
 
   postserve:
     image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"
-    command: "postserve ${TILESET_FILE} --verbose --serve=${OMT_HOST:-localhost}:${PPORT:-8090}"
+    command: "postserve ${TILESET_FILE} --verbose --serve=${OMT_HOST:-http://localhost}:${PPORT:-8090}"
     env_file: .env
     environment:
       TILESET_FILE: ${TILESET_FILE}


### PR DESCRIPTION
The current option of postserve in the docker-compose produce an invalid tilejson.
```json
"tiles": ["localhost:8090/tiles/{z}/{x}/{y}.pbf"]
```
`tiles` should be URL. The protocol is missing.

Not sure about the best way to fix this. Just adding `http://` to the docker-compose.yaml does not allow https usage. But setting protocol in `OMT_HOST` seems weird.

Could add an extra OMT_PROTOCOL with `http` as default.
