### PR TITLE
`make generate-tiles-pg` without editing `.env`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ generate-tiles-pg: all start-db
 	@$(assert_area_is_given)
 	@echo "Generating tiles into $(MBTILES_LOCAL_FILE) (will delete if already exists)..."
 	@rm -rf "$(MBTILES_LOCAL_FILE)"
-	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools generate-tiles
+	$(DOCKER_COMPOSE) run $(DC_OPTS) -e EXPORT_DIR=/import openmaptiles-tools generate-tiles
 	@echo "Updating generated tile metadata ..."
 	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools \
 			mbtiles-tools meta-generate "$(MBTILES_LOCAL_FILE)" $(TILESET_FILE) --auto-minmax --show-ranges


### PR DESCRIPTION
Currently, `make generate-tiles-pg` always produces an error

```
[Error: SQLITE_CANTOPEN: unable to open database file] {
  errno: 14,
  code: 'SQLITE_CANTOPEN'
}
make: *** [generate-tiles-pg] Error 1
```

In [this Slack thread](https://osmus.slack.com/archives/CH6GFAFRC/p1609608482047400), @TomPohys wrote:
> Hi, did you uncomment line 55 in `.env` ? I got this error when I forgot to uncomment `EXPORT_DIR`.

In addition to not being obvious, such editing of the `.env` file breaks the ability to run `quicktime.sh`.

This PR allows using `make generate-tiles-pg` without editing `.env` while keeping `quickstart.sh` available for most users.

Resolves #1070 