### PR TITLE
Fix updates on transportation_name layer

### DIFF
--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -475,7 +475,7 @@ BEGIN
     FROM osm_transportation_name_linestring AS n
         USING name_changes_compact AS c
     WHERE coalesce(n.ref, '') = coalesce(c.ref, '')
-      AND n.tags IS NOT DISTINCT FROM c.tags
+      AND coalesce(n.tags, '') = coalesce(c.tags, '')
       AND n.highway IS NOT DISTINCT FROM c.highway
       AND n.subclass IS NOT DISTINCT FROM c.subclass
       AND n.brunnel IS NOT DISTINCT FROM c.brunnel
@@ -522,7 +522,7 @@ BEGIN
         FROM osm_transportation_name_network AS n
             JOIN name_changes_compact AS c ON
                  coalesce(n.ref, '') = coalesce(c.ref, '')
-             AND n.tags IS NOT DISTINCT FROM c.tags
+             AND coalesce(n.tags, '') = coalesce(c.tags, '')
              AND n.highway IS NOT DISTINCT FROM c.highway
              AND n.subclass IS NOT DISTINCT FROM c.subclass
              AND n.brunnel IS NOT DISTINCT FROM c.brunnel
@@ -546,7 +546,7 @@ BEGIN
     USING name_changes_compact AS c
     WHERE
         coalesce(n.tags->'name', n.ref) = c.name_ref
-        AND n.tags IS NOT DISTINCT FROM c.tags
+        AND coalesce(n.tags, '') = coalesce(c.tags, '')
         AND n.ref IS NOT DISTINCT FROM c.ref
         AND n.highway IS NOT DISTINCT FROM c.highway
         AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -564,7 +564,7 @@ BEGIN
     FROM osm_transportation_name_linestring_gen1_view AS n
         JOIN name_changes_compact AS c ON
             coalesce(n.tags->'name', n.ref) = c.name_ref
-            AND n.tags IS NOT DISTINCT FROM c.tags
+            AND coalesce(n.tags, '') = coalesce(c.tags, '')
             AND n.ref IS NOT DISTINCT FROM c.ref
             AND n.highway IS NOT DISTINCT FROM c.highway
             AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -582,7 +582,7 @@ BEGIN
     USING name_changes_compact AS c
     WHERE
         coalesce(n.tags->'name', n.ref) = c.name_ref
-        AND n.tags IS NOT DISTINCT FROM c.tags
+        AND coalesce(n.tags, '') = coalesce(c.tags, '')
         AND n.ref IS NOT DISTINCT FROM c.ref
         AND n.highway IS NOT DISTINCT FROM c.highway
         AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -600,7 +600,7 @@ BEGIN
     FROM osm_transportation_name_linestring_gen2_view AS n
         JOIN name_changes_compact AS c ON
             coalesce(n.tags->'name', n.ref) = c.name_ref
-            AND n.tags IS NOT DISTINCT FROM c.tags
+            AND coalesce(n.tags, '') = coalesce(c.tags, '')
             AND n.ref IS NOT DISTINCT FROM c.ref
             AND n.highway IS NOT DISTINCT FROM c.highway
             AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -618,7 +618,7 @@ BEGIN
     USING name_changes_compact AS c
     WHERE
         coalesce(n.tags->'name', n.ref) = c.name_ref
-        AND n.tags IS NOT DISTINCT FROM c.tags
+        AND coalesce(n.tags, '') = coalesce(c.tags, '')
         AND n.ref IS NOT DISTINCT FROM c.ref
         AND n.highway IS NOT DISTINCT FROM c.highway
         AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -636,7 +636,7 @@ BEGIN
     FROM osm_transportation_name_linestring_gen3_view AS n
         JOIN name_changes_compact AS c ON
             coalesce(n.tags->'name', n.ref) = c.name_ref
-            AND n.tags IS NOT DISTINCT FROM c.tags
+            AND coalesce(n.tags, '') = coalesce(c.tags, '')
             AND n.ref IS NOT DISTINCT FROM c.ref
             AND n.highway IS NOT DISTINCT FROM c.highway
             AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -654,7 +654,7 @@ BEGIN
     USING name_changes_compact AS c
     WHERE
         coalesce(n.tags->'name', n.ref) = c.name_ref
-        AND n.tags IS NOT DISTINCT FROM c.tags
+        AND coalesce(n.tags, '') = coalesce(c.tags, '')
         AND n.ref IS NOT DISTINCT FROM c.ref
         AND n.highway IS NOT DISTINCT FROM c.highway
         AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -672,7 +672,7 @@ BEGIN
     FROM osm_transportation_name_linestring_gen4_view AS n
         JOIN name_changes_compact AS c ON
             coalesce(n.tags->'name', n.ref) = c.name_ref
-            AND n.tags IS NOT DISTINCT FROM c.tags
+            AND coalesce(n.tags, '') = coalesce(c.tags, '')
             AND n.ref IS NOT DISTINCT FROM c.ref
             AND n.highway IS NOT DISTINCT FROM c.highway
             AND n.subclass IS NOT DISTINCT FROM c.subclass


### PR DESCRIPTION
Updates on `transporation_name` layer take much more time than before.

Tested on Switzerland - time to import a single diff (all layers), time to import/update just `transportation_name`  layer
(3.12.2 vs 3.13. vs this PR):

diff  | till data  | 3.12.2 </br> all layers| 3.13 </br> all layers | PR </br> all layers | 3.12.2 </br >transportation_name  | 3.13 </br> transportation_name   | PR </br>transportation_name
--    | --         | --                            |  --                   | --                  | --                                | --                               | --
#3399 | 2022-01-02 | 6m50.073583491s               |  13m17.812631745s     | 7m23.398765657s     | 00:00:01.893855                   | 00:07:58.861602                  | 00:00:13.561437
#3400 | 2022-01-03 | 8m4.75959592s                 |  18m25.170386374s     | 8m7.952587563s      | 00:00:01.964811                   | 00:13:14.77066                   | 00:00:33.339465
#3401 | 2022-01-04 | 9m42.808508614s               |  16m45.069075494s     | 7m58.997389623s     | 00:00:01.186381                   | 00:10:49.560629                  | 00:00:14.200444
#3402 | 2022-01-05 | 9m7.992858106s                |  27m30.221890517s     | 8m39.140444619s     | 00:00:01.469556                   | 00:19:26.266047                  | 00:00:28.535937

In 3.13 there had been introduced highway concurrency into `transportation` and `transportation_name` so I expected the update process will take more time but not that much. Because of this it's impossible to use updates on larger areas because the process takes too long.

The issue is caused by `IS NOT DISTINCT FROM` operator over `tags` (hstore) columns. I replaced it with `=` operator in combination with `coalesce()` function which returns the same results but in shorter time. Tested on https://github.com/openmaptiles/openmaptiles/blob/master/layers/transportation_name/update_transportation_name.sql#L474 and https://github.com/openmaptiles/openmaptiles/blob/master/layers/transportation_name/update_transportation_name.sql#L494 queries.

   | coalesce(n.tags, '') = coalesce(c.tags, '') | n.tags IS NOT DISTINCT FROM c.tags
-- | -- | --
DELETE | DELETE 9557</br>Time: 1437.927 ms (00:01.438) | DELETE 9557</br>Time: 278240.179 ms (04:38.240)
INSERT | INSERT 0 49685</br>Time: 11638.266 ms (00:11.638) | INSERT 0 49685</br>Time: 427126.126 ms (07:07.126)

@zstadler @ZeLonewolf could you please check this as it is related to your work? Thank you very much.
