### PR TITLE
Remove empty subclass tags from tiles

### DIFF
--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -37,7 +37,7 @@ FROM (
             ELSE NULLIF(hl.ref, '')
             END AS ref,
         hl.highway,
-        hl.construction AS subclass,
+        NULLIF(hl.construction, '') AS subclass,
         brunnel(hl.is_bridge, hl.is_tunnel, hl.is_ford) AS brunnel,
         CASE WHEN highway IN ('footway', 'steps') THEN layer END AS layer,
         CASE WHEN highway IN ('footway', 'steps') THEN level END AS level,
@@ -303,7 +303,7 @@ BEGIN
                 ELSE NULLIF(hl.ref, '')
                 END AS ref,
             hl.highway,
-            hl.subclass,
+            NULLIF(hl.subclass, '') AS subclass,
             brunnel(hl.is_bridge, hl.is_tunnel, hl.is_ford) AS brunnel,
             CASE WHEN highway IN ('footway', 'steps') THEN layer END AS layer,
             CASE WHEN highway IN ('footway', 'steps') THEN level END AS level,


### PR DESCRIPTION
PR #1119 (adding support for `highway=motorway_junction`) missed a few cases where NULLIF functions were needed in order to suppress empty-string `subclass` tags from appearing in vector tiles, resulting in unnecessary  `subclass` entries on `transportation_name` objects where it was not needed, for example:
![image](https://user-images.githubusercontent.com/3254090/123889414-7a11c600-d923-11eb-938c-f278b9bf1ffa.png)

This PR adds the missing NULLIF function so that those empty tags are suppressed:
![image](https://user-images.githubusercontent.com/3254090/123889540-b6452680-d923-11eb-8f0b-5c8c03640059.png)
