### PR TITLE
show tracks / paths at zoom 12 and 13

### DIFF
--- a/layers/transportation/transportation.sql
+++ b/layers/transportation/transportation.sql
@@ -360,12 +360,11 @@ FROM (
          WHERE NOT is_area
            AND (
                      zoom_level = 12 AND (
-                             highway_class(highway, public_transport, construction) NOT IN ('track', 'path', 'minor')
+                             highway_class(highway, public_transport, construction) NOT IN ('minor')
                          OR highway IN ('unclassified', 'residential')
                      ) AND man_made <> 'pier'
                  OR zoom_level = 13
                          AND (
-                                    highway_class(highway, public_transport, construction) NOT IN ('track', 'path') AND
                                     man_made <> 'pier'
                             OR
                                     man_made = 'pier' AND NOT ST_IsClosed(geometry)


### PR DESCRIPTION
As discussed this PR changed the visibility of tracks/paths to be shown at lower level as done by most hikings maps
