### PR TITLE
Update osm_poi_point only on change

### DIFF
--- a/layers/poi/update_poi_point.sql
+++ b/layers/poi/update_poi_point.sql
@@ -17,7 +17,8 @@ BEGIN
 
     UPDATE osm_poi_point
     SET tags = update_tags(tags, geometry)
-    WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
+    WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL
+      AND tags != update_tags(tags, geometry);
 
 END;
 $$ LANGUAGE plpgsql;
@@ -28,20 +29,33 @@ CREATE OR REPLACE FUNCTION update_osm_poi_point_agg() RETURNS void AS
 $$
 BEGIN
     UPDATE osm_poi_point p
-    SET agg_stop = CASE
-                       WHEN p.subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
-                           THEN 1
+    SET
+        agg_stop = CASE
+            WHEN p.subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
+                THEN 1
+        END
+    WHERE
+        agg_stop != CASE
+            WHEN p.subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
+                THEN 1
         END;
 
     UPDATE osm_poi_point p
-    SET agg_stop = (
+    SET
+        agg_stop = (
         CASE
             WHEN p.subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
                      AND r.rk IS NULL OR r.rk = 1
                 THEN 1
-            END)
+        END)
     FROM osm_poi_stop_rank r
-    WHERE p.osm_id = r.osm_id;
+    WHERE p.osm_id = r.osm_id AND
+        agg_stop != (
+        CASE
+            WHEN p.subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
+                     AND r.rk IS NULL OR r.rk = 1
+                THEN 1
+        END);
 
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
After each diff import the table `osm_poi_point` is fully rewritten due to a full update of the field tags. It is now good to do an a update, event if the content does not change, postgres delete and reinsert internally the record. Resulting in more write and internal table size raising.

Note: not directly linked, but there is a problem in this case, the autocaccum is not sufficient to keep this table size moderate, but grow indefinitely.
