### PR TITLE
Run `get_basic_name` after `osml10n_street_abbrev_*`

### DIFF
--- a/layers/transportation/highway_name.sql
+++ b/layers/transportation/highway_name.sql
@@ -6,7 +6,6 @@ SELECT hstore(string_agg(nullif(slice_language_tags(tags ||
                        'name:en', CASE WHEN length(name_en) > 15 THEN osml10n_street_abbrev_en(name_en) ELSE NULLIF(name_en, '') END,
                        'name:de', CASE WHEN length(name_de) > 15 THEN osml10n_street_abbrev_de(name_de) ELSE NULLIF(name_de, '') END
                      ]))::text,
-                     ''), ','))
-                     || get_basic_names(tags, geometry);
+                     ''), ','));
 $$ LANGUAGE SQL IMMUTABLE
                 PARALLEL SAFE;

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS osm_transportation_name_network AS
 SELECT
     geometry,
     osm_id,
-    tags,
+    tags || get_basic_names(tags, geometry) AS tags,
     ref,
     highway,
     subclass,

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -8,7 +8,7 @@
 -- etldoc: osm_aerialway_linestring ->  osm_transportation_name_linestring
 CREATE TABLE IF NOT EXISTS osm_transportation_name_linestring AS
 SELECT (ST_Dump(geometry)).geom AS geometry,
-       tags,
+       tags || get_basic_names(tags, geometry) AS tags,
        ref,
        highway,
        subclass,
@@ -278,7 +278,7 @@ BEGIN
     SELECT
         geometry,
         osm_id,
-        tags,
+        tags || get_basic_names(tags, geometry) AS tags,
         ref,
         highway,
         subclass,
@@ -493,7 +493,7 @@ BEGIN
 
     INSERT INTO osm_transportation_name_linestring
     SELECT (ST_Dump(geometry)).geom AS geometry,
-           tags,
+           tags|| get_basic_names(tags, geometry) AS tags,
            ref,
            highway,
            subclass,


### PR DESCRIPTION
PR move `get_basic_names(tags, geometry)` function from `transportation_name_tags` function and adding it after `transportation_name_tags` resolve street abbrevation.

PR runs through `test-sql` test without error. Adding to `osm_transportation_name_network` (table and for update) was done in consequence of `test-sql` errors ([update test 500](https://github.com/openmaptiles/openmaptiles/blob/a747d985508933c9619c9a765efc59d8c5c88085/tests/test-post-update.sql#L53)). Originally `get_basic_names` was just in `osm_transportation_name_linestring` table.

FIX #1324

![seattle_fix](https://user-images.githubusercontent.com/5182210/145085141-7857e97e-9b83-4467-bb98-84cc4a2e0623.png)