### PR TITLE
[WIP] Revert #1344 and use in place index

### DIFF
--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -475,7 +475,8 @@ BEGIN
     FROM osm_transportation_name_linestring AS n
         USING name_changes_compact AS c
     WHERE coalesce(n.ref, '') = coalesce(c.ref, '')
-      AND coalesce(n.tags, '') = coalesce(c.tags, '')
+      AND coalesce(n.tags->'name', '') = coalesce(c.tags->'name', '') -- Extra clause to use index
+      AND n.tags IS NOT DISTINCT FROM c.tags
       AND n.highway IS NOT DISTINCT FROM c.highway
       AND n.subclass IS NOT DISTINCT FROM c.subclass
       AND n.brunnel IS NOT DISTINCT FROM c.brunnel
@@ -522,7 +523,8 @@ BEGIN
         FROM osm_transportation_name_network AS n
             JOIN name_changes_compact AS c ON
                  coalesce(n.ref, '') = coalesce(c.ref, '')
-             AND coalesce(n.tags, '') = coalesce(c.tags, '')
+             AND coalesce(n.tags->'name', '') = coalesce(c.tags->'name', '') -- Extra clause to use index
+             AND n.tags IS NOT DISTINCT FROM c.tags
              AND n.highway IS NOT DISTINCT FROM c.highway
              AND n.subclass IS NOT DISTINCT FROM c.subclass
              AND n.brunnel IS NOT DISTINCT FROM c.brunnel
@@ -546,7 +548,7 @@ BEGIN
     USING name_changes_compact AS c
     WHERE
         coalesce(n.tags->'name', n.ref) = c.name_ref
-        AND coalesce(n.tags, '') = coalesce(c.tags, '')
+        AND n.tags IS NOT DISTINCT FROM c.tags
         AND n.ref IS NOT DISTINCT FROM c.ref
         AND n.highway IS NOT DISTINCT FROM c.highway
         AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -564,7 +566,7 @@ BEGIN
     FROM osm_transportation_name_linestring_gen1_view AS n
         JOIN name_changes_compact AS c ON
             coalesce(n.tags->'name', n.ref) = c.name_ref
-            AND coalesce(n.tags, '') = coalesce(c.tags, '')
+            AND n.tags IS NOT DISTINCT FROM c.tags
             AND n.ref IS NOT DISTINCT FROM c.ref
             AND n.highway IS NOT DISTINCT FROM c.highway
             AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -582,7 +584,7 @@ BEGIN
     USING name_changes_compact AS c
     WHERE
         coalesce(n.tags->'name', n.ref) = c.name_ref
-        AND coalesce(n.tags, '') = coalesce(c.tags, '')
+        AND n.tags IS NOT DISTINCT FROM c.tags
         AND n.ref IS NOT DISTINCT FROM c.ref
         AND n.highway IS NOT DISTINCT FROM c.highway
         AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -600,7 +602,7 @@ BEGIN
     FROM osm_transportation_name_linestring_gen2_view AS n
         JOIN name_changes_compact AS c ON
             coalesce(n.tags->'name', n.ref) = c.name_ref
-            AND coalesce(n.tags, '') = coalesce(c.tags, '')
+            AND n.tags IS NOT DISTINCT FROM c.tags
             AND n.ref IS NOT DISTINCT FROM c.ref
             AND n.highway IS NOT DISTINCT FROM c.highway
             AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -618,7 +620,7 @@ BEGIN
     USING name_changes_compact AS c
     WHERE
         coalesce(n.tags->'name', n.ref) = c.name_ref
-        AND coalesce(n.tags, '') = coalesce(c.tags, '')
+        AND n.tags IS NOT DISTINCT FROM c.tags
         AND n.ref IS NOT DISTINCT FROM c.ref
         AND n.highway IS NOT DISTINCT FROM c.highway
         AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -636,7 +638,7 @@ BEGIN
     FROM osm_transportation_name_linestring_gen3_view AS n
         JOIN name_changes_compact AS c ON
             coalesce(n.tags->'name', n.ref) = c.name_ref
