### PR TITLE
Avoid grep errors in `clean-unnecessary-docker`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,7 +559,7 @@ clean-unnecessary-docker:
 	@echo "Deleting unnecessary container(s)..."
 	@docker ps -a -q --filter "status=exited" | $(XARGS) docker rm
 	@echo "Deleting unnecessary image(s)..."
-	@docker images | grep \<none\> | awk -F" " '{print $$3}' | $(XARGS) docker rmi
+	@docker images | awk -F" " '/<none>/{print $$3}' | $(XARGS) docker rmi
 
 .PHONY: test-perf-null
 test-perf-null: init-dirs


### PR DESCRIPTION
When `make clean-unnecessary-docker` is run twice, or when there are no docker images tagges as "\<none\>", make fails because grep fails:

```
Deleting unnecessary container(s)...
Deleting unnecessary image(s)...
make: *** [Makefile:562: clean-unnecessary-docker] Error 1
```

Using `awk` to _also_ search for "\<none\>", instead of `grep`, solves this issue.