### PR TITLE
Fix unintentional inclusion of tertiary at zoom 9-10

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -62,7 +62,7 @@ SELECT ST_Simplify(geometry, ZRes(12)) AS geometry,
        layer
 FROM osm_transportation_merge_linestring_gen_z11
 WHERE highway NOT IN ('tertiary', 'tertiary_link')
-      OR construction NOT IN ('tertiary', 'tertiary_link')
+      AND construction NOT IN ('tertiary', 'tertiary_link')
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z10_geometry_idx
     ON osm_transportation_merge_linestring_gen_z10 USING gist (geometry);


### PR DESCRIPTION
This PR fixes a bug in the `WHERE` clauses in the transportation layer generalization tables for zoom 10.    The intended behavior of the layer is to suppress `highway=tertiary` and `highway=tertiary_link` at zoom 10 and lower.  However, due to this bug, these objects were not suppressed as intended, because an `OR` was used in the SQL where an `AND` was needed instead.

This bug was inadvertently introduced in #1172 😞 