### PR TITLE
typo and spelling fixes in the output of quickstart.sh

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -83,7 +83,7 @@ function version { echo "$@" | tr -cs '0-9.' '.' | awk -F. '{ printf("%03d%03d%0
 
 COMPOSE_VER=$(docker-compose version --short)
 if [ "$(version "$COMPOSE_VER")" -lt "$(version "$MIN_COMPOSE_VER")" ]; then
-  echo "ERR: Your Docker-compose version is Known to have bugs , Please Update docker-compose!"
+  echo "ERR: Your Docker-compose version is known to have bugs, please update docker-compose!"
   exit 1
 fi
 
@@ -109,8 +109,8 @@ echo "--------------------------------------------------------------------------
 echo "====> : OpenMapTiles quickstart! [ https://github.com/openmaptiles/openmaptiles ]    "
 echo "      : This will be logged to the $log_file file (for debugging) and to the screen"
 echo "      : Area             : $area "
-echo "      : Download Server  : ${osm_server:-unset (automatic)} "
-echo "      : Preloaded Image  : $USE_PRELOADED_IMAGE "
+echo "      : Download server  : ${osm_server:-unset (automatic)} "
+echo "      : Preloaded image  : $USE_PRELOADED_IMAGE "
 echo "      : Git version      : $(git rev-parse HEAD) "
 echo "      : Started          : $STARTDATE "
 echo "      : Your bash version: $BASH_VERSION"
@@ -132,9 +132,9 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     fi
     echo "      : --- Memory, CPU info ---- "
     mem=$( grep MemTotal /proc/meminfo | awk '{print $2}' | xargs -I {} echo "scale=4; {}/1024^2" | bc )
-    echo "system memory (GB): ${mem}"
+    echo "System memory (GB): ${mem}"
     grep SwapTotal /proc/meminfo
-    echo "cpu number: $(grep -c processor /proc/cpuinfo) x $(grep "bogomips" /proc/cpuinfo | head -1)"
+    echo "CPU number: $(grep -c processor /proc/cpuinfo) x $(grep "bogomips" /proc/cpuinfo | head -1)"
     grep Free /proc/meminfo
 else
     echo " "
@@ -200,7 +200,7 @@ if [[ "$USE_PRELOADED_IMAGE" == true ]]; then
   echo "      :   make import-data"
   echo "      :"
   echo "      : Source code: https://github.com/openmaptiles/openmaptiles-tools/tree/master/docker/postgis-preloaded"
-  echo "      : Thank you: https://www.postgresql.org !  Thank you http://postgis.org !"
+  echo "      : Thank you https://www.postgresql.org !  Thank you http://postgis.org !"
   make start-db-preloaded
 else
   echo "====> : Start PostgreSQL service using empty database and importing all the data:"
@@ -213,7 +213,7 @@ else
   echo "      : Source code: https://github.com/openmaptiles/openmaptiles-tools/tree/master/docker/import-data"
   echo "      :   includes all data from the import-data image"
   echo "      :"
-  echo "      : Thank you: https://www.postgresql.org !  Thank you http://postgis.org !"
+  echo "      : Thank you https://www.postgresql.org !  Thank you http://postgis.org !"
   make start-db
   make import-data
 fi
@@ -233,7 +233,7 @@ echo "--------------------------------------------------------------------------
 echo "====> : Start importing border ${area} data into PostgreSQL using osmborder"
 echo "      : Source code: https://github.com/pnorman/osmborder"
 echo "      : Data license: http://www.openstreetmap.org/copyright"
-echo "      : Thank you: Paul Norman"
+echo "      : Thank you Paul Norman"
 make import-borders
 
 echo " "
@@ -328,10 +328,10 @@ ls -la ./data
 echo " "
 echo "-------------------------------------------------------------------------------------"
 echo "The ./quickstart.sh $area  is finished! "
-echo "It takes $((ENDTIME - STARTTIME)) seconds to complete"
-echo "We saved the log file to $log_file  ( for debugging ) You can compare with the travis log !"
+echo "It took $((ENDTIME - STARTTIME)) seconds to complete"
+echo "We saved the log file to $log_file  (for debugging) You can compare with the travis log !"
 echo " "
-echo "Start experimenting! And check the QUICKSTART.MD file!"
+echo "Start experimenting and check the QUICKSTART.MD file!"
 echo " "
 echo "*  Use   make start-maputnik     to explore tile generation on request"
 echo "*  Use   make start-tileserver   to view pre-generated tiles"


### PR DESCRIPTION
This simply fixes some spelling and/or grammar errors in the quickstart script output