### PR TITLE
Remove `STRICT` statement

### DIFF
--- a/layers/transportation/highway_name.sql
+++ b/layers/transportation/highway_name.sql
@@ -9,7 +9,4 @@ SELECT hstore(string_agg(nullif(slice_language_tags(tags ||
                      ''), ','))
                      || get_basic_names(tags, geometry);
 $$ LANGUAGE SQL IMMUTABLE
-                STRICT
                 PARALLEL SAFE;
-
-


### PR DESCRIPTION
Remove `STRICT` statement from `transportation_name_tags` function.

Concurrently with remove `STRICT` from `get_basic_names` and `get_latin_name` in OMT-T

FIX #1319