### PR TITLE
include route relation ref in existence check

### DIFF
--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -45,7 +45,7 @@ FROM (
         hl.z_order
     FROM osm_highway_linestring hl
             LEFT OUTER JOIN osm_route_member rm ON rm.member = hl.osm_id AND rm.concurrency_index=1
-    WHERE (hl.name <> '' OR hl.ref <> '')
+    WHERE (hl.name <> '' OR hl.ref <> '' OR rm.ref <> '')
       AND NULLIF(hl.highway, '') IS NOT NULL
 ) AS t;
 CREATE INDEX IF NOT EXISTS osm_transportation_name_network_osm_id_idx ON osm_transportation_name_network (osm_id);


### PR DESCRIPTION
Fixes #1138
Unblocks #1131
Unblocks #1128 

Below is an example of a way that is part of a route relation (in this case, RI-3), but does not have a ref set on the way itself:
![image](https://user-images.githubusercontent.com/3254090/124366616-1509e900-dc1f-11eb-87ab-aadd4f21287d.png)

This screenshot demonstrates that the `transportation_name` object now contains the ref from the route relation:
![image](https://user-images.githubusercontent.com/3254090/124366563-b5abd900-dc1e-11eb-9fd9-96315ddf7682.png)
