### PR TITLE
Simplify Trans-Canada Highway logic

### DIFF
--- a/layers/transportation_name/update_route_member.sql
+++ b/layers/transportation_name/update_route_member.sql
@@ -29,22 +29,7 @@ SELECT CASE
            WHEN network = 'US:US' THEN 'us-highway'::route_network_type
            WHEN network LIKE 'US:__' THEN 'us-state'::route_network_type
            -- https://en.wikipedia.org/wiki/Trans-Canada_Highway
-           -- TODO: improve hierarchical queries using
-           --    http://www.openstreetmap.org/relation/1307243
-           --    however the relation does not cover the whole Trans-Canada_Highway
-           WHEN
-                   (network = 'CA:transcanada') OR
-                   (network = 'CA:BC:primary' AND ref IN ('16')) OR
-                   (name = 'Yellowhead Highway (AB)' AND ref IN ('16')) OR
-                   (network = 'CA:SK:primary' AND ref IN ('16')) OR
-                   (network = 'CA:ON:primary' AND ref IN ('17', '417')) OR
-                   (name = 'Route Transcanadienne') OR
-                   (network = 'CA:NB:primary' AND ref IN ('2', '16')) OR
-                   (network = 'CA:PE' AND ref IN ('1')) OR
-                   (network = 'CA:NS' AND ref IN ('104', '105')) OR
-                   (network = 'CA:NL:R' AND ref IN ('1')) OR
-                   (name = 'Trans-Canada Highway')
-               THEN 'ca-transcanada'::route_network_type
+           WHEN network LIKE 'CA:transcanada%' THEN 'ca-transcanada'::route_network_type
            WHEN network = 'omt-gb-motorway' THEN 'gb-motorway'::route_network_type
            WHEN network = 'omt-gb-trunk' THEN 'gb-trunk'::route_network_type
            END;


### PR DESCRIPTION
Fixes #1142

Screenshot from Alberta showing TCH still shown in `transportation_name` layer:
![image](https://user-images.githubusercontent.com/3254090/124532399-77f5ae80-ddde-11eb-8929-36970ebb8386.png)

Screenshot from Ontario showing TCH still shown in `transportation_name` layer:
![image](https://user-images.githubusercontent.com/3254090/124532512-b68b6900-ddde-11eb-9b6a-636c872375c1.png)
