### PR TITLE
Mount /export dir in docker-compose.yaml

### DIFF
--- a/.env
+++ b/.env
@@ -51,7 +51,5 @@ COPY_CONCURRENCY=10
 
 # Variables for generate tiles using PGquery
 PGHOSTS_LIST=
-# Uncomment when used PGquery
-#EXPORT_DIR=/import
 NO_GZIP=1
 USE_KEY_COLUMN=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
     volumes:
       - .:/tileset
       - ./data:/import
+      - ./data:/export
       - ./build/sql:/sql
       - ./build:/mapping
       - ./cache:/cache


### PR DESCRIPTION
Mount /export dir in docker-compose.yaml
This PR allows `using make generate-tiles-pg` without editing `.env`.
Resolves #1070
Related to PR #1069