### PR TITLE
Add boundaries `import-data` info to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ make start-db
 ```
 
 Import external data from [OpenStreetMapData](http://osmdata.openstreetmap.de/), [Natural Earth](http://www.naturalearthdata.com/) and [OpenStreetMap Lake Labels](https://github.com/lukasmartinelli/osm-lakelines).
-
+The boundaries of the countries are used from Natural Earth until zoom level 4.
 ```bash
 make import-data
 ```


### PR DESCRIPTION
I was thought that the borders are completley imported over `import-borders` but until z4 the Natural Earth Data are used.
I added this info to the Readme