-            AND coalesce(n.tags, '') = coalesce(c.tags, '')
+            AND n.tags IS NOT DISTINCT FROM c.tags
             AND n.ref IS NOT DISTINCT FROM c.ref
             AND n.highway IS NOT DISTINCT FROM c.highway
             AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -654,7 +656,7 @@ BEGIN
     USING name_changes_compact AS c
     WHERE
         coalesce(n.tags->'name', n.ref) = c.name_ref
-        AND coalesce(n.tags, '') = coalesce(c.tags, '')
+        AND n.tags IS NOT DISTINCT FROM c.tags
         AND n.ref IS NOT DISTINCT FROM c.ref
         AND n.highway IS NOT DISTINCT FROM c.highway
         AND n.subclass IS NOT DISTINCT FROM c.subclass
@@ -672,7 +674,7 @@ BEGIN
     FROM osm_transportation_name_linestring_gen4_view AS n
         JOIN name_changes_compact AS c ON
             coalesce(n.tags->'name', n.ref) = c.name_ref
-            AND coalesce(n.tags, '') = coalesce(c.tags, '')
+            AND n.tags IS NOT DISTINCT FROM c.tags
             AND n.ref IS NOT DISTINCT FROM c.ref
             AND n.highway IS NOT DISTINCT FROM c.highway
             AND n.subclass IS NOT DISTINCT FROM c.subclass


### PR DESCRIPTION
#1344 try to fix transportation name update issue taking too long.
But it does not address the usage of the index.

Following tests on 1000 random highway in France.

### Before #1344

```sql
explain
    DELETE
    FROM osm_transportation_name_linestring AS n
        USING name_changes_compact AS c
    WHERE coalesce(n.ref, '') = coalesce(c.ref, '')
      AND n.tags IS NOT DISTINCT FROM c.tags
      AND n.highway IS NOT DISTINCT FROM c.highway
      AND n.subclass IS NOT DISTINCT FROM c.subclass
      AND n.brunnel IS NOT DISTINCT FROM c.brunnel
      AND n.sac_scale IS NOT DISTINCT FROM c.sac_scale
      AND n.level IS NOT DISTINCT FROM c.level
      AND n.layer IS NOT DISTINCT FROM c.layer
      AND n.indoor IS NOT DISTINCT FROM c.indoor
      AND n.network IS NOT DISTINCT FROM c.network_type
      AND n.route_1 IS NOT DISTINCT FROM c.route_1
      AND n.route_2 IS NOT DISTINCT FROM c.route_2
      AND n.route_3 IS NOT DISTINCT FROM c.route_3
      AND n.route_4 IS NOT DISTINCT FROM c.route_4
      AND n.route_5 IS NOT DISTINCT FROM c.route_5
      AND n.route_6 IS NOT DISTINCT FROM c.route_6;
```

