### PR TITLE
Allow non-default `PGPORT`

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@
 TILESET_FILE=openmaptiles.yaml
 
 # Use 3-part patch version to ignore patch updates, e.g. 5.0.0
-TOOLS_VERSION=6.1
+TOOLS_VERSION=latest
 
 # Make sure these values are in sync with the ones in .env-postgres file
 PGDATABASE=openmaptiles

--- a/.env-postgres
+++ b/.env-postgres
@@ -1,8 +1,0 @@
-# This file defines environment variables for the PostgreSQL image.
-# The main docker PostgreSQL image requires these vars rather than
-# the standard PG* ones that all PostgreSQL tools use.
-
-# Make sure these values are in sync with the ones in .env file
-POSTGRES_DB=openmaptiles
-POSTGRES_USER=openmaptiles
-POSTGRES_PASSWORD=openmaptiles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,14 @@ services:
     networks:
       - postgres
     ports:
-      - "5432"
-    env_file: .env-postgres
+      - "${PGPORT:-5432}:${PGPORT:-5432}"
+    env_file: .env
+    environment:
+      # postgress container uses old variable names
+      POSTGRES_DB: ${PGDATABASE:-openmaptiles}
+      POSTGRES_USER: ${PGUSER:-openmaptiles}
+      POSTGRES_PASSWORD: ${PGPASSWORD:-openmaptiles}
+      PGPORT: ${PGPORT:-5432}
 
   import-data:
     image: "openmaptiles/import-data:${TOOLS_VERSION}"
@@ -44,6 +50,10 @@ services:
       IMPOSM_CONFIG_FILE: ${IMPOSM_CONFIG_FILE}
       # Control import-sql processes
       MAX_PARALLEL_PSQL: ${MAX_PARALLEL_PSQL}
+      PGDATABASE: ${PGDATABASE:-openmaptiles}
+      PGUSER: ${PGUSER:-openmaptiles}
+      PGPASSWORD: ${PGPASSWORD:-openmaptiles}
+      PGPORT: ${PGPORT:-5432}
     networks:
       - postgres
     volumes:
@@ -71,6 +81,10 @@ services:
       MBTILES_NAME: ${MBTILES_FILE}
       # Control tilelive-copy threads
       COPY_CONCURRENCY: ${COPY_CONCURRENCY}
+      PGDATABASE: ${PGDATABASE:-openmaptiles}
+      PGUSER: ${PGUSER:-openmaptiles}
+      PGPASSWORD: ${PGPASSWORD:-openmaptiles}
+      PGPORT: ${PGPORT:-5432}
 
   generate-vectortiles:
     image: "openmaptiles/generate-vectortiles:${TOOLS_VERSION}"
@@ -88,6 +102,10 @@ services:
       # Control tilelive-copy threads
       COPY_CONCURRENCY: ${COPY_CONCURRENCY}
       #
+      PGDATABASE: ${PGDATABASE:-openmaptiles}
+      PGUSER: ${PGUSER:-openmaptiles}
+      PGPASSWORD: ${PGPASSWORD:-openmaptiles}
+      PGPORT: ${PGPORT:-5432}
 
   postserve:
     image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"


### PR DESCRIPTION
Also

- Remove `.env-postgres` and the need to synchronize it with `.env`
- Allow use of environment variables in addition to `.env`

Resolves #1354
Related to https://github.com/openmaptiles/openmaptiles-tools/pull/403