### PR TITLE
fix: prevent crash when re running import-sql

### DIFF
--- a/layers/building/update_building.sql
+++ b/layers/building/update_building.sql
@@ -95,7 +95,7 @@ CREATE MATERIALIZED VIEW osm_building_block_gen1_dup AS
 SELECT *
 FROM osm_building_block_gen1();
 
-CREATE INDEX ON osm_building_block_gen1_dup USING gist (geometry);
+CREATE INDEX IF NOT EXISTS ON osm_building_block_gen1_dup USING gist (geometry);
 
 -- etldoc: osm_building_polygon -> osm_building_block_gen_z13
 DROP MATERIALIZED VIEW IF EXISTS osm_building_block_gen_z13;


### PR DESCRIPTION
Without that change any subsequent call to `make import-sql` would fail because the index already exists.