### PR TITLE
Fix negative feature IDs

### DIFF
--- a/layers/aerodrome_label/aerodrome_label.sql
+++ b/layers/aerodrome_label/aerodrome_label.sql
@@ -5,7 +5,7 @@ CREATE OR REPLACE FUNCTION layer_aerodrome_label(bbox geometry,
                                                  zoom_level integer)
     RETURNS TABLE
             (
-                osm_id   bigint,
+                id       bigint,
                 geometry geometry,
                 name     text,
                 name_en  text,
@@ -21,7 +21,7 @@ AS
 $$
 SELECT
     -- etldoc: osm_aerodrome_label_point -> layer_aerodrome_label:z10_
-    osm_id,
+    ABS(osm_id) AS id, -- mvt feature IDs can't be negative
     geometry,
     name,
     COALESCE(NULLIF(name_en, ''), name) AS name_en,

--- a/layers/aerodrome_label/aerodrome_label.yaml
+++ b/layers/aerodrome_label/aerodrome_label.yaml
@@ -38,10 +38,10 @@ layer:
     ele_ft: Elevation (`ele`) in feets.
   datasource:
     geometry_field: geometry
-    key_field: osm_id
+    key_field: id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, iata, icao, ele, ele_ft FROM layer_aerodrome_label(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT id, geometry, name, name_en, name_de, {name_languages}, class, iata, icao, ele, ele_ft FROM layer_aerodrome_label(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./update_aerodrome_label_point.sql
   - ./aerodrome_label.sql


### PR DESCRIPTION
This PR removes the possibility of negative feature IDs for the `aerodrome_label` layer by defining the feature as the absolute value of the OSM id (imposm maps relations with negative numbers).  There is a very unlikely  scenario in which a relation and a way have the same ID (and are also in the same tile), however, unique IDs are not a strict requirement of MVT.

Noted in:
https://github.com/openmaptiles/openmaptiles/pull/1176#issuecomment-902503655

Positive feature ID for Quonset State Airport, which is mapped as a relation:
![image](https://user-images.githubusercontent.com/3254090/130232322-c797d491-ece9-4889-9695-ffb6f3ac011f.png)
