### PR TITLE
Remove unused network type params

### DIFF
--- a/layers/transportation_name/update_route_member.sql
+++ b/layers/transportation_name/update_route_member.sql
@@ -22,7 +22,7 @@ INSERT INTO osm_route_member (osm_id, member, ref, network)
 SELECT *
 FROM gbr_route_members_view;
 
-CREATE OR REPLACE FUNCTION osm_route_member_network_type(network text, name text, ref text) RETURNS route_network_type AS
+CREATE OR REPLACE FUNCTION osm_route_member_network_type(network text) RETURNS route_network_type AS
 $$
 SELECT CASE
            WHEN network = 'US:I' THEN 'us-interstate'::route_network_type
@@ -39,9 +39,9 @@ $$ LANGUAGE sql IMMUTABLE
 -- etldoc:  osm_route_member ->  osm_route_member
 -- see http://wiki.openstreetmap.org/wiki/Relation:route#Road_routes
 UPDATE osm_route_member
-SET network_type = osm_route_member_network_type(network, name, ref)
+SET network_type = osm_route_member_network_type(network)
 WHERE network != ''
-  AND network_type IS DISTINCT FROM osm_route_member_network_type(network, name, ref)
+  AND network_type IS DISTINCT FROM osm_route_member_network_type(network)
 ;
 
 CREATE OR REPLACE FUNCTION update_osm_route_member() RETURNS void AS
@@ -62,10 +62,10 @@ BEGIN
 
     UPDATE
         osm_route_member AS r
-    SET network_type = osm_route_member_network_type(network, name, ref)
+    SET network_type = osm_route_member_network_type(network)
     FROM transportation_name.network_changes AS c
     WHERE network != ''
-      AND network_type IS DISTINCT FROM osm_route_member_network_type(network, name, ref)
+      AND network_type IS DISTINCT FROM osm_route_member_network_type(network)
       AND r.member = c.osm_id;
 END;
 $$ LANGUAGE plpgsql;

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -297,7 +297,7 @@ BEGIN
                 ELSE NULLIF(hl.ref, '')
                 END AS ref,
             hl.highway,
-            NULLIF(hl.subclass, '') AS subclass,
+            NULLIF(hl.construction, '') AS subclass,
             brunnel(hl.is_bridge, hl.is_tunnel, hl.is_ford) AS brunnel,
             CASE WHEN highway IN ('footway', 'steps') THEN layer END AS layer,
             CASE WHEN highway IN ('footway', 'steps') THEN level END AS level,
@@ -459,7 +459,6 @@ BEGIN
 
     INSERT INTO osm_transportation_name_linestring
     SELECT (ST_Dump(geometry)).geom AS geometry,
-           NULL::bigint AS osm_id,
            name,
            name_en,
            name_de,

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -297,7 +297,7 @@ BEGIN
                 ELSE NULLIF(hl.ref, '')
                 END AS ref,
             hl.highway,
-            NULLIF(hl.construction, '') AS subclass,
+            NULLIF(hl.subclass, '') AS subclass,
             brunnel(hl.is_bridge, hl.is_tunnel, hl.is_ford) AS brunnel,
             CASE WHEN highway IN ('footway', 'steps') THEN layer END AS layer,
             CASE WHEN highway IN ('footway', 'steps') THEN level END AS level,
@@ -459,6 +459,7 @@ BEGIN
 
     INSERT INTO osm_transportation_name_linestring
     SELECT (ST_Dump(geometry)).geom AS geometry,
+           NULL::bigint AS osm_id,
            name,
            name_en,
            name_de,


### PR DESCRIPTION
Changes in #1143 removed the need for `name` and `ref` parameters in the network-to-network_type conversion function.  This PR removes this dead code.

Verified by running ./quickstart rhode-island which completed successfully.