### PR TITLE
Fix SQL failures in transportation_name update code

### DIFF
--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -297,7 +297,7 @@ BEGIN
                 ELSE NULLIF(hl.ref, '')
                 END AS ref,
             hl.highway,
-            NULLIF(hl.subclass, '') AS subclass,
+            NULLIF(hl.construction, '') AS subclass,
             brunnel(hl.is_bridge, hl.is_tunnel, hl.is_ford) AS brunnel,
             CASE WHEN highway IN ('footway', 'steps') THEN layer END AS layer,
             CASE WHEN highway IN ('footway', 'steps') THEN level END AS level,
@@ -459,7 +459,6 @@ BEGIN
 
     INSERT INTO osm_transportation_name_linestring
     SELECT (ST_Dump(geometry)).geom AS geometry,
-           NULL::bigint AS osm_id,
            name,
            name_en,
            name_de,


### PR DESCRIPTION
This PR fixed bugs introduced in #1147 and #1119 which broke the update triggers in `transportation_name_update`.  I noticed this issue while I was working a different PR and tried to update a table in the `transportation` layer.

**Test**

The following code currently fails because of cascading update failures, but will complete successfully after this PR is merged.
```
UPDATE osm_highway_linestring hl
    SET network = rm.network_type
    FROM osm_route_member rm
    WHERE hl.osm_id=rm.member;
```