### PR TITLE
Simplify SQL used to generalise the landcover layer

### DIFF
--- a/layers/landcover/generalized.sql
+++ b/layers/landcover/generalized.sql
@@ -28,26 +28,12 @@ CREATE INDEX ON simplify_vw_z13 USING GIST (geometry);
 
 CREATE TABLE osm_landcover_gen_z13 AS
 (
-SELECT subclass,
-       ST_MakeValid(
-        (ST_dump(
-         ST_Union(geometry))).geom) AS geometry
-    FROM (
-        SELECT subclass,
-               ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) over () AS cid, geometry
-        FROM simplify_vw_z13
-        WHERE ST_NPoints(geometry) < 50
-          AND subclass IN ('wood', 'forest')) union_geom50
-    GROUP BY subclass,
-             cid
-    UNION ALL
     SELECT subclass, ST_MakeValid((ST_dump(ST_Union(geometry))).geom) AS geometry
     FROM (
         SELECT subclass,
                ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) over () AS cid, geometry
         FROM simplify_vw_z13
-        WHERE ST_NPoints(geometry) >= 50
-          AND ST_NPoints(geometry) < 300
+        WHERE ST_NPoints(geometry) < 300
           AND subclass IN ('wood', 'forest')) union_geom300
     GROUP BY subclass,
              cid
@@ -77,26 +63,12 @@ CREATE INDEX ON simplify_vw_z12 USING GIST (geometry);
 
 CREATE TABLE osm_landcover_gen_z12 AS
 (
-SELECT subclass,
-       ST_MakeValid(
-        (ST_dump(
-         ST_Union(geometry))).geom) AS geometry
-    FROM (
-        SELECT subclass,
-               ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) over () AS cid, geometry
-        FROM simplify_vw_z12
-        WHERE ST_NPoints(geometry) < 50
-          AND subclass IN ('wood', 'forest')) union_geom50
-    GROUP BY subclass,
-             cid
-    UNION ALL
     SELECT subclass, ST_MakeValid((ST_dump(ST_Union(geometry))).geom) AS geometry
     FROM (
         SELECT subclass,
                ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) over () AS cid, geometry
         FROM simplify_vw_z12
-        WHERE ST_NPoints(geometry) >= 50
-          AND ST_NPoints(geometry) < 300
+        WHERE ST_NPoints(geometry) < 300
           AND subclass IN ('wood', 'forest')) union_geom300
     GROUP BY subclass,
              cid
@@ -126,26 +98,12 @@ CREATE INDEX ON simplify_vw_z11 USING GIST (geometry);
 
 CREATE TABLE osm_landcover_gen_z11 AS
 (
-SELECT subclass,
-       ST_MakeValid(
-        (ST_dump(
-         ST_Union(geometry))).geom) AS geometry
-    FROM (
-        SELECT subclass,
-               ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) over () AS cid, geometry
-        FROM simplify_vw_z11
-        WHERE ST_NPoints(geometry) < 50
-          AND subclass IN ('wood', 'forest')) union_geom50
-    GROUP BY subclass,
-             cid
-    UNION ALL
     SELECT subclass, ST_MakeValid((ST_dump(ST_Union(geometry))).geom) AS geometry
     FROM (
         SELECT subclass,
                ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) over () AS cid, geometry
         FROM simplify_vw_z11
-        WHERE ST_NPoints(geometry) >= 50
-          AND ST_NPoints(geometry) < 300
+        WHERE ST_NPoints(geometry) < 300
           AND subclass IN ('wood', 'forest')) union_geom300
     GROUP BY subclass,
              cid
@@ -175,26 +133,12 @@ CREATE INDEX ON simplify_vw_z10 USING GIST (geometry);
 
 CREATE TABLE osm_landcover_gen_z10 AS
 (
-SELECT subclass,
-       ST_MakeValid(
-        (ST_dump(
-         ST_Union(geometry))).geom) AS geometry
-    FROM (
-        SELECT subclass,
-               ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) over () AS cid, geometry
-        FROM simplify_vw_z10
-        WHERE ST_NPoints(geometry) < 50
-          AND subclass IN ('wood', 'forest')) union_geom50
-    GROUP BY subclass,
-             cid
-    UNION ALL
     SELECT subclass, ST_MakeValid((ST_dump(ST_Union(geometry))).geom) AS geometry
     FROM (
         SELECT subclass,
                ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) over () AS cid, geometry
         FROM simplify_vw_z10
-        WHERE ST_NPoints(geometry) >= 50
-          AND ST_NPoints(geometry) < 300
+        WHERE ST_NPoints(geometry) < 300
           AND subclass IN ('wood', 'forest')) union_geom300
     GROUP BY subclass,
              cid
@@ -224,26 +168,12 @@ CREATE INDEX ON simplify_vw_z9 USING GIST (geometry);
 
 CREATE TABLE osm_landcover_gen_z9 AS
 (
-SELECT subclass,
-       ST_MakeValid(
-        (ST_dump(
-         ST_Union(geometry))).geom) AS geometry
-    FROM (
-        SELECT subclass,
-               ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) over () AS cid, geometry
-        FROM simplify_vw_z9
-        WHERE ST_NPoints(geometry) < 50
-          AND subclass IN ('wood', 'forest')) union_geom50
-    GROUP BY subclass,
-             cid
-    UNION ALL
     SELECT subclass, ST_MakeValid((ST_dump(ST_Union(geometry))).geom) AS geometry
     FROM (
         SELECT subclass,
                ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) over () AS cid, geometry
         FROM simplify_vw_z9
-        WHERE ST_NPoints(geometry) >= 50
-          AND ST_NPoints(geometry) < 300
+        WHERE ST_NPoints(geometry) < 300
           AND subclass IN ('wood', 'forest')) union_geom300
     GROUP BY subclass,
              cid


### PR DESCRIPTION
I was reading through the SQL used to generalise the landcover layer ([`layers/landcover/generalized.sql`](https://github.com/openmaptiles/openmaptiles/blob/596f44aa26bf3711cd5775d111105e09a34916a0/layers/landcover/generalized.sql)) and I noticed that when creating the generalised landcover tables for zooms 9-13, the SQL was doing something like this:

```sql
SELECT * FROM simplify_vw_z13 WHERE ST_NPoints(geometry) < 50
UNION ALL
SELECT * FROM simplify_vw_z13 WHERE ST_NPoints(geometry) >= 50 AND ST_NPoints(geometry) < 300
```

As in, the simplification/clustering of landcover generalisations was being done in two steps: once for polygons with fewer than fifty points, and once for polygons with 50+ points.

As far as I can see, there's no benefit to doing this — it's probably just an artefact of the dev work done for the [original pull request](https://github.com/openmaptiles/openmaptiles/pull/1035). Of course, I might be completely missing the reason for clustering polygons into two groups (<50 points and 50+ points). But assuming I haven't, I've created this pull request to simplify the SQL used in the generalisation, merging the two steps into something like this:

```sql
SELECT * FROM simplify_vw_z13 WHERE ST_NPoints(geometry) < 300
```

The effect is to slightly reduce the number of landcover features (polygons with <50 points can now be clustered/unioned with those 50+), and to reduce the time taken to generalise the landcover tables (in a small test using OSM's Iceland data I saw a 7% reduction in the time spent). It doesn't alter the features that are shown on the map.

Builds upon work from commits https://github.com/openmaptiles/openmaptiles/commit/4a1b0afa26f9b9dcd12f796369bf8c121fd60426 and https://github.com/openmaptiles/openmaptiles/commit/da689f9e424dcd2c38aece17ae40b55255a28c4d.