### PR TITLE
buildings: prevent slivers of self-intersecting geometry

### DIFF
--- a/layers/building/update_building.sql
+++ b/layers/building/update_building.sql
@@ -27,7 +27,7 @@ BEGIN
             FROM osm_building_polygon o
         )
         SELECT (array_agg(dta.osm_id))[1]                                                                   osm_id,
-               ST_Buffer(ST_MemUnion(ST_Buffer(dta.geometry, zres14, 'join=mitre')), -zres14, 'join=mitre') geometry
+               ST_Buffer(ST_MemUnion(ST_Buffer(dta.geometry, -zres14, 'join=mitre')), zres14, 'join=mitre') geometry
         FROM dta
         GROUP BY cid
 


### PR DESCRIPTION
To address issue #1022 , where current New Zealand region with invalid data which aborts the import-sql loop.

It seems adding ST_IsValid condition to would pass and does not pass through New Zealand, however
flipping negative and positive radius for ST_Buffer helps to remove self-intersection.
It was suggested online at https://gis.stackexchange.com/questions/281935/topology-exception-on-geometry-intersection

Hopefully that should not have performance impact as it is not adding to the query.
Visually checking, regions buildings looks the same in output tiles, with benefit of New Zealand passing.

💡 At first I've tried adding ST_IsValid conditions at   https://github.com/openmaptiles/openmaptiles/blob/master/layers/building/update_building.sql#L27 
OR https://github.com/openmaptiles/openmaptiles/blob/master/layers/building/update_building.sql#L31
though it still aborted.

Issue log: (when doing `quickstart.sh new-zealand` , `make import-sql` step) 
<details>
CREATE FUNCTION
Time: 0.991 ms
psql:/sql/parallel/building.sql:82: ERROR:  lwgeom_union: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection at or near point 19566767.608174294 -4873356.7422359968 at 19566767.608174294 -4873356.7422359968
CONTEXT:  PL/pgSQL function osm_building_block_gen1() line 6 at FOR over SELECT rows
Time: 150915.098 ms (02:30.915)
</details>
