### PR TITLE
Render ramps up to zoom 7

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -119,8 +119,8 @@ FROM (
                 is_ford,
                 min(z_order) AS z_order
          FROM osm_highway_linestring
-         WHERE (highway IN ('motorway', 'trunk', 'primary') OR
-                highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary'))
+         WHERE (highway IN ('motorway', 'trunk', 'primary', 'motorway_link', 'trunk_link', 'primary_link') OR
+                highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary', 'motorway_link', 'trunk_link', 'primary_link'))
            AND ST_IsValid(geometry)
          GROUP BY highway, construction, is_bridge, is_tunnel, is_ford
      ) AS highway_union
@@ -141,8 +141,7 @@ SELECT ST_Simplify(geometry, ZRes(10)) AS geometry,
        is_ford,
        z_order
 FROM osm_transportation_merge_linestring
-WHERE highway IN ('motorway', 'trunk', 'primary')
-   OR highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary')
+WHERE ST_Length(geometry) > 25
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z8_geometry_idx
     ON osm_transportation_merge_linestring_gen_z8 USING gist (geometry);
@@ -160,9 +159,7 @@ SELECT ST_Simplify(geometry, ZRes(9)) AS geometry,
        is_ford,
        z_order
 FROM osm_transportation_merge_linestring_gen_z8
-WHERE (highway IN ('motorway', 'trunk', 'primary') OR
-       highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary'))
-  AND ST_Length(geometry) > 50
+WHERE ST_Length(geometry) > 50
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z7_geometry_idx
     ON osm_transportation_merge_linestring_gen_z7 USING gist (geometry);


### PR DESCRIPTION
Fixes #1161

This PR extends ramp rendering up to zoom 7 (from the current zoom 9) and makes associated optimizations.

Screenshot of ramp rendering at zoom 8:
![image](https://user-images.githubusercontent.com/3254090/127423744-1c821d08-9b15-4e1c-885f-49cb0ffabc16.png)

Current ramp rendering at zoom 8:
![image](https://user-images.githubusercontent.com/3254090/127423793-ee3d0737-7b65-4216-9cfe-db37f54eacae.png)

The approach is as follows:
* Link roads are added to the where clause in `osm_transportation_merge_linestring`
* `WHERE` clauses in the z7 and z8 merge tables are removed as unnecessary because motorway/trunk/primary filtering is already done in the underlying `osm_transportation_merge_linestring` table
* The existing `WHERE` clause in the z6 merge table will drop primary and all ramp types
* An `ST_Length()` filter is applied to the z8 merge table in order to filter out smaller link road segments that won't be visible at this zoom.