```
 Delete on osm_transportation_name_linestring n  (cost=1127294.28..1497179.34 rows=1 width=12)
   ->  Merge Join  (cost=1127294.28..1497179.34 rows=1 width=12)
         Merge Cond: (((COALESCE(c.ref, ''::character varying))::text) = (COALESCE(n.ref, ''::text)))
         Join Filter: ((NOT (n.tags IS DISTINCT FROM c.tags)) AND (NOT ((n.highway)::text IS DISTINCT FROM (c.highway)::text)) AND (NOT (n.subclass IS DISTINCT FROM (c.subclass)::text)) AND (NOT (n.brunnel IS DISTINCT FROM (c.brunnel)::te
xt)) AND (NOT ((n.sac_scale)::text IS DISTINCT FROM (c.sac_scale)::text)) AND (NOT (n.level IS DISTINCT FROM c.level)) AND (NOT (n.layer IS DISTINCT FROM c.layer)) AND (NOT (n.indoor IS DISTINCT FROM c.indoor)) AND (NOT (n.network IS DIST
INCT FROM c.network_type)) AND (NOT (n.route_1 IS DISTINCT FROM (c.route_1)::text)) AND (NOT (n.route_2 IS DISTINCT FROM (c.route_2)::text)) AND (NOT (n.route_3 IS DISTINCT FROM (c.route_3)::text)) AND (NOT (n.route_4 IS DISTINCT FROM (c.
route_4)::text)) AND (NOT (n.route_5 IS DISTINCT FROM (c.route_5)::text)) AND (NOT (n.route_6 IS DISTINCT FROM (c.route_6)::text)))
         ->  Sort  (cost=658.05..670.67 rows=5049 width=403)
               Sort Key: ((COALESCE(c.ref, ''::character varying))::text)
               ->  Seq Scan on name_changes_compact c  (cost=0.00..347.49 rows=5049 width=403)
         ->  Materialize  (cost=1126636.23..1140068.87 rows=2686527 width=258)
               ->  Sort  (cost=1126636.23..1133352.55 rows=2686527 width=258)
                     Sort Key: (COALESCE(n.ref, ''::text))
                     ->  Seq Scan on osm_transportation_name_linestring n  (cost=0.00..178608.27 rows=2686527 width=258)
```

Time:  too long


### Now, with #1344

It is not so much better on explain but execution time is.

```sql
explain
    DELETE
    FROM osm_transportation_name_linestring AS n
        USING name_changes_compact AS c
    WHERE coalesce(n.ref, '') = coalesce(c.ref, '')
      AND coalesce(n.tags, '') = coalesce(c.tags, '')
      AND n.highway IS NOT DISTINCT FROM c.highway
      AND n.subclass IS NOT DISTINCT FROM c.subclass
      AND n.brunnel IS NOT DISTINCT FROM c.brunnel
      AND n.sac_scale IS NOT DISTINCT FROM c.sac_scale
      AND n.level IS NOT DISTINCT FROM c.level
      AND n.layer IS NOT DISTINCT FROM c.layer
      AND n.indoor IS NOT DISTINCT FROM c.indoor
      AND n.network IS NOT DISTINCT FROM c.network_type
      AND n.route_1 IS NOT DISTINCT FROM c.route_1
      AND n.route_2 IS NOT DISTINCT FROM c.route_2
      AND n.route_3 IS NOT DISTINCT FROM c.route_3
      AND n.route_4 IS NOT DISTINCT FROM c.route_4
      AND n.route_5 IS NOT DISTINCT FROM c.route_5
      AND n.route_6 IS NOT DISTINCT FROM c.route_6;
```

