### PR TITLE
Bugfix update_aerodrome_label_point()

### DIFF
--- a/layers/aerodrome_label/update_aerodrome_label_point.sql
+++ b/layers/aerodrome_label/update_aerodrome_label_point.sql
@@ -21,7 +21,7 @@ $$
     SET tags = update_tags(tags, geometry)
     WHERE (full_update OR osm_id IN (SELECT osm_id FROM aerodrome_label.osm_ids))
         AND COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL
-        AND tags = update_tags(tags, geometry);
+        AND tags != update_tags(tags, geometry);
 $$ LANGUAGE SQL;
 
 SELECT update_aerodrome_label_point(true);


### PR DESCRIPTION
Bug introduced in #944.
Missing exclamation mark in not equal operator caused that tags were not updated thus there were missing `name_int`, `name:latin` and `name:nonlatin`.