### PR TITLE
Compute separate concurrency_index on osm_route_member

### DIFF
--- a/layers/transportation_name/update_route_member.sql
+++ b/layers/transportation_name/update_route_member.sql
@@ -91,3 +91,12 @@ CREATE INDEX IF NOT EXISTS osm_route_member_name_idx ON osm_route_member ("name"
 CREATE INDEX IF NOT EXISTS osm_route_member_ref_idx ON osm_route_member ("ref");
 
 CREATE INDEX IF NOT EXISTS osm_route_member_network_type_idx ON osm_route_member ("network_type");
+
+ALTER TABLE osm_route_member ADD COLUMN IF NOT EXISTS concurrency_index int;
+
+INSERT INTO osm_route_member (id, concurrency_index)
+  SELECT
+    id,
+    ROW_NUMBER() over (PARTITION BY member ORDER BY network_type, network, LENGTH(ref), ref) AS concurrency_index
+  FROM osm_route_member
+  ON CONFLICT (id) DO UPDATE SET concurrency_index = EXCLUDED.concurrency_index;


### PR DESCRIPTION
Closes #1134 

Adds a `concurrency_index` column to `osm_route_member` as described in #1134.  For example, listing concurrencies on a [segment of the Washington Bridge](https://www.openstreetmap.org/way/43080535) in Providence, Rhode Island, USA:

```
openmaptiles=# select osm_id, network, ref, network_type, name, concurrency_index from osm_route_member where member=43080535 order by concurrency_index asc;
  osm_id  | network | ref | network_type  |     name      | concurrency_index
----------+---------+-----+---------------+---------------+-------------------
 -1694950 | US:I    | 195 | us-interstate | I 195 (RI/MA) |                 1
 -2308410 | US:US   | 6   | us-highway    | US 6 (RI)     |                 2
 -1347856 | US:US   | 1A  | us-highway    | US 1A (RI)    |                 3
 -2309143 | US:US   | 44  | us-highway    | US 44 (RI)    |                 4
(4 rows)
```