```
 Delete on osm_transportation_name_linestring n  (cost=1127303.64..1149292.77 rows=1 width=12)
   ->  Merge Join  (cost=1127303.64..1149292.77 rows=1 width=12)
         Merge Cond: (((COALESCE(n.ref, ''::text)) = ((COALESCE(c.ref, ''::character varying))::text)) AND ((COALESCE(n.tags, ''::hstore)) = (COALESCE(c.tags, ''::hstore))))
         Join Filter: ((NOT ((n.highway)::text IS DISTINCT FROM (c.highway)::text)) AND (NOT (n.subclass IS DISTINCT FROM (c.subclass)::text)) AND (NOT (n.brunnel IS DISTINCT FROM (c.brunnel)::text)) AND (NOT ((n.sac_scale)::text IS DISTI
NCT FROM (c.sac_scale)::text)) AND (NOT (n.level IS DISTINCT FROM c.level)) AND (NOT (n.layer IS DISTINCT FROM c.layer)) AND (NOT (n.indoor IS DISTINCT FROM c.indoor)) AND (NOT (n.network IS DISTINCT FROM c.network_type)) AND (NOT (n.rout
e_1 IS DISTINCT FROM (c.route_1)::text)) AND (NOT (n.route_2 IS DISTINCT FROM (c.route_2)::text)) AND (NOT (n.route_3 IS DISTINCT FROM (c.route_3)::text)) AND (NOT (n.route_4 IS DISTINCT FROM (c.route_4)::text)) AND (NOT (n.route_5 IS DIS
TINCT FROM (c.route_5)::text)) AND (NOT (n.route_6 IS DISTINCT FROM (c.route_6)::text)))
         ->  Sort  (cost=1126636.23..1133352.55 rows=2686527 width=258)
               Sort Key: (COALESCE(n.ref, ''::text)), (COALESCE(n.tags, ''::hstore))
               ->  Seq Scan on osm_transportation_name_linestring n  (cost=0.00..178608.27 rows=2686527 width=258)
         ->  Sort  (cost=667.40..680.20 rows=5117 width=403)
               Sort Key: ((COALESCE(c.ref, ''::character varying))::text), (COALESCE(c.tags, ''::hstore))
               ->  Seq Scan on name_changes_compact c  (cost=0.00..352.17 rows=5117 width=403)
```

Time: 28266.749 ms

Insert

```
 Insert on osm_transportation_name_linestring  (cost=2487776.62..2487792.02 rows=1000 width=170)
```

Time: too long

### Actual plus new index

```sql
CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_name_ref_idx_ ON osm_transportation_name_linestring (coalesce(tags, ''), coalesce(ref, ''));
```

```
 Delete on osm_transportation_name_linestring n  (cost=0.56..150366.72 rows=1 width=12)
   ->  Nested Loop  (cost=0.56..150366.72 rows=1 width=12)
         ->  Seq Scan on name_changes_compact c  (cost=0.00..346.32 rows=5032 width=403)
         ->  Index Scan using osm_transportation_name_linestring_name_ref_idx_ on osm_transportation_name_linestring n  (cost=0.56..29.80 rows=1 width=258)
               Index Cond: ((COALESCE(tags, ''::hstore) = COALESCE(c.tags, ''::hstore)) AND (COALESCE(ref, ''::text) = (COALESCE(c.ref, ''::character varying))::text))
               Filter: ((NOT ((highway)::text IS DISTINCT FROM (c.highway)::text)) AND (NOT (subclass IS DISTINCT FROM (c.subclass)::text)) AND (NOT (brunnel IS DISTINCT FROM (c.brunnel)::text)) AND (NOT ((sac_scale)::text IS DISTINCT FRO
M (c.sac_scale)::text)) AND (NOT (level IS DISTINCT FROM c.level)) AND (NOT (layer IS DISTINCT FROM c.layer)) AND (NOT (indoor IS DISTINCT FROM c.indoor)) AND (NOT (network IS DISTINCT FROM c.network_type)) AND (NOT (route_1 IS DISTINCT F
ROM (c.route_1)::text)) AND (NOT (route_2 IS DISTINCT FROM (c.route_2)::text)) AND (NOT (route_3 IS DISTINCT FROM (c.route_3)::text)) AND (NOT (route_4 IS DISTINCT FROM (c.route_4)::text)) AND (NOT (route_5 IS DISTINCT FROM (c.route_5)::t
ext)) AND (NOT (route_6 IS DISTINCT FROM (c.route_6)::text)))
```

Time: 7385.498 ms

Insert

```sql
CREATE INDEX IF NOT EXISTS osm_transportation_name_network_name_ref_idx_ ON osm_transportation_name_network (coalesce(tags, ''), coalesce(ref, ''));
```
```
 Insert on osm_transportation_name_linestring  (cost=178417.10..178432.49 rows=1000 width=170)
```

Time: 106943.798 ms

###  Fixed query using existing index

The existing Index
```sql
CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_name_ref_idx ON osm_transportation_name_linestring (coalesce(tags->'name', ''), coalesce(ref, ''));
```

