### PR TITLE
Add forgotten `garages` landuse class value to the docs

### DIFF
--- a/layers/landuse/landuse.yaml
+++ b/layers/landuse/landuse.yaml
@@ -22,6 +22,7 @@ layer:
       - residential
       - commercial
       - industrial
+      - garages
       - retail
       - bus_station
       - school


### PR DESCRIPTION
In https://github.com/openmaptiles/openmaptiles/pull/720 I've forgotten to add the `garages` class to the docs. This PR is fixing that issue,