### PR TITLE
Remove FILTER_MAPNIK_OUTPUT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,6 @@ services:
       - postgres
     env_file: .env
     environment:
-      FILTER_MAPNIK_OUTPUT: ${FILTER_MAPNIK_OUTPUT}
       MBTILES_NAME: ${MBTILES_FILE}
       # Control tilelive-copy threads
       COPY_CONCURRENCY: ${COPY_CONCURRENCY}
@@ -78,7 +77,6 @@ services:
       - postgres
     env_file: .env
     environment:
-      FILTER_MAPNIK_OUTPUT: ${FILTER_MAPNIK_OUTPUT}
       MBTILES_NAME: ${MBTILES_FILE}
       BBOX: ${BBOX}
       MIN_ZOOM: ${MIN_ZOOM}


### PR DESCRIPTION
Remove `FILTER_MAPNIK_OUTPUT` variables from docker-compose which stop raising warnings during start-up dockers.

This functionality was removed in https://github.com/openmaptiles/openmaptiles-tools/pull/349.

The current version of the mapnik does not need `FILTER_MAPNIK_OUTPUT`.