### PR TITLE
Fix paths and tracks in transportation layer z12 and z13

### DIFF
--- a/layers/transportation/class.sql
+++ b/layers/transportation/class.sql
@@ -67,7 +67,7 @@ SELECT CASE
                 'motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'raceway',
                 'motorway_construction', 'trunk_construction', 'primary_construction',
                 'secondary_construction', 'tertiary_construction', 'raceway_construction',
-                'busway'
+                'busway', 'track'
                ) THEN TRUE --includes ramps
            ELSE FALSE
        END

--- a/layers/transportation/class.sql
+++ b/layers/transportation/class.sql
@@ -67,7 +67,7 @@ SELECT CASE
                 'motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'raceway',
                 'motorway_construction', 'trunk_construction', 'primary_construction',
                 'secondary_construction', 'tertiary_construction', 'raceway_construction',
-                'busway', 'track'
+                'busway'
                ) THEN TRUE --includes ramps
            ELSE FALSE
        END

--- a/layers/transportation/transportation.sql
+++ b/layers/transportation/transportation.sql
@@ -376,15 +376,14 @@ FROM (
            AND
                CASE WHEN zoom_level = 12 THEN
                          CASE WHEN transportation_filter_z12(hl.highway, hl.construction) THEN TRUE
-                              WHEN n.route_rank = 1 THEN TRUE
+                              WHEN hl.highway IN ('track', 'path') THEN n.route_rank = 1
                          END
                     WHEN zoom_level = 13 THEN
                          CASE WHEN man_made='pier' THEN NOT ST_IsClosed(hl.geometry)
-                              WHEN hl.highway = 'path' THEN (
-                                                        hl.name <> ''
-                                                     OR n.route_rank BETWEEN 1 AND 2
-                                                     OR hl.sac_scale <> ''
-                                                   )
+                              WHEN hl.highway IN ('track', 'path') THEN (hl.name <> ''
+                                                                   OR n.route_rank BETWEEN 1 AND 2
+                                                                   OR hl.sac_scale <> ''
+                                                                   )
                               ELSE transportation_filter_z13(hl.highway, public_transport, hl.construction, service)
                          END
                     WHEN zoom_level >= 14 THEN

--- a/layers/transportation/transportation.sql
+++ b/layers/transportation/transportation.sql
@@ -376,15 +376,15 @@ FROM (
            AND
                CASE WHEN zoom_level = 12 THEN
                          CASE WHEN transportation_filter_z12(hl.highway, hl.construction) THEN TRUE
-                              WHEN hl.highway IN ('track', 'path') THEN n.route_rank = 1
+                              WHEN n.route_rank = 1 THEN TRUE
                          END
                     WHEN zoom_level = 13 THEN
                          CASE WHEN man_made='pier' THEN NOT ST_IsClosed(hl.geometry)
-                              WHEN hl.highway IN ('track', 'path') THEN (
-                                                                   hl.name <> ''
-                                                                OR n.route_rank BETWEEN 1 AND 2
-                                                                OR hl.sac_scale <> ''
-                                                                )
+                              WHEN hl.highway = 'path' THEN (
+                                                        hl.name <> ''
+                                                     OR n.route_rank BETWEEN 1 AND 2
+                                                     OR hl.sac_scale <> ''
+                                                   )
                               ELSE transportation_filter_z13(hl.highway, public_transport, hl.construction, service)
                          END
                     WHEN zoom_level >= 14 THEN

--- a/layers/transportation/transportation.sql
+++ b/layers/transportation/transportation.sql
@@ -376,15 +376,15 @@ FROM (
            AND
                CASE WHEN zoom_level = 12 THEN
                          CASE WHEN transportation_filter_z12(hl.highway, hl.construction) THEN TRUE
-                              WHEN n.route_rank = 1 THEN TRUE
+                              WHEN hl.highway IN ('track', 'path') THEN n.route_rank = 1
                          END
                     WHEN zoom_level = 13 THEN
                          CASE WHEN man_made='pier' THEN NOT ST_IsClosed(hl.geometry)
-                              WHEN hl.highway = 'path' THEN (
-                                                        hl.name <> ''
-                                                     OR n.route_rank BETWEEN 1 AND 2
-                                                     OR hl.sac_scale <> ''
-                                                   )
+                              WHEN hl.highway IN ('track', 'path') THEN (
+                                                                   hl.name <> ''
+                                                                OR n.route_rank BETWEEN 1 AND 2
+                                                                OR hl.sac_scale <> ''
+                                                                )
                               ELSE transportation_filter_z13(hl.highway, public_transport, hl.construction, service)
                          END
                     WHEN zoom_level >= 14 THEN


### PR DESCRIPTION
This PR fixes a bug that causes that `track` lines disappear at z13. This bug was introduced in https://github.com/openmaptiles/openmaptiles/pull/1190, which adds rendering of paths and tracks at z12 and z13.

Before this PR:
z12: lines with `route_rank = 1` are added (no matter what `highway`).
z13: lines with `route_rank BETWEEN 1 AND 2` and `highway = 'path'` are added.
-> tracks with `route_rank=1` are added at z12 but not at z13.
GIF of z11, z12, z13, z14
![master](https://user-images.githubusercontent.com/19833762/147885914-cb92241e-e375-494c-8da9-23fc28d8d4af.gif)


After this PR
z12: lines with `route_rank = 1` and `highway IN ('path', 'track')` are added.
z13: lines with `route_rank BETWEEN 1 AND 2` and `highway IN ('path', 'track')` are added .
-> only tracks and paths are added at z12 and z13 (which was IMHO the goal of https://github.com/openmaptiles/openmaptiles/pull/1190)
GIF of z11, z12, z13, z14
![pr](https://user-images.githubusercontent.com/19833762/147885950-17c1f8a7-a94a-4432-8a06-71e9995489c3.gif)

GIF showing the difference at z13.
![diff_z13](https://user-images.githubusercontent.com/19833762/147885986-2b6ab45a-c35b-4fb7-a995-d9d2ef91d68d.gif)

@ZeLonewolf could you please check this PR as it is related to your work? I hope that I understood your goal to add rendering of paths and tracks correctly.
