### PR TITLE
Remove previous border files when using quickstart

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -236,6 +236,11 @@ make import-osm
 
 echo " "
 echo "-------------------------------------------------------------------------------------"
+echo "====> : Removing old border files"
+rm -f ./data/borders/*
+
+echo " "
+echo "-------------------------------------------------------------------------------------"
 echo "====> : Start importing border ${area} data into PostgreSQL using osmborder"
 echo "      : Source code: https://github.com/pnorman/osmborder"
 echo "      : Data license: http://www.openstreetmap.org/copyright"


### PR DESCRIPTION
When running `quickstart.sh` the `data/borders` folder is not removed if it exists. This can be a problem when a user is running `quickstart.sh` multiple times for different downloads such as Washington and then Arizona:

> ./quickstart.sh washington

This will correctly create borders for Washington in the borders folder.

> ./quickstart.sh arizona

This will use the old borders files that were created for Washington which causes incorrect data to be written for that state, and missing data as well.

This PR associate with issue #1228 .