### PR TITLE
Remove useless WHERE clauses from the transportation layer

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -141,8 +141,6 @@ SELECT ST_Simplify(geometry, ZRes(10)) AS geometry,
        is_ford,
        z_order
 FROM osm_transportation_merge_linestring
-WHERE highway IN ('motorway', 'trunk', 'primary')
-   OR highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary')
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z8_geometry_idx
     ON osm_transportation_merge_linestring_gen_z8 USING gist (geometry);
@@ -160,9 +158,7 @@ SELECT ST_Simplify(geometry, ZRes(9)) AS geometry,
        is_ford,
        z_order
 FROM osm_transportation_merge_linestring_gen_z8
-WHERE (highway IN ('motorway', 'trunk', 'primary') OR
-       highway = 'construction' AND construction IN ('motorway', 'trunk', 'primary'))
-  AND ST_Length(geometry) > 50
+WHERE ST_Length(geometry) > 50
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z7_geometry_idx
     ON osm_transportation_merge_linestring_gen_z7 USING gist (geometry);
@@ -199,8 +195,7 @@ SELECT ST_Simplify(geometry, ZRes(7)) AS geometry,
        is_ford,
        z_order
 FROM osm_transportation_merge_linestring_gen_z6
-WHERE (highway IN ('motorway', 'trunk') OR highway = 'construction' AND construction IN ('motorway', 'trunk'))
-  AND ST_Length(geometry) > 500
+WHERE ST_Length(geometry) > 500
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z5_geometry_idx
     ON osm_transportation_merge_linestring_gen_z5 USING gist (geometry);


### PR DESCRIPTION
This PR removes several redundant/unnecessary WHERE clauses from the transportation layer.  Specifically:

The table `osm_transportation_merge_linestring` is a view of `osm_highway_linestring` which exposes only motorway/trunk/primary roads:
https://github.com/openmaptiles/openmaptiles/blob/9e4be3e3b03c26fcc1e63ee4976f44a5d1f8dba1/layers/transportation/update_transportation_merge.sql#L103-L123

However, the create statement for the table `osm_transportation_merge_linestring_gen_z8`, which is a view of `osm_transportation_merge_linestring`, also contains  a `WHERE` clause which selects down to motorway/trunk/primary roads.  This `WHERE` is unnecessary:
https://github.com/openmaptiles/openmaptiles/blob/9e4be3e3b03c26fcc1e63ee4976f44a5d1f8dba1/layers/transportation/update_transportation_merge.sql#L144-L145

This unneeded `WHERE` clause is similarly present in the create statement for `osm_transportation_merge_linestring_gen_z7`, which is a view of `osm_transportation_merge_linestring_gen_z8`:
https://github.com/openmaptiles/openmaptiles/blob/9e4be3e3b03c26fcc1e63ee4976f44a5d1f8dba1/layers/transportation/update_transportation_merge.sql#L163-L164

Likewise, there is a similar redundant `WHERE` clause in the `osm_transportation_merge_linestring_gen_z5` and `osm_transportation_merge_linestring_gen_z6` tables, both of which select down to `motorway` and `trunk`.  This `WHERE` clause is only needed on the z6 table, and is redundant on the z5 table.

I am not sure what the performance penalty is for these redundant `WHERE` clauses, but there does not appear to be any reason to keep them, and they may incur a performance cost.