### PR TITLE
Fix version check in quickstart.sh

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -79,7 +79,7 @@ docker         --version
 docker-compose --version
 
 # based on: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
-function version { echo "$@" | tr -cs '0-9.' '.' | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
+function version { echo "$@" | tr -d 'v' | tr -cs '0-9.' '.' | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
 
 COMPOSE_VER=$(docker-compose version --short)
 if [ "$(version "$COMPOSE_VER")" -lt "$(version "$MIN_COMPOSE_VER")" ]; then


### PR DESCRIPTION
When docker compose returns a version with v prefix,
the version check would incorrectly treat it as version component
of 000, leading to always failing the docker-compose version check
even if the version is recent enough.

This happens at least with docker-compose 2.2.1 where
  docker-compose version --short
returns v2.2.1 with the leading v.