```sql
explain
    DELETE
    FROM osm_transportation_name_linestring AS n
        USING name_changes_compact AS c
    WHERE coalesce(n.tags->'name', '') = coalesce(c.tags->'name', '') -- Extra clause to use index
      AND coalesce(n.ref, '') = coalesce(c.ref, '')
      AND n.tags IS NOT DISTINCT FROM c.tags
      AND n.highway IS NOT DISTINCT FROM c.highway
      AND n.subclass IS NOT DISTINCT FROM c.subclass
      AND n.brunnel IS NOT DISTINCT FROM c.brunnel
      AND n.sac_scale IS NOT DISTINCT FROM c.sac_scale
      AND n.level IS NOT DISTINCT FROM c.level
      AND n.layer IS NOT DISTINCT FROM c.layer
      AND n.indoor IS NOT DISTINCT FROM c.indoor
      AND n.network IS NOT DISTINCT FROM c.network_type
      AND n.route_1 IS NOT DISTINCT FROM c.route_1
      AND n.route_2 IS NOT DISTINCT FROM c.route_2
      AND n.route_3 IS NOT DISTINCT FROM c.route_3
      AND n.route_4 IS NOT DISTINCT FROM c.route_4
      AND n.route_5 IS NOT DISTINCT FROM c.route_5
      AND n.route_6 IS NOT DISTINCT FROM c.route_6;
```

```
 Delete on osm_transportation_name_linestring n  (cost=0.43..40953.35 rows=1 width=12)
   ->  Nested Loop  (cost=0.43..40953.35 rows=1 width=12)
         ->  Seq Scan on name_changes_compact c  (cost=0.00..356.85 rows=5185 width=403)
         ->  Index Scan using osm_transportation_name_linestring_name_ref_idx on osm_transportation_name_linestring n  (cost=0.43..7.82 rows=1 width=258)
               Index Cond: ((COALESCE((tags -> 'name'::text), ''::text) = COALESCE((c.tags -> 'name'::text), ''::text)) AND (COALESCE(ref, ''::text) = (COALESCE(c.ref, ''::character varying))::text))
               Filter: ((NOT (tags IS DISTINCT FROM c.tags)) AND (NOT ((highway)::text IS DISTINCT FROM (c.highway)::text)) AND (NOT (subclass IS DISTINCT FROM (c.subclass)::text)) AND (NOT (brunnel IS DISTINCT FROM (c.brunnel)::text)) AN
D (NOT ((sac_scale)::text IS DISTINCT FROM (c.sac_scale)::text)) AND (NOT (level IS DISTINCT FROM c.level)) AND (NOT (layer IS DISTINCT FROM c.layer)) AND (NOT (indoor IS DISTINCT FROM c.indoor)) AND (NOT (network IS DISTINCT FROM c.netwo
rk_type)) AND (NOT (route_1 IS DISTINCT FROM (c.route_1)::text)) AND (NOT (route_2 IS DISTINCT FROM (c.route_2)::text)) AND (NOT (route_3 IS DISTINCT FROM (c.route_3)::text)) AND (NOT (route_4 IS DISTINCT FROM (c.route_4)::text)) AND (NOT
 (route_5 IS DISTINCT FROM (c.route_5)::text)) AND (NOT (route_6 IS DISTINCT FROM (c.route_6)::text)))
```

Time: 7186.550 ms

Insert

The existing Index
```sql
CREATE INDEX IF NOT EXISTS osm_transportation_name_network_name_ref_idx ON osm_transportation_name_network (coalesce(tags->'name', ''), coalesce(ref, ''));
```

```
 Insert on osm_transportation_name_linestring  (cost=40788.35..40803.74 rows=1000 width=170)
```

Time: 95274.221 ms


This PR is a bit faster than fixing index of current code.

cc @lazaa32 @nyurik @ZeLonewolf