### PR TITLE
Generalize ramps at zoom 7-8

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -104,25 +104,25 @@ CREATE MATERIALIZED VIEW osm_transportation_merge_linestring AS
 (
 SELECT (ST_Dump(geometry)).geom AS geometry,
        NULL::bigint AS osm_id,
-       highway,
-       construction,
+       highway_merge AS highway,
+       construction_merge AS construction,
        is_bridge,
        is_tunnel,
        is_ford,
        z_order
 FROM (
          SELECT ST_LineMerge(ST_Collect(geometry)) AS geometry,
-                highway,
-                construction,
+                REPLACE(highway, '_link', '') AS highway_merge,
+                REPLACE(construction, '_link', '') AS construction_merge,
                 is_bridge,
                 is_tunnel,
                 is_ford,
                 min(z_order) AS z_order
          FROM osm_highway_linestring
-         WHERE (highway IN ('motorway', 'trunk', 'primary', 'motorway_link', 'trunk_link', 'primary_link') OR
-                highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary', 'motorway_link', 'trunk_link', 'primary_link'))
+         WHERE (highway IN ('motorway', 'trunk', 'primary') OR
+                highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary'))
            AND ST_IsValid(geometry)
-         GROUP BY highway, construction, is_bridge, is_tunnel, is_ford
+         GROUP BY highway_merge, construction_merge, is_bridge, is_tunnel, is_ford
      ) AS highway_union
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_geometry_idx

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -111,7 +111,7 @@ SELECT (ST_Dump(geometry)).geom AS geometry,
        is_ford,
        z_order
 FROM (
-         SELECT ST_LineMerge(ST_Collect(geometry)) AS geometry,
+         SELECT ST_LineMerge(ST_Union(geometry)) AS geometry,
                 REPLACE(highway, '_link', '') AS highway_merge,
                 REPLACE(construction, '_link', '') AS construction_merge,
                 is_bridge,
@@ -119,8 +119,8 @@ FROM (
                 is_ford,
                 min(z_order) AS z_order
          FROM osm_highway_linestring
-         WHERE (highway IN ('motorway', 'trunk', 'primary') OR
-                highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary'))
+         WHERE highway SIMILAR TO '(motorway|trunk|primary)(_link)*' OR
+              (highway = 'construction' AND construction SIMILAR TO '(motorway|trunk|primary)(_link)*')
            AND ST_IsValid(geometry)
          GROUP BY highway_merge, construction_merge, is_bridge, is_tunnel, is_ford
      ) AS highway_union

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -111,7 +111,7 @@ SELECT (ST_Dump(geometry)).geom AS geometry,
        is_ford,
        z_order
 FROM (
-         SELECT ST_LineMerge(ST_Union(geometry)) AS geometry,
+         SELECT ST_LineMerge(ST_Collect(geometry)) AS geometry,
                 REPLACE(highway, '_link', '') AS highway_merge,
                 REPLACE(construction, '_link', '') AS construction_merge,
                 is_bridge,
@@ -119,8 +119,8 @@ FROM (
                 is_ford,
                 min(z_order) AS z_order
          FROM osm_highway_linestring
-         WHERE highway SIMILAR TO '(motorway|trunk|primary)(_link)*' OR
-              (highway = 'construction' AND construction SIMILAR TO '(motorway|trunk|primary)(_link)*')
+         WHERE highway IN ('motorway', 'motorway_link', 'trunk', 'primary') OR
+              (highway = 'construction' AND construction IN ('motorway', 'motorway_link', 'trunk', 'primary'))
            AND ST_IsValid(geometry)
          GROUP BY highway_merge, construction_merge, is_bridge, is_tunnel, is_ford
      ) AS highway_union

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -119,8 +119,8 @@ FROM (
                 is_ford,
                 min(z_order) AS z_order
          FROM osm_highway_linestring
-         WHERE (highway IN ('motorway', 'trunk', 'primary') OR
-                highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary'))
+         WHERE (highway IN ('motorway', 'trunk', 'primary', 'motorway_link', 'trunk_link', 'primary_link') OR
+                highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary', 'motorway_link', 'trunk_link', 'primary_link'))
            AND ST_IsValid(geometry)
          GROUP BY highway, construction, is_bridge, is_tunnel, is_ford
      ) AS highway_union
@@ -141,8 +141,7 @@ SELECT ST_Simplify(geometry, ZRes(10)) AS geometry,
        is_ford,
        z_order
 FROM osm_transportation_merge_linestring
-WHERE highway IN ('motorway', 'trunk', 'primary')
-   OR highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary')
+WHERE ST_Length(geometry) > 25
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z8_geometry_idx
     ON osm_transportation_merge_linestring_gen_z8 USING gist (geometry);
@@ -160,9 +159,7 @@ SELECT ST_Simplify(geometry, ZRes(9)) AS geometry,
        is_ford,
        z_order
 FROM osm_transportation_merge_linestring_gen_z8
-WHERE (highway IN ('motorway', 'trunk', 'primary') OR
-       highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary'))
-  AND ST_Length(geometry) > 50
+WHERE ST_Length(geometry) > 50
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z7_geometry_idx
     ON osm_transportation_merge_linestring_gen_z7 USING gist (geometry);


### PR DESCRIPTION
This is an alternate approach to #1162 for consideration.

In this version of the PR, ramps are generalized into their parent roadways at zoom 8 and above.  I'm offering this as a comparison in order to compare performance and tile size.

Below is a render of the same test area which shows no unusual geometry artifacts at zoom 8:
![image](https://user-images.githubusercontent.com/3254090/127483594-c0f2c3d0-aa33-4bab-9bfa-19fec92f69d0.png)
