### PR TITLE
Implement feature IDs and non-locking updates in the transportation layer

### DIFF
--- a/layers/transportation/transportation.sql
+++ b/layers/transportation/transportation.sql
@@ -11,7 +11,7 @@ $$ LANGUAGE SQL IMMUTABLE
 CREATE OR REPLACE FUNCTION layer_transportation(bbox geometry, zoom_level int)
     RETURNS TABLE
             (
-                osm_id    bigint,
+                id        bigint,
                 geometry  geometry,
                 class     text,
                 subclass  text,
@@ -33,7 +33,7 @@ CREATE OR REPLACE FUNCTION layer_transportation(bbox geometry, zoom_level int)
             )
 AS
 $$
-SELECT osm_id,
+SELECT id,
        geometry,
        CASE
            WHEN highway <> '' OR public_transport <> ''
@@ -71,7 +71,7 @@ SELECT osm_id,
        NULLIF(surface, '') AS surface
 FROM (
          -- etldoc: osm_transportation_merge_linestring_gen_z4 -> layer_transportation:z4
-         SELECT osm_id,
+         SELECT id,
                 geometry,
                 highway,
                 construction,
@@ -103,7 +103,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z5 -> layer_transportation:z5
-         SELECT osm_id,
+         SELECT id,
                 geometry,
                 highway,
                 construction,
@@ -135,7 +135,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z6 -> layer_transportation:z6
-         SELECT osm_id,
+         SELECT id,
                 geometry,
                 highway,
                 construction,
@@ -167,7 +167,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z7  ->  layer_transportation:z7
-         SELECT osm_id,
+         SELECT id,
                 geometry,
                 highway,
                 construction,
@@ -199,7 +199,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z8  ->  layer_transportation:z8
-         SELECT osm_id,
+         SELECT id,
                 geometry,
                 highway,
                 construction,
@@ -231,7 +231,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z9  ->  layer_transportation:z9
-         SELECT osm_id,
+         SELECT id,
                 geometry,
                 highway,
                 construction,
@@ -263,7 +263,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z10  ->  layer_transportation:z10
-         SELECT osm_id,
+         SELECT id,
                 geometry,
                 highway,
                 construction,
@@ -295,7 +295,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_transportation_merge_linestring_gen_z11  ->  layer_transportation:z11
-         SELECT osm_id,
+         SELECT id,
                 geometry,
                 highway,
                 construction,
@@ -329,7 +329,7 @@ FROM (
          -- etldoc: osm_highway_linestring  ->  layer_transportation:z12
          -- etldoc: osm_highway_linestring  ->  layer_transportation:z13
          -- etldoc: osm_highway_linestring  ->  layer_transportation:z14_
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 highway,
                 construction,
@@ -372,7 +372,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_railway_linestring_gen_z8  ->  layer_transportation:z8
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -407,7 +407,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_railway_linestring_gen_z9  ->  layer_transportation:z9
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -442,7 +442,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_railway_linestring_gen_z10  ->  layer_transportation:z10
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -476,7 +476,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_railway_linestring_gen_z11  ->  layer_transportation:z11
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -510,7 +510,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_railway_linestring_gen_z12  ->  layer_transportation:z12
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -545,7 +545,7 @@ FROM (
 
          -- etldoc: osm_railway_linestring ->  layer_transportation:z13
          -- etldoc: osm_railway_linestring ->  layer_transportation:z14_
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -580,7 +580,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_aerialway_linestring_gen_z12  ->  layer_transportation:z12
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -613,7 +613,7 @@ FROM (
 
          -- etldoc: osm_aerialway_linestring ->  layer_transportation:z13
          -- etldoc: osm_aerialway_linestring ->  layer_transportation:z14_
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -645,7 +645,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_shipway_linestring_gen_z11  ->  layer_transportation:z11
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -677,7 +677,7 @@ FROM (
          UNION ALL
 
          -- etldoc: osm_shipway_linestring_gen_z12  ->  layer_transportation:z12
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -710,7 +710,7 @@ FROM (
 
          -- etldoc: osm_shipway_linestring ->  layer_transportation:z13
          -- etldoc: osm_shipway_linestring ->  layer_transportation:z14_
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 NULL AS highway,
                 NULL AS construction,
@@ -747,7 +747,7 @@ FROM (
          -- highway linestrings and as polygon
          -- etldoc: osm_highway_polygon ->  layer_transportation:z13
          -- etldoc: osm_highway_polygon ->  layer_transportation:z14_
-         SELECT osm_id,
+         SELECT osm_id AS id,
                 geometry,
                 highway,
                 NULL AS construction,

--- a/layers/transportation/transportation.yaml
+++ b/layers/transportation/transportation.yaml
@@ -195,8 +195,10 @@ layer:
       - unpaved
   datasource:
     geometry_field: geometry
+    key_field: id
+    key_field_as_attribute: no
     srid: 900913
-    query: (SELECT geometry, class, subclass, network, oneway, ramp, brunnel, service, access, toll, layer, level, indoor, bicycle, foot, horse, mtb_scale, surface FROM layer_transportation(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT id, geometry, class, subclass, network, oneway, ramp, brunnel, service, access, toll, layer, level, indoor, bicycle, foot, horse, mtb_scale, surface FROM layer_transportation(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./network_type.sql
   - ./class.sql

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -16,7 +16,7 @@ CREATE INDEX IF NOT EXISTS osm_highway_linestring_highway_partial_idx
 DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z11 CASCADE;
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z11 AS
 (
-SELECT ST_LineMerge(ST_Collect(geometry)) AS geometry,
+SELECT ST_Collect(geometry) AS geometry,
        min(osm_id) AS id,
        highway,
        network,
@@ -29,14 +29,36 @@ SELECT ST_LineMerge(ST_Collect(geometry)) AS geometry,
        foot,
        horse,
        mtb_scale,
-       CASE
-           WHEN access IN ('private', 'no') THEN 'no'
-           ELSE NULL::text END AS access,
+       access,
        toll,
        layer
-FROM osm_highway_linestring_gen_z11
+FROM
+       (
+       SELECT ST_ClusterDBSCAN(geometry, 0, 1) OVER(
+                PARTITION BY highway, network, construction, is_bridge, is_tunnel, is_ford, bicycle, foot, horse, mtb_scale, access, toll, layer
+              ) AS cluster,
+              geometry,
+              osm_id,
+              highway,
+              network,
+              construction,
+              is_bridge,
+              is_tunnel,
+              is_ford,
+              z_order,
+              bicycle,
+              foot,
+              horse,
+              mtb_scale,
+              CASE
+                  WHEN access IN ('private', 'no') THEN 'no'
+                  ELSE NULL::text END AS access,
+              toll,
+              layer
+       FROM osm_highway_linestring_gen_z11
+       ) cluster_query
 -- mapping.yaml pre-filter: motorway/trunk/primary/secondary/tertiary, with _link variants, construction, ST_IsValid()
-GROUP BY highway, network, construction, is_bridge, is_tunnel, is_ford, bicycle, foot, horse, mtb_scale, access, toll, layer
+GROUP BY highway, network, construction, is_bridge, is_tunnel, is_ford, bicycle, foot, horse, mtb_scale, access, toll, layer, cluster
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z11_geometry_idx
     ON osm_transportation_merge_linestring_gen_z11 USING gist (geometry);
@@ -101,7 +123,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z9_id_
 -- etldoc: osm_transportation_merge_linestring_gen_z9 ->  osm_transportation_merge_linestring_gen_z8
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z8 AS
 (
-SELECT ST_Simplify(ST_LineMerge(ST_Collect(geometry)), ZRes(10)) AS geometry,
+SELECT ST_Simplify(ST_Collect(geometry), ZRes(10)) AS geometry,
        min(id) AS id,
        highway,
        network,

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -16,7 +16,7 @@ CREATE INDEX IF NOT EXISTS osm_highway_linestring_highway_partial_idx
 DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z11 CASCADE;
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z11 AS
 (
-SELECT ST_LineMerge(ST_Collect(geometry)) AS geometry,
+SELECT ST_Collect(geometry) AS geometry,
        min(osm_id) AS id,
        highway,
        network,
@@ -29,14 +29,36 @@ SELECT ST_LineMerge(ST_Collect(geometry)) AS geometry,
        foot,
        horse,
        mtb_scale,
-       CASE
-            WHEN access IN ('private', 'no') THEN 'no'
-            ELSE NULL::text END AS access,
+       access,
        toll,
        layer
-FROM osm_highway_linestring_gen_z11
+FROM
+       (
+       SELECT ST_ClusterDBSCAN(geometry, 0, 1) OVER(
+                PARTITION BY highway, network, construction, is_bridge, is_tunnel, is_ford, bicycle, foot, horse, mtb_scale, access, toll, layer
+              ) AS cluster,
+              geometry,
+              osm_id,
+              highway,
+              network,
+              construction,
+              is_bridge,
+              is_tunnel,
+              is_ford,
+              z_order,
+              bicycle,
+              foot,
+              horse,
+              mtb_scale,
+              CASE
+                  WHEN access IN ('private', 'no') THEN 'no'
+                  ELSE NULL::text END AS access,
+              toll,
+              layer
+       FROM osm_highway_linestring_gen_z11
+       ) cluster_query
 -- mapping.yaml pre-filter: motorway/trunk/primary/secondary/tertiary, with _link variants, construction, ST_IsValid()
-GROUP BY highway, network, construction, is_bridge, is_tunnel, is_ford, bicycle, foot, horse, mtb_scale, access, toll, layer
+GROUP BY highway, network, construction, is_bridge, is_tunnel, is_ford, bicycle, foot, horse, mtb_scale, access, toll, layer, cluster
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */;
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z11_geometry_idx
     ON osm_transportation_merge_linestring_gen_z11 USING gist (geometry);

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -17,7 +17,7 @@ DROP MATERIALIZED VIEW IF EXISTS osm_transportation_merge_linestring_gen_z11 CAS
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z11 AS
 (
 SELECT (ST_Dump(ST_LineMerge(ST_Collect(geometry)))).geom AS geometry,
-       NULL::bigint AS osm_id,
+       min(osm_id) AS id,
        highway,
        network,
        construction,
@@ -45,7 +45,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z11_geometry_
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z10 AS
 (
 SELECT ST_Simplify(geometry, ZRes(12)) AS geometry,
-       osm_id,
+       id,
        highway,
        network,
        construction,
@@ -71,7 +71,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z10_geometry_
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z9 AS
 (
 SELECT ST_Simplify(geometry, ZRes(11)) AS geometry,
-       osm_id,
+       id,
        highway,
        network,
        construction,
@@ -96,7 +96,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z9_geometry_i
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z8 AS
 (
 SELECT ST_Simplify(ST_LineMerge(ST_Collect(geometry)), ZRes(10)) AS geometry,
-       NULL::bigint AS osm_id,
+       min(id) AS id,
        highway,
        network,
        construction,
@@ -118,7 +118,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z8_geometry_i
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z7 AS
 (
 SELECT ST_Simplify(geometry, ZRes(9)) AS geometry,
-       osm_id,
+       id,
        highway,
        network,
        construction,
@@ -137,7 +137,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z7_geometry_i
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z6 AS
 (
 SELECT ST_Simplify(geometry, ZRes(8)) AS geometry,
-       osm_id,
+       id,
        highway,
        network,
        construction,
@@ -156,7 +156,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z6_geometry_i
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z5 AS
 (
 SELECT ST_Simplify(geometry, ZRes(7)) AS geometry,
-       osm_id,
+       id,
        highway,
        network,
        construction,
@@ -175,7 +175,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z5_geometry_i
 CREATE MATERIALIZED VIEW osm_transportation_merge_linestring_gen_z4 AS
 (
 SELECT ST_Simplify(geometry, ZRes(6)) AS geometry,
-       osm_id,
+       id,
        highway,
        network,
        construction,


### PR DESCRIPTION
This PR implements feature IDs and non-locking updates for the highway portion of the transportation layer.

Feature IDs are implemented as the OSM id, or the smallest OSM id of a way in a grouped/generalized feature.

Non-locking updates are implemented by changing the REFRESH MATERIALIZED VIEW sequence to REFRESH MATERIALIZED VIEW CONCURRENTLY, with supporting unique indexes that are required for concurrent materialized views.  This will allow updates to happen without locking reads on the the materialized views.

Sanity-check screens shot of an objects in the transportation/transportation_name layer is provided below to show no change in the output data tiles.

**High zoom**:
![image](https://user-images.githubusercontent.com/3254090/141606298-0c04c150-ce27-4529-b190-66478511278c.png)

**Low zoom**:
![image](https://user-images.githubusercontent.com/3254090/141664194-9c1d4d58-b981-41ef-a883-27877c75055d.png)

For consistency, in the SQL layer, columns are named `osm_id` when a record corresponds 1:1 with an OSM feature, and `id` for derived IDs, in this case min(osm_id).

In addition, an unnecessary `ST_Dump` call was removed from the z11 materialized view, which was causing extra records to be created in that view.  This was replaced with simple line merging, which groups together connected features with identical tagging.