### PR TITLE
Fix name of PR comment workflow in new modernized github actions

### DIFF
--- a/.github/workflows/pr-updater.yml
+++ b/.github/workflows/pr-updater.yml
@@ -14,7 +14,7 @@ jobs:
       - name: main
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          WORKFLOW_NAME: "OpenMapTiles CI"
+          WORKFLOW_NAME: "OpenMapTiles Performance CI"
           # the name of the artifact whose content comment published by PR. Must have a single markdown file inside.
           MSG_ARTIFACT_NAME: "pr_message"
           # How far back to look for finished runs, in minutes.


### PR DESCRIPTION
(Hopefully) fixes a typo introduced in #1189. The workflow is correctly triggered but fails in grabbing the PR comments from the wrong workflow.