### PR TITLE
Remove unneeded toll code from transportation layer

### DIFF
--- a/layers/transportation/transportation.sql
+++ b/layers/transportation/transportation.sql
@@ -340,7 +340,7 @@ FROM (
                 public_transport,
                 service_value(service) AS service,
                 CASE WHEN access IN ('private', 'no') THEN 'no' END AS access,
-                CASE WHEN toll='yes' THEN true ELSE NULL::boolean END AS toll,
+                toll,
                 is_bridge,
                 is_tunnel,
                 is_ford,

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -32,9 +32,7 @@ SELECT (ST_Dump(ST_LineMerge(ST_Collect(geometry)))).geom AS geometry,
        CASE
            WHEN access IN ('private', 'no') THEN 'no'
            ELSE NULL::text END AS access,
-       CASE
-           WHEN toll = 'yes' THEN true
-           ELSE false END AS toll,
+       toll,
        layer
 FROM osm_highway_linestring_gen_z11
 -- mapping.yaml pre-filter: motorway/trunk/primary/secondary/tertiary, with _link variants, construction, ST_IsValid()


### PR DESCRIPTION
This PR removes unneeded `CASE` clauses which converts `toll` tags to booleans.  However, the `toll` tag is already mapped as a boolean by imposm, therefore this processing can be simplified.