### PR TITLE
Remove useless null osm_id from transportation layer

### DIFF
--- a/layers/transportation/transportation.sql
+++ b/layers/transportation/transportation.sql
@@ -11,7 +11,6 @@ $$ LANGUAGE SQL IMMUTABLE
 CREATE OR REPLACE FUNCTION layer_transportation(bbox geometry, zoom_level int)
     RETURNS TABLE
             (
-                osm_id    bigint,
                 geometry  geometry,
                 class     text,
                 subclass  text,
@@ -30,8 +29,7 @@ CREATE OR REPLACE FUNCTION layer_transportation(bbox geometry, zoom_level int)
             )
 AS
 $$
-SELECT osm_id,
-       geometry,
+SELECT geometry,
        CASE
            WHEN NULLIF(highway, '') IS NOT NULL OR NULLIF(public_transport, '') IS NOT NULL
                THEN highway_class(highway, public_transport, construction)
@@ -65,8 +63,7 @@ SELECT osm_id,
        NULLIF(surface, '') AS surface
 FROM (
          -- etldoc: osm_transportation_merge_linestring_gen_z4 -> layer_transportation:z4
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 highway,
                 construction,
                 NULL AS railway,
@@ -94,8 +91,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z5 -> layer_transportation:z5
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 highway,
                 construction,
                 NULL AS railway,
@@ -123,8 +119,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z6 -> layer_transportation:z6
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 highway,
                 construction,
                 NULL AS railway,
@@ -152,8 +147,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z7  ->  layer_transportation:z7
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 highway,
                 construction,
                 NULL AS railway,
@@ -181,8 +175,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z8  ->  layer_transportation:z8
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 highway,
                 construction,
                 NULL AS railway,
@@ -210,8 +203,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z9  ->  layer_transportation:z9
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 highway,
                 construction,
                 NULL AS railway,
@@ -239,8 +231,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z10  ->  layer_transportation:z10
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 highway,
                 construction,
                 NULL AS railway,
@@ -268,8 +259,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z11  ->  layer_transportation:z11
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 highway,
                 construction,
                 NULL AS railway,
@@ -299,8 +289,7 @@ FROM (
          -- etldoc: osm_highway_linestring  ->  layer_transportation:z12
          -- etldoc: osm_highway_linestring  ->  layer_transportation:z13
          -- etldoc: osm_highway_linestring  ->  layer_transportation:z14_
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 highway,
                 construction,
                 NULL AS railway,
@@ -347,8 +336,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_railway_linestring_gen_z8  ->  layer_transportation:z8
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 railway,
@@ -379,8 +367,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_railway_linestring_gen_z9  ->  layer_transportation:z9
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 railway,
@@ -411,8 +398,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_railway_linestring_gen_z10  ->  layer_transportation:z10
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 railway,
@@ -442,8 +428,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_railway_linestring_gen_z11  ->  layer_transportation:z11
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 railway,
@@ -473,8 +458,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_railway_linestring_gen_z12  ->  layer_transportation:z12
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 railway,
@@ -505,8 +489,7 @@ FROM (
 
          -- etldoc: osm_railway_linestring ->  layer_transportation:z13
          -- etldoc: osm_railway_linestring ->  layer_transportation:z14_
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 railway,
@@ -537,8 +520,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_aerialway_linestring_gen_z12  ->  layer_transportation:z12
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 NULL AS railway,
@@ -567,8 +549,7 @@ FROM (
 
          -- etldoc: osm_aerialway_linestring ->  layer_transportation:z13
          -- etldoc: osm_aerialway_linestring ->  layer_transportation:z14_
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 NULL AS railway,
@@ -596,8 +577,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_shipway_linestring_gen_z11  ->  layer_transportation:z11
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 NULL AS railway,
@@ -625,8 +605,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_shipway_linestring_gen_z12  ->  layer_transportation:z12
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 NULL AS railway,
@@ -655,8 +634,7 @@ FROM (
 
          -- etldoc: osm_shipway_linestring ->  layer_transportation:z13
          -- etldoc: osm_shipway_linestring ->  layer_transportation:z14_
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 NULL AS highway,
                 NULL AS construction,
                 NULL AS railway,
@@ -689,8 +667,7 @@ FROM (
          -- highway linestrings and as polygon
          -- etldoc: osm_highway_polygon ->  layer_transportation:z13
          -- etldoc: osm_highway_polygon ->  layer_transportation:z14_
-         SELECT osm_id,
-                geometry,
+         SELECT geometry,
                 highway,
                 NULL AS construction,
                 NULL AS railway,

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -17,7 +17,6 @@ DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z11 CAS
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z11 AS
 (
 SELECT (ST_Dump(geometry)).geom AS geometry,
-       NULL::bigint AS osm_id,
        highway,
        construction,
        is_bridge,
@@ -55,7 +54,6 @@ DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z10 CAS
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z10 AS
 (
 SELECT ST_Simplify(geometry, ZRes(12)) AS geometry,
-       osm_id,
        highway,
        construction,
        is_bridge,
@@ -68,7 +66,7 @@ SELECT ST_Simplify(geometry, ZRes(12)) AS geometry,
        mtb_scale,
        layer
 FROM osm_transportation_merge_linestring_gen_z11
-WHERE highway NOT IN ('tertiary', 'tertiary_link') 
+WHERE highway NOT IN ('tertiary', 'tertiary_link')
       OR highway = 'construction' AND construction NOT IN ('tertiary', 'tertiary_link')
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z10_geometry_idx
@@ -79,7 +77,6 @@ DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z9 CASC
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z9 AS
 (
 SELECT ST_Simplify(geometry, ZRes(11)) AS geometry,
-       osm_id,
        highway,
        construction,
        is_bridge,
@@ -92,7 +89,7 @@ SELECT ST_Simplify(geometry, ZRes(11)) AS geometry,
        mtb_scale,
        layer
 FROM osm_transportation_merge_linestring_gen_z10
-WHERE highway NOT IN ('tertiary', 'tertiary_link') 
+WHERE highway NOT IN ('tertiary', 'tertiary_link')
       OR highway = 'construction' AND construction NOT IN ('tertiary', 'tertiary_link')
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z9_geometry_idx
@@ -103,7 +100,6 @@ DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring CASCADE;
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring AS
 (
 SELECT (ST_Dump(geometry)).geom AS geometry,
-       NULL::bigint AS osm_id,
        highway,
        construction,
        is_bridge,
@@ -133,7 +129,6 @@ DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z8 CASC
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z8 AS
 (
 SELECT ST_Simplify(geometry, ZRes(10)) AS geometry,
-       osm_id,
        highway,
        construction,
        is_bridge,
@@ -152,7 +147,6 @@ DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z7 CASC
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z7 AS
 (
 SELECT ST_Simplify(geometry, ZRes(9)) AS geometry,
-       osm_id,
        highway,
        construction,
        is_bridge,
@@ -172,7 +166,6 @@ DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z6 CASC
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z6 AS
 (
 SELECT ST_Simplify(geometry, ZRes(8)) AS geometry,
-       osm_id,
        highway,
        construction,
        is_bridge,
@@ -191,7 +184,6 @@ DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z5 CASC
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z5 AS
 (
 SELECT ST_Simplify(geometry, ZRes(7)) AS geometry,
-       osm_id,
        highway,
        construction,
        is_bridge,
@@ -210,7 +202,6 @@ DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z4 CASC
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z4 AS
 (
 SELECT ST_Simplify(geometry, ZRes(6)) AS geometry,
-       osm_id,
        highway,
        construction,
        is_bridge,


### PR DESCRIPTION
This issue is similar to the fix in #1147, which removed null osm_id columns from the `transportation_name` layer.  This PR does the same cleanup in the `transportation` which similarly had unused null osm_id columns that were not used in the layer.

Below is a rendering of Rhode Island, USA that I generated after removing the null columns:
![image](https://user-images.githubusercontent.com/3254090/126417070-bcab46d2-f605-493f-bd66-4357ceb55a26.png)
![image](https://user-images.githubusercontent.com/3254090/126417152-e1be9177-491b-489f-9662-589fd692c4b1.png)

While I was in this file, I also removed a few unneeded spaces at the ends of lines.