### PR TITLE
Remove unused osm_id column

### DIFF
--- a/layers/transportation_name/transportation_name.sql
+++ b/layers/transportation_name/transportation_name.sql
@@ -4,7 +4,6 @@
 CREATE OR REPLACE FUNCTION layer_transportation_name(bbox geometry, zoom_level integer)
     RETURNS TABLE
             (
-                osm_id     bigint,
                 geometry   geometry,
                 name       text,
                 name_en    text,
@@ -22,8 +21,7 @@ CREATE OR REPLACE FUNCTION layer_transportation_name(bbox geometry, zoom_level i
             )
 AS
 $$
-SELECT osm_id,
-       geometry,
+SELECT geometry,
        name,
        COALESCE(name_en, name) AS name_en,
        COALESCE(name_de, name, name_en) AS name_de,
@@ -89,7 +87,6 @@ FROM (
 
          -- etldoc: osm_transportation_name_linestring ->  layer_transportation_name:z12
          SELECT geometry,
-                osm_id,
                 name,
                 name_en,
                 name_de,
@@ -112,7 +109,6 @@ FROM (
 
          -- etldoc: osm_transportation_name_linestring ->  layer_transportation_name:z13
          SELECT geometry,
-                osm_id,
                 name,
                 name_en,
                 name_de,
@@ -134,7 +130,6 @@ FROM (
 
          -- etldoc: osm_transportation_name_linestring ->  layer_transportation_name:z14_
          SELECT geometry,
-                osm_id,
                 name,
                 name_en,
                 name_de,
@@ -155,7 +150,6 @@ FROM (
          -- etldoc: osm_highway_point ->  layer_transportation_name:z10
          SELECT
 		p.geometry,
-                p.osm_id,
                 p.name,
                 p.name_en,
                 p.name_de,

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -56,7 +56,6 @@ CREATE INDEX IF NOT EXISTS osm_transportation_name_network_geometry_idx ON osm_t
 -- etldoc: osm_transportation_name_network ->  osm_transportation_name_linestring
 CREATE TABLE IF NOT EXISTS osm_transportation_name_linestring AS
 SELECT (ST_Dump(geometry)).geom AS geometry,
-       NULL::bigint AS osm_id,
        name,
        name_en,
        name_de,
@@ -100,7 +99,6 @@ CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_highway_partial_id
 -- etldoc: osm_transportation_name_linestring -> osm_transportation_name_linestring_gen1
 CREATE OR REPLACE VIEW osm_transportation_name_linestring_gen1_view AS
 SELECT ST_Simplify(geometry, 50) AS geometry,
-       osm_id,
        name,
        name_en,
        name_de,
@@ -128,7 +126,6 @@ CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen1_highway_parti
 -- etldoc: osm_transportation_name_linestring_gen1 -> osm_transportation_name_linestring_gen2
 CREATE OR REPLACE VIEW osm_transportation_name_linestring_gen2_view AS
 SELECT ST_Simplify(geometry, 120) AS geometry,
-       osm_id,
        name,
        name_en,
        name_de,
@@ -156,7 +153,6 @@ CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen2_highway_parti
 -- etldoc: osm_transportation_name_linestring_gen2 -> osm_transportation_name_linestring_gen3
 CREATE OR REPLACE VIEW osm_transportation_name_linestring_gen3_view AS
 SELECT ST_Simplify(geometry, 200) AS geometry,
-       osm_id,
        name,
        name_en,
        name_de,
@@ -184,7 +180,6 @@ CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen3_highway_parti
 -- etldoc: osm_transportation_name_linestring_gen3 -> osm_transportation_name_linestring_gen4
 CREATE OR REPLACE VIEW osm_transportation_name_linestring_gen4_view AS
 SELECT ST_Simplify(geometry, 500) AS geometry,
-       osm_id,
        name,
        name_en,
        name_de,


### PR DESCRIPTION
Fixes #1146

This PR removes the always-null osm_id column from the `transportation_name_linestring` table and the series of generalized tables that derive from it.

Demonstration of `transportation_name` objects behaving normally after the column has been removed:

![image](https://user-images.githubusercontent.com/3254090/124684944-4512ef80-de9e-11eb-998c-b66bc23be09e.png)
