### PR TITLE
Suppress rendering of underground buildings

### DIFF
--- a/layers/building/mapping.yaml
+++ b/layers/building/mapping.yaml
@@ -65,6 +65,7 @@ tables:
         building: ["no","none","No"]
         building:part: ["no","none","No"]
         man_made: ["bridge"]
+        location: ["underground"]
     type: polygon
 
   # etldoc: imposm3 -> osm_building_relation

--- a/layers/building/mapping.yaml
+++ b/layers/building/mapping.yaml
@@ -60,6 +60,8 @@ tables:
       aeroway:
       - terminal
       - hangar
+      location:
+      - underground
     filters:
       reject:
         building: ["no","none","No"]
@@ -158,4 +160,12 @@ tables:
       type: member_type
     mapping:
       type: [building]
+      location:
+      - underground
+    filters:
+      reject:
+        building: ["no","none","No"]
+        building:part: ["no","none","No"]
+        man_made: ["bridge"]
+        location: ["underground"]
     type: relation_member


### PR DESCRIPTION
Closes #1227

This PR does the following:
1. Suppresses underground buildings from rendering, when such buildings are tagged `location=underground`.  Based on the wiki documentation, the `layer` tag does not determine whether a feature is above of below ground.
2. Unifies the building and building relation imposm exclusion mappings.

The following underground building feature in Luxembourg is used as the test object:
https://www.openstreetmap.org/way/582873794

**Before:**
![image](https://user-images.githubusercontent.com/3254090/133913068-d142f092-3b5a-483d-aa4f-981525c340dc.png)

**After:**
![image](https://user-images.githubusercontent.com/3254090/133913095-28de5735-c394-4829-b95b-e29d33e13efe.png)