### PR TITLE
[EXPERIMENTAL] Convert park layer to tag-based approach

### DIFF
--- a/layers/park/mapping.yaml
+++ b/layers/park/mapping.yaml
@@ -1,3 +1,9 @@
+tags:
+  include:
+  - landuse
+  - leisure
+  - boundary
+
 generalized_tables:
   # etldoc: osm_park_polygon_gen_z5 -> osm_park_polygon_gen_z4
   park_polygon_gen_z4:
@@ -70,29 +76,8 @@ tables:
       type: id
     - name: geometry
       type: validated_geometry
-    - name: name
-      key: name
-      type: string
-    - name: name_en
-      key: name:en
-      type: string
-    - name: name_de
-      key: name:de
-      type: string
     - name: tags
       type: hstore_tags
-    - name: landuse
-      key: landuse
-      type: string
-    - name: leisure
-      key: leisure
-      type: string
-    - name: boundary
-      key: boundary
-      type: string
-    - name: protection_title
-      key: protection_title
-      type: string
     - name: area
       type: area
     mapping:

--- a/layers/park/park.sql
+++ b/layers/park/park.sql
@@ -27,26 +27,24 @@ FROM (
          SELECT osm_id,
                 geometry,
                 COALESCE(
-                        LOWER(REPLACE(NULLIF(protection_title, ''), ' ', '_')),
-                        NULLIF(boundary, ''),
-                        NULLIF(leisure, '')
+                        LOWER(REPLACE(NULLIF(tags->'protection_title', ''), ' ', '_')),
+                        NULLIF(tags->'boundary', ''),
+                        NULLIF(tags->'leisure', '')
                     ) AS class,
-                name,
-                name_en,
-                name_de,
+                tags->'name' AS name,
+                COALESCE(
+                  tags->'name:en',
+                  tags->'name') AS name_en,
+                COALESCE(
+                  tags->'name:de',
+                  tags->'name') AS name_de,
                 tags,
                 NULL::int AS rank
          FROM (
                   -- etldoc: osm_park_polygon_dissolve_z4 -> layer_park:z4
                   SELECT NULL::int AS osm_id,
                          geometry,
-                         NULL AS name,
-                         NULL AS name_en,
-                         NULL AS name_de,
-                         NULL AS tags,
-                         NULL AS leisure,
-                         NULL AS boundary,
-                         NULL AS protection_title
+                         hstore('') AS tags
                   FROM osm_park_polygon_dissolve_z4
                   WHERE zoom_level = 4
                     AND geometry && bbox
@@ -54,13 +52,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z5 -> layer_park:z5
                   SELECT osm_id,
                          geometry,
-                         name,
-                         name_en,
-                         name_de,
-                         tags,
-                         leisure,
-                         boundary,
-                         protection_title
+                         tags
                   FROM osm_park_polygon_gen_z5
                   WHERE zoom_level = 5
                     AND geometry && bbox
@@ -68,13 +60,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z6 -> layer_park:z6
                   SELECT osm_id,
                          geometry,
-                         name,
-                         name_en,
-                         name_de,
-                         tags,
-                         leisure,
-                         boundary,
-                         protection_title
+                         tags
                   FROM osm_park_polygon_gen_z6
                   WHERE zoom_level = 6
                     AND geometry && bbox
@@ -82,13 +68,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z7 -> layer_park:z7
                   SELECT osm_id,
                          geometry,
-                         name,
-                         name_en,
-                         name_de,
-                         tags,
-                         leisure,
-                         boundary,
-                         protection_title
+                         tags
                   FROM osm_park_polygon_gen_z7
                   WHERE zoom_level = 7
                     AND geometry && bbox
@@ -96,13 +76,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z8 -> layer_park:z8
                   SELECT osm_id,
                          geometry,
-                         name,
-                         name_en,
-                         name_de,
-                         tags,
-                         leisure,
-                         boundary,
-                         protection_title
+                         tags
                   FROM osm_park_polygon_gen_z8
                   WHERE zoom_level = 8
                     AND geometry && bbox
@@ -110,13 +84,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z9 -> layer_park:z9
                   SELECT osm_id,
                          geometry,
-                         name,
-                         name_en,
-                         name_de,
-                         tags,
-                         leisure,
-                         boundary,
-                         protection_title
+                         tags
                   FROM osm_park_polygon_gen_z9
                   WHERE zoom_level = 9
                     AND geometry && bbox
@@ -124,13 +92,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z10 -> layer_park:z10
                   SELECT osm_id,
                          geometry,
-                         name,
-                         name_en,
-                         name_de,
-                         tags,
-                         leisure,
-                         boundary,
-                         protection_title
+                         tags
                   FROM osm_park_polygon_gen_z10
                   WHERE zoom_level = 10
                     AND geometry && bbox
@@ -138,13 +100,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z11 -> layer_park:z11
                   SELECT osm_id,
                          geometry,
-                         name,
-                         name_en,
-                         name_de,
-                         tags,
-                         leisure,
-                         boundary,
-                         protection_title
+                         tags
                   FROM osm_park_polygon_gen_z11
                   WHERE zoom_level = 11
                     AND geometry && bbox
@@ -152,13 +108,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z12 -> layer_park:z12
                   SELECT osm_id,
                          geometry,
-                         name,
-                         name_en,
-                         name_de,
-                         tags,
-                         leisure,
-                         boundary,
-                         protection_title
+                         tags
                   FROM osm_park_polygon_gen_z12
                   WHERE zoom_level = 12
                     AND geometry && bbox
@@ -166,13 +116,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z13 -> layer_park:z13
                   SELECT osm_id,
                          geometry,
-                         name,
-                         name_en,
-                         name_de,
-                         tags,
-                         leisure,
-                         boundary,
-                         protection_title
+                         tags
                   FROM osm_park_polygon_gen_z13
                   WHERE zoom_level = 13
                     AND geometry && bbox
@@ -180,13 +124,7 @@ FROM (
                   -- etldoc: osm_park_polygon -> layer_park:z14
                   SELECT osm_id,
                          geometry,
-                         name,
-                         name_en,
-                         name_de,
-                         tags,
-                         leisure,
-                         boundary,
-                         protection_title
+                         tags
                   FROM osm_park_polygon
                   WHERE zoom_level >= 14
                     AND geometry && bbox
@@ -196,18 +134,22 @@ FROM (
          SELECT osm_id,
                 geometry_point AS geometry,
                 COALESCE(
-                        LOWER(REPLACE(NULLIF(protection_title, ''), ' ', '_')),
-                        NULLIF(boundary, ''),
-                        NULLIF(leisure, '')
+                        LOWER(REPLACE(NULLIF(tags->'protection_title', ''), ' ', '_')),
+                        NULLIF(tags->'boundary', ''),
+                        NULLIF(tags->'leisure', '')
                     ) AS class,
-                name,
-                name_en,
-                name_de,
+                tags->'name',
+                COALESCE(
+                  tags->'name:en',
+                  tags->'name') AS name_en,
+                COALESCE(
+                  tags->'name:de',
+                  tags->'name') AS name_de,
                 tags,
                 row_number() OVER (
                     PARTITION BY LabelGrid(geometry_point, 100 * pixel_width)
                     ORDER BY
-                        (CASE WHEN boundary = 'national_park' THEN TRUE ELSE FALSE END) DESC,
+                        (CASE WHEN tags->'boundary' = 'national_park' THEN TRUE ELSE FALSE END) DESC,
                         (COALESCE(NULLIF(tags->'wikipedia', ''), NULLIF(tags->'wikidata', '')) IS NOT NULL) DESC,
                         area DESC
                     )::int AS "rank"
@@ -215,13 +157,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z5 -> layer_park:z5
                   SELECT osm_id,
                          geometry_point,
-                         name,
-                         name_en,
-                         name_de,
                          tags,
-                         leisure,
-                         boundary,
-                         protection_title,
                          area
                   FROM osm_park_polygon_gen_z5
                   WHERE zoom_level = 5
@@ -232,13 +168,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z6 -> layer_park:z6
                   SELECT osm_id,
                          geometry_point,
-                         name,
-                         name_en,
-                         name_de,
                          tags,
-                         leisure,
-                         boundary,
-                         protection_title,
                          area
                   FROM osm_park_polygon_gen_z6
                   WHERE zoom_level = 6
@@ -249,13 +179,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z7 -> layer_park:z7
                   SELECT osm_id,
                          geometry_point,
-                         name,
-                         name_en,
-                         name_de,
                          tags,
-                         leisure,
-                         boundary,
-                         protection_title,
                          area
                   FROM osm_park_polygon_gen_z7
                   WHERE zoom_level = 7
@@ -266,13 +190,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z8 -> layer_park:z8
                   SELECT osm_id,
                          geometry_point,
-                         name,
-                         name_en,
-                         name_de,
                          tags,
-                         leisure,
-                         boundary,
-                         protection_title,
                          area
                   FROM osm_park_polygon_gen_z8
                   WHERE zoom_level = 8
@@ -283,13 +201,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z9 -> layer_park:z9
                   SELECT osm_id,
                          geometry_point,
-                         name,
-                         name_en,
-                         name_de,
                          tags,
-                         leisure,
-                         boundary,
-                         protection_title,
                          area
                   FROM osm_park_polygon_gen_z9
                   WHERE zoom_level = 9
@@ -300,13 +212,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z10 -> layer_park:z10
                   SELECT osm_id,
                          geometry_point,
-                         name,
-                         name_en,
-                         name_de,
                          tags,
-                         leisure,
-                         boundary,
-                         protection_title,
                          area
                   FROM osm_park_polygon_gen_z10
                   WHERE zoom_level = 10
@@ -317,13 +223,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z11 -> layer_park:z11
                   SELECT osm_id,
                          geometry_point,
-                         name,
-                         name_en,
-                         name_de,
                          tags,
-                         leisure,
-                         boundary,
-                         protection_title,
                          area
                   FROM osm_park_polygon_gen_z11
                   WHERE zoom_level = 11
@@ -334,13 +234,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z12 -> layer_park:z12
                   SELECT osm_id,
                          geometry_point,
-                         name,
-                         name_en,
-                         name_de,
                          tags,
-                         leisure,
-                         boundary,
-                         protection_title,
                          area
                   FROM osm_park_polygon_gen_z12
                   WHERE zoom_level = 12
@@ -351,13 +245,7 @@ FROM (
                   -- etldoc: osm_park_polygon_gen_z13 -> layer_park:z13
                   SELECT osm_id,
                          geometry_point,
-                         name,
-                         name_en,
-                         name_de,
                          tags,
-                         leisure,
-                         boundary,
-                         protection_title,
                          area
                   FROM osm_park_polygon_gen_z13
                   WHERE zoom_level = 13
@@ -368,13 +256,7 @@ FROM (
                   -- etldoc: osm_park_polygon -> layer_park:z14
                   SELECT osm_id,
                          geometry_point,
-                         name,
-                         name_en,
-                         name_de,
                          tags,
-                         leisure,
-                         boundary,
-                         protection_title,
                          area
                   FROM osm_park_polygon
                   WHERE zoom_level >= 14


### PR DESCRIPTION
This is an experimental PR intended to support ongoing discussions about how to add customizability to OMT layers.  As an experiment, this PR only modifies the `park` layer.

This PR moves tags not involved in `WHERE` clauses into the `tags` hstore object.  The advantage of this approach is that it eliminates the duplication of tag data in both the table columns as well as in the `tags` hstore.

The disadvantage of this approach is that the new tag `include` keys will apply across all layers rather than just this one.  If we wish to use this approach, it should be replicated across all layers in order to achieve the space-saving benefits.

(as an aside, this PR also fixes the fact that `name_en` and `name_de` weren't correctly hooked up, however, these fields will likely be removed in a future version so it's probably not even worth extracting to a separate PR to fix.)