### PR TITLE
Update brunnel aggregation to avoid splitting highways

### DIFF
--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -80,14 +80,17 @@ FROM (
                 ref,
                 highway,
                 subclass,
-                brunnel,
+                CASE WHEN COUNT(*) = COUNT(brunnel) AND MAX(brunnel) = MIN(brunnel)
+                     THEN MAX(brunnel)
+                     ELSE NULL::text END AS brunnel,
                 "level",
                 layer,
                 indoor,
                 network_type,
                 min(z_order) AS z_order
          FROM osm_transportation_name_network
-         GROUP BY name, name_en, name_de, tags, ref, highway, subclass, brunnel, "level", layer, indoor, network_type
+         WHERE name <> '' OR ref <> ''
+         GROUP BY name, name_en, name_de, tags, ref, highway, subclass, "level", layer, indoor, network_type
      ) AS highway_union
 ;
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_name_ref_idx ON osm_transportation_name_linestring (coalesce(name, ''), coalesce(ref, ''));


### PR DESCRIPTION
Fixes #1131

This change does the following:
1. Excludes roads from `transportation_name` that don't have a `name` or a `ref`
2. Updates the road name merging logic to exclude changes in `brunnel` status.  This will ensure that minor bridges don't disrupt the continuity of named roads as the map zooms out.
3. The `brunnel` tag will now only be set when a bridge or tunnel is distinctly named.  Distinctly named is defined as "has a different name from the road on either side".

This example shows an unnamed interstate highway rendered as a continuous feature at low zoom.  This road has many small bridges along its length:

![image](https://user-images.githubusercontent.com/3254090/124370289-b30faa80-dc43-11eb-80d6-034c18ce99ad.png)


This example shows a named bridge rendered with `brunnel` tag set:

![image](https://user-images.githubusercontent.com/3254090/124370298-d0dd0f80-dc43-11eb-8a78-183420a6bd62.png)
