### PR TITLE
Add OSM ID to the lakes

### DIFF
--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -57,7 +57,7 @@ WITH name_match AS
         osm.osm_id,
         (ST_Area(ST_Intersection(ne.geometry, osm.geometry))/ST_Area(ne.geometry)) AS area_ratio
 	FROM ne_10m_lakes ne, osm_water_polygon_gen_z6 osm
-	WHERE ST_Intersects(ne.geometry,osm.geometry)
+	WHERE ST_Intersects(ne.geometry, osm.geometry)
         AND ne.ne_id NOT IN 
             (   SELECT ne_id 
                 FROM name_match
@@ -555,11 +555,11 @@ CREATE INDEX ON water_z12 USING gist(geometry);
 
 -- etldoc: layer_water [shape=record fillcolor=lightpink, style="rounded,filled",
 -- etldoc:     label="layer_water |<z0> z0|<z1>z1|<z2>z2|<z3>z3 |<z4> z4|<z5>z5|<z6>z6|<z7>z7| <z8> z8 |<z9> z9 |<z10> z10 |<z11> z11 |<z12> z12+" ] ;
-DROP FUNCTION IF EXISTS layer_water(geometry, integer);
+
 CREATE OR REPLACE FUNCTION layer_water(bbox geometry, zoom_level int)
     RETURNS TABLE
             (
-                osm_id           bigint,
+                osm_id       bigint,
                 geometry     geometry,
                 class        text,
                 brunnel      text,

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -82,7 +82,7 @@ FROM geom_match
 DROP MATERIALIZED VIEW IF EXISTS ne_10m_ocean_gen_z5 CASCADE;
 CREATE MATERIALIZED VIEW ne_10m_ocean_gen_z5 AS
 (
-SELECT  NULL::integer AS osm_id,
+SELECT  NULL::integer AS id,
        (ST_Dump(ST_Simplify(geometry, ZRes(7)))).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -97,7 +97,7 @@ CREATE INDEX IF NOT EXISTS ne_10m_ocean_gen_z5_idx ON ne_10m_ocean_gen_z5 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_10m_lakes_gen_z5 CASCADE;
 CREATE MATERIALIZED VIEW ne_10m_lakes_gen_z5 AS
 (
-SELECT COALESCE(osm.osm_id, ne_id) AS osm_id,
+SELECT COALESCE(osm.osm_id, ne_id) AS id,
         -- Union fixing e.g. Lake Huron and Georgian Bay duplicity 
        (ST_Dump(ST_MakeValid(ST_Simplify(ST_Union(geometry), ZRes(7))))).geom AS geometry,
        'lake'::text AS class,
@@ -114,7 +114,7 @@ CREATE INDEX IF NOT EXISTS ne_10m_lakes_gen_z5_idx ON ne_10m_lakes_gen_z5 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_10m_lakes_gen_z4 CASCADE;
 CREATE MATERIALIZED VIEW ne_10m_lakes_gen_z4 AS
 (
-SELECT osm_id,
+SELECT id,
        (ST_Dump(ST_MakeValid(ST_Simplify(geometry, ZRes(6))))).geom AS geometry,
        class,
        is_intermittent,
@@ -129,7 +129,7 @@ CREATE INDEX IF NOT EXISTS ne_10m_lakes_gen_z4_idx ON ne_10m_lakes_gen_z4 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_50m_ocean_gen_z4 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_ocean_gen_z4 AS
 (
-SELECT NULL::integer AS osm_id,
+SELECT NULL::integer AS id,
        (ST_Dump(ST_Simplify(geometry, ZRes(6)))).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -143,7 +143,7 @@ CREATE INDEX IF NOT EXISTS ne_50m_ocean_gen_z4_idx ON ne_50m_ocean_gen_z4 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_50m_ocean_gen_z3 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_ocean_gen_z3 AS
 (
-SELECT osm_id,
+SELECT id,
        ST_Simplify(geometry, ZRes(5)) AS geometry,
        class,
        is_intermittent,
@@ -157,7 +157,7 @@ CREATE INDEX IF NOT EXISTS ne_50m_ocean_gen_z3_idx ON ne_50m_ocean_gen_z3 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_50m_ocean_gen_z2 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_ocean_gen_z2 AS
 (
-SELECT osm_id,
+SELECT id,
        ST_Simplify(geometry, ZRes(4)) AS geometry,
        class,
        is_intermittent,
@@ -172,7 +172,7 @@ CREATE INDEX IF NOT EXISTS ne_50m_ocean_gen_z2_idx ON ne_50m_ocean_gen_z2 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_50m_lakes_gen_z3 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_lakes_gen_z3 AS
 (
-SELECT COALESCE(osm.osm_id, ne_id) AS osm_id,
+SELECT COALESCE(osm.osm_id, ne_id) AS id,
        (ST_Dump(ST_MakeValid(ST_Simplify(geometry, ZRes(5))))).geom AS geometry,
        'lake'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -187,7 +187,7 @@ CREATE INDEX IF NOT EXISTS ne_50m_lakes_gen_z3_idx ON ne_50m_lakes_gen_z3 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_50m_lakes_gen_z2 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_lakes_gen_z2 AS
 (
-SELECT osm_id,
+SELECT id,
        (ST_Dump(ST_MakeValid(ST_Simplify(geometry, ZRes(4))))).geom AS geometry,
        class,
        is_intermittent,
@@ -202,7 +202,7 @@ CREATE INDEX IF NOT EXISTS ne_50m_lakes_gen_z2_idx ON ne_50m_lakes_gen_z2 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_110m_ocean_gen_z1 CASCADE;
 CREATE MATERIALIZED VIEW ne_110m_ocean_gen_z1 AS
 (
-SELECT NULL::integer AS osm_id,
+SELECT NULL::integer AS id,
        ST_Simplify(geometry, ZRes(3)) AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -216,7 +216,7 @@ CREATE INDEX IF NOT EXISTS ne_110m_ocean_gen_z1_idx ON ne_110m_ocean_gen_z1 USIN
 DROP MATERIALIZED VIEW IF EXISTS ne_110m_ocean_gen_z0 CASCADE;
 CREATE MATERIALIZED VIEW ne_110m_ocean_gen_z0 AS
 (
-SELECT osm_id,
+SELECT id,
        ST_Simplify(geometry, ZRes(2)) AS geometry,
        class,
        is_intermittent,
@@ -232,7 +232,7 @@ CREATE INDEX IF NOT EXISTS ne_110m_ocean_gen_z0_idx ON ne_110m_ocean_gen_z0 USIN
 DROP MATERIALIZED VIEW IF EXISTS ne_110m_lakes_gen_z1 CASCADE;
 CREATE MATERIALIZED VIEW ne_110m_lakes_gen_z1 AS
 (
-SELECT COALESCE(osm.osm_id, ne_id) AS osm_id,
+SELECT COALESCE(osm.osm_id, ne_id) AS id,
        (ST_Dump(ST_Simplify(geometry, ZRes(3)))).geom AS geometry,
        'lake'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -247,7 +247,7 @@ CREATE INDEX IF NOT EXISTS ne_110m_lakes_gen_z1_idx ON ne_110m_lakes_gen_z1 USIN
 DROP MATERIALIZED VIEW IF EXISTS ne_110m_lakes_gen_z0 CASCADE;
 CREATE MATERIALIZED VIEW ne_110m_lakes_gen_z0 AS
 (
-SELECT osm_id,
+SELECT id,
        (ST_Dump(ST_Simplify(geometry, ZRes(2)))).geom AS geometry,
        class,
        is_intermittent,
@@ -268,7 +268,7 @@ DROP MATERIALIZED VIEW IF EXISTS water_z12;
 CREATE OR REPLACE VIEW water_z0 AS
 (
 -- etldoc:  ne_110m_ocean_gen_z0 ->  water_z0
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -277,7 +277,7 @@ SELECT osm_id,
 FROM ne_110m_ocean_gen_z0
 UNION ALL
 -- etldoc:  ne_110m_lakes_gen_z0 ->  water_z0
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -289,7 +289,7 @@ FROM ne_110m_lakes_gen_z0
 CREATE OR REPLACE VIEW water_z1 AS
 (
 -- etldoc:  ne_110m_ocean_gen_z1 ->  water_z1
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -298,7 +298,7 @@ SELECT osm_id,
 FROM ne_110m_ocean_gen_z1
 UNION ALL
 -- etldoc:  ne_110m_lakes_gen_z1 ->  water_z1
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -310,7 +310,7 @@ FROM ne_110m_lakes_gen_z1
 CREATE OR REPLACE VIEW water_z2 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z2 ->  water_z2
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -319,7 +319,7 @@ SELECT osm_id,
 FROM ne_50m_ocean_gen_z2
 UNION ALL
 -- etldoc:  ne_50m_lakes_gen_z2 ->  water_z2
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -331,7 +331,7 @@ FROM ne_50m_lakes_gen_z2
 CREATE OR REPLACE VIEW water_z3 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z3 ->  water_z3
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -340,7 +340,7 @@ SELECT osm_id,
 FROM ne_50m_ocean_gen_z3
 UNION ALL
 -- etldoc:  ne_50m_lakes_gen_z3 ->  water_z3
-SELECT osm_id, 
+SELECT id, 
        geometry,
        class,
        is_intermittent,
@@ -352,7 +352,7 @@ FROM ne_50m_lakes_gen_z3
 CREATE OR REPLACE VIEW water_z4 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z4 ->  water_z4
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -361,7 +361,7 @@ SELECT osm_id,
 FROM ne_50m_ocean_gen_z4
 UNION ALL
 -- etldoc:  ne_10m_lakes_gen_z4 ->  water_z4
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -374,7 +374,7 @@ FROM ne_10m_lakes_gen_z4
 CREATE OR REPLACE VIEW water_z5 AS
 (
 -- etldoc:  ne_10m_ocean_gen_z5 ->  water_z5
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -383,7 +383,7 @@ SELECT osm_id,
 FROM ne_10m_ocean_gen_z5
 UNION ALL
 -- etldoc:  ne_10m_lakes_gen_z5 ->  water_z5
-SELECT osm_id,
+SELECT id,
        geometry,
        class,
        is_intermittent,
@@ -395,7 +395,7 @@ FROM ne_10m_lakes_gen_z5
 CREATE MATERIALIZED VIEW water_z6 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z6 ->  water_z6
-SELECT NULL::integer AS osm_id,
+SELECT NULL::integer AS id,
        (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -404,7 +404,7 @@ SELECT NULL::integer AS osm_id,
 FROM osm_ocean_polygon_gen_z6
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z6 ->  water_z6
-SELECT osm_id,
+SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
        water_class(waterway, water) AS class,
        is_intermittent,
@@ -418,7 +418,7 @@ CREATE INDEX ON water_z6 USING gist(geometry);
 CREATE MATERIALIZED VIEW water_z7 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z7 ->  water_z7
-SELECT NULL::integer AS osm_id,
+SELECT NULL::integer AS id,
        (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -427,7 +427,7 @@ SELECT NULL::integer AS osm_id,
 FROM osm_ocean_polygon_gen_z7
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z7 ->  water_z7
-SELECT osm_id,
+SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
        water_class(waterway, water) AS class,
        is_intermittent,
@@ -441,7 +441,7 @@ CREATE INDEX ON water_z7 USING gist(geometry);
 CREATE MATERIALIZED VIEW water_z8 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z8 ->  water_z8
-SELECT NULL::integer AS osm_id,
+SELECT NULL::integer AS id,
        (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -450,7 +450,7 @@ SELECT NULL::integer AS osm_id,
 FROM osm_ocean_polygon_gen_z8
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z8 ->  water_z8
-SELECT osm_id,
+SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
        water_class(waterway, water) AS class,
        is_intermittent,
@@ -464,7 +464,7 @@ CREATE INDEX ON water_z8 USING gist(geometry);
 CREATE MATERIALIZED VIEW water_z9 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z9 ->  water_z9
-SELECT NULL::integer AS osm_id,
+SELECT NULL::integer AS id,
        (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -473,7 +473,7 @@ SELECT NULL::integer AS osm_id,
 FROM osm_ocean_polygon_gen_z9
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z9 ->  water_z9
-SELECT osm_id,
+SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
        water_class(waterway, water) AS class,
        is_intermittent,
@@ -487,7 +487,7 @@ CREATE INDEX ON water_z9 USING gist(geometry);
 CREATE MATERIALIZED VIEW water_z10 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z10 ->  water_z10
-SELECT NULL::integer AS osm_id,
+SELECT NULL::integer AS id,
        (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -496,7 +496,7 @@ SELECT NULL::integer AS osm_id,
 FROM osm_ocean_polygon_gen_z10
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z10 ->  water_z10
-SELECT osm_id,
+SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
        water_class(waterway, water) AS class,
        is_intermittent,
@@ -510,7 +510,7 @@ CREATE INDEX ON water_z10 USING gist(geometry);
 CREATE MATERIALIZED VIEW water_z11 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z11 ->  water_z11
-SELECT NULL::integer AS osm_id,
+SELECT NULL::integer AS id,
        (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -519,7 +519,7 @@ SELECT NULL::integer AS osm_id,
 FROM osm_ocean_polygon_gen_z11
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z11 ->  water_z11
-SELECT osm_id,
+SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
        water_class(waterway, water) AS class,
        is_intermittent,
@@ -533,7 +533,7 @@ CREATE INDEX ON water_z11 USING gist(geometry);
 CREATE MATERIALIZED VIEW water_z12 AS
 (
 -- etldoc:  osm_ocean_polygon_union ->  water_z12
-SELECT NULL::integer AS osm_id,
+SELECT NULL::integer AS id,
        (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
@@ -542,7 +542,7 @@ SELECT NULL::integer AS osm_id,
 FROM osm_ocean_polygon_union
 UNION ALL
 -- etldoc:  osm_water_polygon ->  water_z12
-SELECT osm_id,
+SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
        water_class(waterway, water) AS class,
        is_intermittent,
@@ -559,7 +559,7 @@ CREATE INDEX ON water_z12 USING gist(geometry);
 CREATE OR REPLACE FUNCTION layer_water(bbox geometry, zoom_level int)
     RETURNS TABLE
             (
-                osm_id       bigint,
+                id           bigint,
                 geometry     geometry,
                 class        text,
                 brunnel      text,
@@ -567,7 +567,7 @@ CREATE OR REPLACE FUNCTION layer_water(bbox geometry, zoom_level int)
             )
 AS
 $$
-SELECT osm_id,
+SELECT id,
        geometry,
        class::text,
        waterway_brunnel(is_bridge, is_tunnel) AS brunnel,

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -20,37 +20,17 @@ $$ LANGUAGE SQL IMMUTABLE
                 PARALLEL SAFE;
 
 -- Add ne_id for missing ne_50m_lakes.
-WITH zero_ne_id AS 
-(
-    SELECT wikidataid 
-    FROM ne_50m_lakes 
-    WHERE ne_id = 0
-)
 UPDATE ne_50m_lakes SET ne_id = ne_10m_lakes.ne_id
-FROM zero_ne_id
+FROM ne_50m_lakes lakes
 LEFT JOIN ne_10m_lakes USING (wikidataid)
-WHERE ne_50m_lakes.wikidataid = ne_10m_lakes.wikidataid;
+WHERE   ne_50m_lakes.wikidataid = ne_10m_lakes.wikidataid
+    AND ne_50m_lakes.ne_id = 0;
 
--- Update ne_110_lakes ne_id where two lakes have identical attributes.
-WITH filter_1159113251 AS 
-(
-    SELECT ne_id 
-    FROM ne_110m_lakes 
-    WHERE ne_id = 1159113251
-)
+-- Update ne_110_lakes ne_id where two lakes (Lake Onega) have identical attributes.
+-- New ne_id is taken from ne_50m_lakes
 UPDATE ne_110m_lakes SET ne_id = 1159126421
-FROM filter_1159113251
-WHERE ST_Equals(geometry, ST_GeomFromText('POLYGON((-12483229.3144705 5033360.527372767,
-                                                    -12486922.479901155 4990456.714552536,
-                                                    -12543349.675710004 5031607.5852004215,
-                                                    -12546318.014280442 5037085.149542927,
-                                                    -12565537.431264574 5105440.89686128,
-                                                    -12533412.069352603 5077299.122474826,
-                                                    -12512904.071283631 5062328.071020125,
-                                                    -12492163.093152434 5075760.691117508,
-                                                    -12488271.463224344 5062806.938351084,
-                                                    -12483229.3144705 5033360.527372767))',3857)
-);
+WHERE   ne_id = 1159113251
+    AND ST_Area(geometry) < 10000000000;
 
 -- Get matching osm id for natural earth id.
 DROP MATERIALIZED VIEW IF EXISTS match_osm_ne_id CASCADE;

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -400,6 +400,7 @@ SELECT osm_id,
        is_bridge,
        is_tunnel
 FROM ne_10m_lakes_gen_z4
+WHERE ST_GeometryType(geometry) != 'ST_LineString'
     );
 CREATE INDEX ON water_z4 USING gist(geometry);
 
@@ -423,6 +424,7 @@ SELECT osm_id,
        is_bridge,
        is_tunnel
 FROM ne_10m_lakes_gen_z5
+WHERE ST_GeometryType(geometry) != 'ST_LineString'
     );
 CREATE INDEX ON water_z5 USING gist(geometry);
 

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -19,12 +19,91 @@ $$ LANGUAGE SQL IMMUTABLE
                 STRICT
                 PARALLEL SAFE;
 
+-- Add ne_id for missing ne_50m_lakes.
+WITH zero_ne_id AS 
+(
+    SELECT wikidataid 
+    FROM ne_50m_lakes 
+    WHERE ne_id = 0
+)
+UPDATE ne_50m_lakes SET ne_id = ne_10m_lakes.ne_id
+FROM zero_ne_id
+LEFT JOIN ne_10m_lakes USING (wikidataid)
+WHERE ne_50m_lakes.wikidataid = ne_10m_lakes.wikidataid;
+
+-- Update ne_110_lakes ne_id where two lakes have identical attributes.
+WITH filter_1159113251 AS 
+(
+    SELECT ne_id 
+    FROM ne_110m_lakes 
+    WHERE ne_id = 1159113251
+)
+UPDATE ne_110m_lakes SET ne_id = 1159126421
+FROM filter_1159113251
+WHERE ST_Equals(geometry, ST_GeomFromText('POLYGON((-12483229.3144705 5033360.527372767,
+                                                    -12486922.479901155 4990456.714552536,
+                                                    -12543349.675710004 5031607.5852004215,
+                                                    -12546318.014280442 5037085.149542927,
+                                                    -12565537.431264574 5105440.89686128,
+                                                    -12533412.069352603 5077299.122474826,
+                                                    -12512904.071283631 5062328.071020125,
+                                                    -12492163.093152434 5075760.691117508,
+                                                    -12488271.463224344 5062806.938351084,
+                                                    -12483229.3144705 5033360.527372767))',3857)
+);
+
+-- Get matching osm id for natural earth id.
+DROP MATERIALIZED VIEW IF EXISTS match_osm_ne_id CASCADE;
+CREATE MATERIALIZED VIEW match_osm_ne_id AS
+(
+WITH name_match AS
+    (
+        -- Distinct on keeps just the first occurence -> order by 'area_ratio DESC'.
+    SELECT DISTINCT ON (ne.ne_id) 
+        ne.ne_id,
+        osm.osm_id,
+        (ST_Area(ST_Intersection(ne.geometry, osm.geometry))/ST_Area(ne.geometry)) AS area_ratio
+    FROM ne_10m_lakes ne, osm_water_polygon_gen_z6 osm
+    WHERE ne.name = osm.name 
+        AND ST_Intersects(ne.geometry, osm.geometry)
+    ORDER BY ne_id,
+             area_ratio DESC
+    ),
+        -- Add lakes which are not match by name, but intersects. 
+        -- Duplicity solves 'DISTICT ON' with 'area_ratio'.
+    geom_match AS
+    (SELECT DISTINCT ON (ne.ne_id) 
+        ne.ne_id,
+        osm.osm_id,
+        (ST_Area(ST_Intersection(ne.geometry, osm.geometry))/ST_Area(ne.geometry)) AS area_ratio
+	FROM ne_10m_lakes ne, osm_water_polygon_gen_z6 osm
+	WHERE ST_Intersects(ne.geometry,osm.geometry)
+        AND ne.ne_id NOT IN 
+            (   SELECT ne_id 
+                FROM name_match
+            )
+    ORDER BY ne_id,
+             area_ratio DESC
+    )
+ 
+SELECT  ne_id,
+        osm_id 
+FROM name_match
+
+UNION
+
+SELECT  ne_id,
+        osm_id 
+FROM geom_match
+);
+
 -- ne_10m_ocean
 -- etldoc:  ne_10m_ocean ->  ne_10m_ocean_gen_z5
 DROP MATERIALIZED VIEW IF EXISTS ne_10m_ocean_gen_z5 CASCADE;
 CREATE MATERIALIZED VIEW ne_10m_ocean_gen_z5 AS
 (
-SELECT ST_Simplify(geometry, ZRes(7)) AS geometry,
+SELECT  NULL::integer AS osm_id,
+       (ST_Dump(ST_Simplify(geometry, ZRes(7)))).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -38,13 +117,16 @@ CREATE INDEX IF NOT EXISTS ne_10m_ocean_gen_z5_idx ON ne_10m_ocean_gen_z5 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_10m_lakes_gen_z5 CASCADE;
 CREATE MATERIALIZED VIEW ne_10m_lakes_gen_z5 AS
 (
-SELECT ogc_fid,
-       ST_MakeValid(ST_Simplify(geometry, ZRes(7))) AS geometry,
+SELECT COALESCE(osm.osm_id, ne_id) AS osm_id,
+        -- Union fixing e.g. Lake Huron and Georgian Bay duplicity 
+       (ST_Dump(ST_MakeValid(ST_Simplify(ST_Union(geometry), ZRes(7))))).geom AS geometry,
        'lake'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
 FROM ne_10m_lakes
+LEFT JOIN match_osm_ne_id osm USING (ne_id)
+GROUP BY COALESCE(osm.osm_id, ne_id), is_intermittent, is_bridge, is_tunnel
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
 CREATE INDEX IF NOT EXISTS ne_10m_lakes_gen_z5_idx ON ne_10m_lakes_gen_z5 USING gist (geometry);
 
@@ -52,8 +134,8 @@ CREATE INDEX IF NOT EXISTS ne_10m_lakes_gen_z5_idx ON ne_10m_lakes_gen_z5 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_10m_lakes_gen_z4 CASCADE;
 CREATE MATERIALIZED VIEW ne_10m_lakes_gen_z4 AS
 (
-SELECT ogc_fid,
-       ST_MakeValid(ST_Simplify(geometry, ZRes(6))) AS geometry,
+SELECT osm_id,
+       (ST_Dump(ST_MakeValid(ST_Simplify(geometry, ZRes(6))))).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -67,7 +149,8 @@ CREATE INDEX IF NOT EXISTS ne_10m_lakes_gen_z4_idx ON ne_10m_lakes_gen_z4 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_50m_ocean_gen_z4 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_ocean_gen_z4 AS
 (
-SELECT ST_Simplify(geometry, ZRes(6)) AS geometry,
+SELECT NULL::integer AS osm_id,
+       (ST_Dump(ST_Simplify(geometry, ZRes(6)))).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -80,7 +163,8 @@ CREATE INDEX IF NOT EXISTS ne_50m_ocean_gen_z4_idx ON ne_50m_ocean_gen_z4 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_50m_ocean_gen_z3 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_ocean_gen_z3 AS
 (
-SELECT ST_Simplify(geometry, ZRes(5)) AS geometry,
+SELECT osm_id,
+       ST_Simplify(geometry, ZRes(5)) AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -93,7 +177,8 @@ CREATE INDEX IF NOT EXISTS ne_50m_ocean_gen_z3_idx ON ne_50m_ocean_gen_z3 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_50m_ocean_gen_z2 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_ocean_gen_z2 AS
 (
-SELECT ST_Simplify(geometry, ZRes(4)) AS geometry,
+SELECT osm_id,
+       ST_Simplify(geometry, ZRes(4)) AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -107,13 +192,14 @@ CREATE INDEX IF NOT EXISTS ne_50m_ocean_gen_z2_idx ON ne_50m_ocean_gen_z2 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_50m_lakes_gen_z3 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_lakes_gen_z3 AS
 (
-SELECT ogc_fid,
+SELECT COALESCE(osm.osm_id, ne_id) AS osm_id,
        ST_MakeValid(ST_Simplify(geometry, ZRes(5))) AS geometry,
        'lakes'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
 FROM ne_50m_lakes
+LEFT JOIN match_osm_ne_id osm USING (ne_id)
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
 CREATE INDEX IF NOT EXISTS ne_50m_lakes_gen_z3_idx ON ne_50m_lakes_gen_z3 USING gist (geometry);
 
@@ -121,7 +207,7 @@ CREATE INDEX IF NOT EXISTS ne_50m_lakes_gen_z3_idx ON ne_50m_lakes_gen_z3 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_50m_lakes_gen_z2 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_lakes_gen_z2 AS
 (
-SELECT ogc_fid,
+SELECT osm_id,
        ST_MakeValid(ST_Simplify(geometry, ZRes(4))) AS geometry,
        class,
        is_intermittent,
@@ -136,7 +222,8 @@ CREATE INDEX IF NOT EXISTS ne_50m_lakes_gen_z2_idx ON ne_50m_lakes_gen_z2 USING 
 DROP MATERIALIZED VIEW IF EXISTS ne_110m_ocean_gen_z1 CASCADE;
 CREATE MATERIALIZED VIEW ne_110m_ocean_gen_z1 AS
 (
-SELECT ST_Simplify(geometry, ZRes(3)) AS geometry,
+SELECT NULL::integer AS osm_id,
+       ST_Simplify(geometry, ZRes(3)) AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -149,7 +236,8 @@ CREATE INDEX IF NOT EXISTS ne_110m_ocean_gen_z1_idx ON ne_110m_ocean_gen_z1 USIN
 DROP MATERIALIZED VIEW IF EXISTS ne_110m_ocean_gen_z0 CASCADE;
 CREATE MATERIALIZED VIEW ne_110m_ocean_gen_z0 AS
 (
-SELECT ST_Simplify(geometry, ZRes(2)) AS geometry,
+SELECT osm_id,
+       ST_Simplify(geometry, ZRes(2)) AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -164,13 +252,14 @@ CREATE INDEX IF NOT EXISTS ne_110m_ocean_gen_z0_idx ON ne_110m_ocean_gen_z0 USIN
 DROP MATERIALIZED VIEW IF EXISTS ne_110m_lakes_gen_z1 CASCADE;
 CREATE MATERIALIZED VIEW ne_110m_lakes_gen_z1 AS
 (
-SELECT ogc_fid,
+SELECT COALESCE(osm.osm_id, ne_id) AS osm_id,
        ST_Simplify(geometry, ZRes(3)) AS geometry,
        'lakes'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
 FROM ne_110m_lakes
+LEFT JOIN match_osm_ne_id osm USING (ne_id)
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
 CREATE INDEX IF NOT EXISTS ne_110m_lakes_gen_z1_idx ON ne_110m_lakes_gen_z1 USING gist (geometry);
 
@@ -178,7 +267,7 @@ CREATE INDEX IF NOT EXISTS ne_110m_lakes_gen_z1_idx ON ne_110m_lakes_gen_z1 USIN
 DROP MATERIALIZED VIEW IF EXISTS ne_110m_lakes_gen_z0 CASCADE;
 CREATE MATERIALIZED VIEW ne_110m_lakes_gen_z0 AS
 (
-SELECT ogc_fid,
+SELECT osm_id,
        ST_Simplify(geometry, ZRes(2)) AS geometry,
        class,
        is_intermittent,
@@ -192,7 +281,7 @@ CREATE INDEX IF NOT EXISTS ne_110m_lakes_gen_z0_idx ON ne_110m_lakes_gen_z0 USIN
 CREATE OR REPLACE VIEW water_z0 AS
 (
 -- etldoc:  ne_110m_ocean_gen_z0 ->  water_z0
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -200,7 +289,7 @@ SELECT geometry,
 FROM ne_110m_ocean_gen_z0
 UNION ALL
 -- etldoc:  ne_110m_lakes_gen_z0 ->  water_z0
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -211,7 +300,7 @@ FROM ne_110m_lakes_gen_z0
 CREATE OR REPLACE VIEW water_z1 AS
 (
 -- etldoc:  ne_110m_ocean_gen_z1 ->  water_z1
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -219,7 +308,7 @@ SELECT geometry,
 FROM ne_110m_ocean_gen_z1
 UNION ALL
 -- etldoc:  ne_110m_lakes_gen_z1 ->  water_z1
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -230,7 +319,7 @@ FROM ne_110m_lakes_gen_z1
 CREATE OR REPLACE VIEW water_z2 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z2 ->  water_z2
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -238,7 +327,7 @@ SELECT geometry,
 FROM ne_50m_ocean_gen_z2
 UNION ALL
 -- etldoc:  ne_50m_lakes_gen_z2 ->  water_z2
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -249,7 +338,7 @@ FROM ne_50m_lakes_gen_z2
 CREATE OR REPLACE VIEW water_z3 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z3 ->  water_z3
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -257,7 +346,7 @@ SELECT geometry,
 FROM ne_50m_ocean_gen_z3
 UNION ALL
 -- etldoc:  ne_50m_lakes_gen_z3 ->  water_z3
-SELECT geometry,
+SELECT osm_id, 
        class,
        is_intermittent,
        is_bridge,
@@ -268,7 +357,7 @@ FROM ne_50m_lakes_gen_z3
 CREATE OR REPLACE VIEW water_z4 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z4 ->  water_z4
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -276,7 +365,7 @@ SELECT geometry,
 FROM ne_50m_ocean_gen_z4
 UNION ALL
 -- etldoc:  ne_10m_lakes_gen_z4 ->  water_z4
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -287,7 +376,7 @@ FROM ne_10m_lakes_gen_z4
 CREATE OR REPLACE VIEW water_z5 AS
 (
 -- etldoc:  ne_10m_ocean_gen_z5 ->  water_z5
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -295,7 +384,7 @@ SELECT geometry,
 FROM ne_10m_ocean_gen_z5
 UNION ALL
 -- etldoc:  ne_10m_lakes_gen_z5 ->  water_z5
-SELECT geometry,
+SELECT osm_id,
        class,
        is_intermittent,
        is_bridge,
@@ -306,7 +395,7 @@ FROM ne_10m_lakes_gen_z5
 CREATE OR REPLACE VIEW water_z6 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z6 ->  water_z6
-SELECT geometry,
+SELECT NULL::integer AS osm_id,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -314,8 +403,7 @@ SELECT geometry,
 FROM osm_ocean_polygon_gen_z6
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z6 ->  water_z6
-SELECT geometry,
-       water_class(waterway, water) AS class,
+SELECT osm_id,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -326,7 +414,7 @@ WHERE "natural" != 'bay'
 CREATE OR REPLACE VIEW water_z7 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z7 ->  water_z7
-SELECT geometry,
+SELECT NULL::integer AS osm_id,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -334,8 +422,7 @@ SELECT geometry,
 FROM osm_ocean_polygon_gen_z7
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z7 ->  water_z7
-SELECT geometry,
-       water_class(waterway, water) AS class,
+SELECT osm_id,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -346,7 +433,7 @@ WHERE "natural" != 'bay'
 CREATE OR REPLACE VIEW water_z8 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z8 ->  water_z8
-SELECT geometry,
+SELECT NULL::integer AS osm_id,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -354,8 +441,7 @@ SELECT geometry,
 FROM osm_ocean_polygon_gen_z8
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z8 ->  water_z8
-SELECT geometry,
-       water_class(waterway, water) AS class,
+SELECT osm_id,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -366,7 +452,7 @@ WHERE "natural" != 'bay'
 CREATE OR REPLACE VIEW water_z9 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z9 ->  water_z9
-SELECT geometry,
+SELECT NULL::integer AS osm_id,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -374,8 +460,7 @@ SELECT geometry,
 FROM osm_ocean_polygon_gen_z9
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z9 ->  water_z9
-SELECT geometry,
-       water_class(waterway, water) AS class,
+SELECT osm_id,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -386,7 +471,7 @@ WHERE "natural" != 'bay'
 CREATE OR REPLACE VIEW water_z10 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z10 ->  water_z10
-SELECT geometry,
+SELECT NULL::integer AS osm_id,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -394,8 +479,7 @@ SELECT geometry,
 FROM osm_ocean_polygon_gen_z10
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z10 ->  water_z10
-SELECT geometry,
-       water_class(waterway, water) AS class,
+SELECT osm_id,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -406,7 +490,7 @@ WHERE "natural" != 'bay'
 CREATE OR REPLACE VIEW water_z11 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z11 ->  water_z11
-SELECT geometry,
+SELECT NULL::integer AS osm_id,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -414,8 +498,7 @@ SELECT geometry,
 FROM osm_ocean_polygon_gen_z11
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z11 ->  water_z11
-SELECT geometry,
-       water_class(waterway, water) AS class,
+SELECT osm_id,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -426,7 +509,7 @@ WHERE "natural" != 'bay'
 CREATE OR REPLACE VIEW water_z12 AS
 (
 -- etldoc:  osm_ocean_polygon_union ->  water_z12
-SELECT geometry,
+SELECT NULL::integer AS osm_id,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -434,8 +517,7 @@ SELECT geometry,
 FROM osm_ocean_polygon_union
 UNION ALL
 -- etldoc:  osm_water_polygon ->  water_z12
-SELECT geometry,
-       water_class(waterway, water) AS class,
+SELECT osm_id,
        is_intermittent,
        is_bridge,
        is_tunnel
@@ -445,10 +527,11 @@ WHERE "natural" != 'bay'
 
 -- etldoc: layer_water [shape=record fillcolor=lightpink, style="rounded,filled",
 -- etldoc:     label="layer_water |<z0> z0|<z1>z1|<z2>z2|<z3>z3 |<z4> z4|<z5>z5|<z6>z6|<z7>z7| <z8> z8 |<z9> z9 |<z10> z10 |<z11> z11 |<z12> z12+" ] ;
-
+DROP FUNCTION IF EXISTS layer_water(geometry, integer);
 CREATE OR REPLACE FUNCTION layer_water(bbox geometry, zoom_level int)
     RETURNS TABLE
             (
+                osm_id           bigint,
                 geometry     geometry,
                 class        text,
                 brunnel      text,
@@ -456,7 +539,8 @@ CREATE OR REPLACE FUNCTION layer_water(bbox geometry, zoom_level int)
             )
 AS
 $$
-SELECT geometry,
+SELECT osm_id,
+       geometry,
        class::text,
        waterway_brunnel(is_bridge, is_tunnel) AS brunnel,
        is_intermittent::int AS intermittent

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -194,7 +194,7 @@ CREATE MATERIALIZED VIEW ne_50m_lakes_gen_z3 AS
 (
 SELECT COALESCE(osm.osm_id, ne_id) AS osm_id,
        ST_MakeValid(ST_Simplify(geometry, ZRes(5))) AS geometry,
-       'lakes'::text AS class,
+       'lake'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -254,7 +254,7 @@ CREATE MATERIALIZED VIEW ne_110m_lakes_gen_z1 AS
 (
 SELECT COALESCE(osm.osm_id, ne_id) AS osm_id,
        ST_Simplify(geometry, ZRes(3)) AS geometry,
-       'lakes'::text AS class,
+       'lake'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -257,12 +257,6 @@ FROM ne_110m_lakes_gen_z1
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
 CREATE INDEX IF NOT EXISTS ne_110m_lakes_gen_z0_idx ON ne_110m_lakes_gen_z0 USING gist (geometry);
 
-DROP MATERIALIZED VIEW IF EXISTS water_z0;
-DROP MATERIALIZED VIEW IF EXISTS water_z1;
-DROP MATERIALIZED VIEW IF EXISTS water_z2;
-DROP MATERIALIZED VIEW IF EXISTS water_z3;
-DROP MATERIALIZED VIEW IF EXISTS water_z4;
-DROP MATERIALIZED VIEW IF EXISTS water_z5;
 DROP MATERIALIZED VIEW IF EXISTS water_z6;
 DROP MATERIALIZED VIEW IF EXISTS water_z7;
 DROP MATERIALIZED VIEW IF EXISTS water_z8;
@@ -271,11 +265,11 @@ DROP MATERIALIZED VIEW IF EXISTS water_z10;
 DROP MATERIALIZED VIEW IF EXISTS water_z11;
 DROP MATERIALIZED VIEW IF EXISTS water_z12;
 
-CREATE MATERIALIZED VIEW water_z0 AS
+CREATE OR REPLACE VIEW water_z0 AS
 (
 -- etldoc:  ne_110m_ocean_gen_z0 ->  water_z0
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -284,20 +278,19 @@ FROM ne_110m_ocean_gen_z0
 UNION ALL
 -- etldoc:  ne_110m_lakes_gen_z0 ->  water_z0
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_110m_lakes_gen_z0
     );
-CREATE INDEX ON water_z0 USING gist(geometry);
 
-CREATE MATERIALIZED VIEW water_z1 AS
+CREATE OR REPLACE VIEW water_z1 AS
 (
 -- etldoc:  ne_110m_ocean_gen_z1 ->  water_z1
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -306,21 +299,19 @@ FROM ne_110m_ocean_gen_z1
 UNION ALL
 -- etldoc:  ne_110m_lakes_gen_z1 ->  water_z1
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_110m_lakes_gen_z1
     );
-CREATE INDEX ON water_z1 USING gist(geometry);
 
-
-CREATE MATERIALIZED VIEW water_z2 AS
+CREATE OR REPLACE VIEW water_z2 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z2 ->  water_z2
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -329,21 +320,19 @@ FROM ne_50m_ocean_gen_z2
 UNION ALL
 -- etldoc:  ne_50m_lakes_gen_z2 ->  water_z2
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_50m_lakes_gen_z2
     );
-CREATE INDEX ON water_z2 USING gist(geometry);
 
-
-CREATE MATERIALIZED VIEW water_z3 AS
+CREATE OR REPLACE VIEW water_z3 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z3 ->  water_z3
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -352,20 +341,19 @@ FROM ne_50m_ocean_gen_z3
 UNION ALL
 -- etldoc:  ne_50m_lakes_gen_z3 ->  water_z3
 SELECT osm_id, 
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_50m_lakes_gen_z3
     );
-CREATE INDEX ON water_z3 USING gist(geometry);
 
-CREATE MATERIALIZED VIEW water_z4 AS
+CREATE OR REPLACE VIEW water_z4 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z4 ->  water_z4
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -374,22 +362,20 @@ FROM ne_50m_ocean_gen_z4
 UNION ALL
 -- etldoc:  ne_10m_lakes_gen_z4 ->  water_z4
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_10m_lakes_gen_z4
-WHERE ST_GeometryType(geometry) != 'ST_LineString'
     );
-CREATE INDEX ON water_z4 USING gist(geometry);
 
 
-CREATE MATERIALIZED VIEW water_z5 AS
+CREATE OR REPLACE VIEW water_z5 AS
 (
 -- etldoc:  ne_10m_ocean_gen_z5 ->  water_z5
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -398,15 +384,13 @@ FROM ne_10m_ocean_gen_z5
 UNION ALL
 -- etldoc:  ne_10m_lakes_gen_z5 ->  water_z5
 SELECT osm_id,
-       (ST_Dump(geometry)).geom AS geometry,
+       geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_10m_lakes_gen_z5
-WHERE ST_GeometryType(geometry) != 'ST_LineString'
     );
-CREATE INDEX ON water_z5 USING gist(geometry);
 
 CREATE MATERIALIZED VIEW water_z6 AS
 (

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -277,11 +277,25 @@ FROM ne_110m_lakes_gen_z1
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
 CREATE INDEX IF NOT EXISTS ne_110m_lakes_gen_z0_idx ON ne_110m_lakes_gen_z0 USING gist (geometry);
 
+DROP MATERIALIZED VIEW IF EXISTS water_z0;
+DROP MATERIALIZED VIEW IF EXISTS water_z1;
+DROP MATERIALIZED VIEW IF EXISTS water_z2;
+DROP MATERIALIZED VIEW IF EXISTS water_z3;
+DROP MATERIALIZED VIEW IF EXISTS water_z4;
+DROP MATERIALIZED VIEW IF EXISTS water_z5;
+DROP MATERIALIZED VIEW IF EXISTS water_z6;
+DROP MATERIALIZED VIEW IF EXISTS water_z7;
+DROP MATERIALIZED VIEW IF EXISTS water_z8;
+DROP MATERIALIZED VIEW IF EXISTS water_z9;
+DROP MATERIALIZED VIEW IF EXISTS water_z10;
+DROP MATERIALIZED VIEW IF EXISTS water_z11;
+DROP MATERIALIZED VIEW IF EXISTS water_z12;
 
-CREATE OR REPLACE VIEW water_z0 AS
+CREATE MATERIALIZED VIEW water_z0 AS
 (
 -- etldoc:  ne_110m_ocean_gen_z0 ->  water_z0
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -290,17 +304,20 @@ FROM ne_110m_ocean_gen_z0
 UNION ALL
 -- etldoc:  ne_110m_lakes_gen_z0 ->  water_z0
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_110m_lakes_gen_z0
     );
+CREATE INDEX ON water_z0 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z1 AS
+CREATE MATERIALIZED VIEW water_z1 AS
 (
 -- etldoc:  ne_110m_ocean_gen_z1 ->  water_z1
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -309,17 +326,21 @@ FROM ne_110m_ocean_gen_z1
 UNION ALL
 -- etldoc:  ne_110m_lakes_gen_z1 ->  water_z1
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_110m_lakes_gen_z1
     );
+CREATE INDEX ON water_z1 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z2 AS
+
+CREATE MATERIALIZED VIEW water_z2 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z2 ->  water_z2
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -328,17 +349,21 @@ FROM ne_50m_ocean_gen_z2
 UNION ALL
 -- etldoc:  ne_50m_lakes_gen_z2 ->  water_z2
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_50m_lakes_gen_z2
     );
+CREATE INDEX ON water_z2 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z3 AS
+
+CREATE MATERIALIZED VIEW water_z3 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z3 ->  water_z3
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -347,17 +372,20 @@ FROM ne_50m_ocean_gen_z3
 UNION ALL
 -- etldoc:  ne_50m_lakes_gen_z3 ->  water_z3
 SELECT osm_id, 
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_50m_lakes_gen_z3
     );
+CREATE INDEX ON water_z3 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z4 AS
+CREATE MATERIALIZED VIEW water_z4 AS
 (
 -- etldoc:  ne_50m_ocean_gen_z4 ->  water_z4
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -366,17 +394,21 @@ FROM ne_50m_ocean_gen_z4
 UNION ALL
 -- etldoc:  ne_10m_lakes_gen_z4 ->  water_z4
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_10m_lakes_gen_z4
     );
+CREATE INDEX ON water_z4 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z5 AS
+
+CREATE MATERIALIZED VIEW water_z5 AS
 (
 -- etldoc:  ne_10m_ocean_gen_z5 ->  water_z5
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -385,17 +417,20 @@ FROM ne_10m_ocean_gen_z5
 UNION ALL
 -- etldoc:  ne_10m_lakes_gen_z5 ->  water_z5
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM ne_10m_lakes_gen_z5
     );
+CREATE INDEX ON water_z5 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z6 AS
+CREATE MATERIALIZED VIEW water_z6 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z6 ->  water_z6
 SELECT NULL::integer AS osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -404,17 +439,21 @@ FROM osm_ocean_polygon_gen_z6
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z6 ->  water_z6
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
+       water_class(waterway, water) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
 FROM osm_water_polygon_gen_z6
 WHERE "natural" != 'bay'
     );
+CREATE INDEX ON water_z6 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z7 AS
+CREATE MATERIALIZED VIEW water_z7 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z7 ->  water_z7
 SELECT NULL::integer AS osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -423,17 +462,21 @@ FROM osm_ocean_polygon_gen_z7
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z7 ->  water_z7
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
+       water_class(waterway, water) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
 FROM osm_water_polygon_gen_z7
 WHERE "natural" != 'bay'
     );
+CREATE INDEX ON water_z7 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z8 AS
+CREATE MATERIALIZED VIEW water_z8 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z8 ->  water_z8
 SELECT NULL::integer AS osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -442,17 +485,21 @@ FROM osm_ocean_polygon_gen_z8
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z8 ->  water_z8
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
+       water_class(waterway, water) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
 FROM osm_water_polygon_gen_z8
 WHERE "natural" != 'bay'
     );
+CREATE INDEX ON water_z8 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z9 AS
+CREATE MATERIALIZED VIEW water_z9 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z9 ->  water_z9
 SELECT NULL::integer AS osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -461,17 +508,21 @@ FROM osm_ocean_polygon_gen_z9
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z9 ->  water_z9
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
+       water_class(waterway, water) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
 FROM osm_water_polygon_gen_z9
 WHERE "natural" != 'bay'
     );
+CREATE INDEX ON water_z9 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z10 AS
+CREATE MATERIALIZED VIEW water_z10 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z10 ->  water_z10
 SELECT NULL::integer AS osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -480,17 +531,21 @@ FROM osm_ocean_polygon_gen_z10
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z10 ->  water_z10
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
+       water_class(waterway, water) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
 FROM osm_water_polygon_gen_z10
 WHERE "natural" != 'bay'
     );
+CREATE INDEX ON water_z10 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z11 AS
+CREATE MATERIALIZED VIEW water_z11 AS
 (
 -- etldoc:  osm_ocean_polygon_gen_z11 ->  water_z11
 SELECT NULL::integer AS osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -499,17 +554,21 @@ FROM osm_ocean_polygon_gen_z11
 UNION ALL
 -- etldoc:  osm_water_polygon_gen_z11 ->  water_z11
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
+       water_class(waterway, water) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
 FROM osm_water_polygon_gen_z11
 WHERE "natural" != 'bay'
     );
+CREATE INDEX ON water_z11 USING gist(geometry);
 
-CREATE OR REPLACE VIEW water_z12 AS
+CREATE MATERIALIZED VIEW water_z12 AS
 (
 -- etldoc:  osm_ocean_polygon_union ->  water_z12
 SELECT NULL::integer AS osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
        'ocean'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -518,12 +577,15 @@ FROM osm_ocean_polygon_union
 UNION ALL
 -- etldoc:  osm_water_polygon ->  water_z12
 SELECT osm_id,
+       (ST_Dump(geometry)).geom AS geometry,
+       water_class(waterway, water) AS class,
        is_intermittent,
        is_bridge,
        is_tunnel
 FROM osm_water_polygon
 WHERE "natural" != 'bay'
     );
+CREATE INDEX ON water_z12 USING gist(geometry);
 
 -- etldoc: layer_water [shape=record fillcolor=lightpink, style="rounded,filled",
 -- etldoc:     label="layer_water |<z0> z0|<z1>z1|<z2>z2|<z3>z3 |<z4> z4|<z5>z5|<z6>z6|<z7>z7| <z8> z8 |<z9> z9 |<z10> z10 |<z11> z11 |<z12> z12+" ] ;

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -173,7 +173,7 @@ DROP MATERIALIZED VIEW IF EXISTS ne_50m_lakes_gen_z3 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_lakes_gen_z3 AS
 (
 SELECT COALESCE(osm.osm_id, ne_id) AS osm_id,
-       ST_MakeValid(ST_Simplify(geometry, ZRes(5))) AS geometry,
+       (ST_Dump(ST_MakeValid(ST_Simplify(geometry, ZRes(5))))).geom AS geometry,
        'lake'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -188,7 +188,7 @@ DROP MATERIALIZED VIEW IF EXISTS ne_50m_lakes_gen_z2 CASCADE;
 CREATE MATERIALIZED VIEW ne_50m_lakes_gen_z2 AS
 (
 SELECT osm_id,
-       ST_MakeValid(ST_Simplify(geometry, ZRes(4))) AS geometry,
+       (ST_Dump(ST_MakeValid(ST_Simplify(geometry, ZRes(4))))).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,
@@ -233,7 +233,7 @@ DROP MATERIALIZED VIEW IF EXISTS ne_110m_lakes_gen_z1 CASCADE;
 CREATE MATERIALIZED VIEW ne_110m_lakes_gen_z1 AS
 (
 SELECT COALESCE(osm.osm_id, ne_id) AS osm_id,
-       ST_Simplify(geometry, ZRes(3)) AS geometry,
+       (ST_Dump(ST_Simplify(geometry, ZRes(3)))).geom AS geometry,
        'lake'::text AS class,
        NULL::boolean AS is_intermittent,
        NULL::boolean AS is_bridge,
@@ -248,7 +248,7 @@ DROP MATERIALIZED VIEW IF EXISTS ne_110m_lakes_gen_z0 CASCADE;
 CREATE MATERIALIZED VIEW ne_110m_lakes_gen_z0 AS
 (
 SELECT osm_id,
-       ST_Simplify(geometry, ZRes(2)) AS geometry,
+       (ST_Dump(ST_Simplify(geometry, ZRes(2)))).geom AS geometry,
        class,
        is_intermittent,
        is_bridge,

--- a/layers/water/water.yaml
+++ b/layers/water/water.yaml
@@ -12,6 +12,10 @@ layer:
       This however can lead to less rendering options in clients since these boundaries show up. So you might not be
       able to use border styling for ocean water features.
   fields:
+    osm_id: 
+      description: |
+          From zoom 6 are taken OSM IDs. Up to zoom 5 there are used Natural Earth lakes, where are propagated the OSM IDs insted of Natural Earth IDs.
+          For smaller area then planet, NE lakes keep their Natural Earth IDs.
     class:
       description: |
           All water polygons from [OpenStreetMapData](http://osmdata.openstreetmap.de/) have the class `ocean`.
@@ -39,7 +43,7 @@ layer:
         - tunnel
   buffer_size: 4
   datasource:
-    query: (SELECT geometry, class, intermittent, brunnel FROM layer_water(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT osm_id, geometry, class, intermittent, brunnel FROM layer_water(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./update_water.sql
   - ./water.sql

--- a/layers/water/water.yaml
+++ b/layers/water/water.yaml
@@ -12,7 +12,7 @@ layer:
       This however can lead to less rendering options in clients since these boundaries show up. So you might not be
       able to use border styling for ocean water features.
   fields:
-    osm_id: 
+    id: 
       description: |
           From zoom 6 are taken OSM IDs. Up to zoom 5 there are used Natural Earth lakes, where are propagated the OSM IDs insted of Natural Earth IDs.
           For smaller area then planet, NE lakes keep their Natural Earth IDs.
@@ -43,7 +43,7 @@ layer:
         - tunnel
   buffer_size: 4
   datasource:
-    query: (SELECT osm_id, geometry, class, intermittent, brunnel FROM layer_water(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT id, geometry, class, intermittent, brunnel FROM layer_water(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./update_water.sql
   - ./water.sql


### PR DESCRIPTION
This PR adding OSM ID to the lakes

OSM lakes are used from zoom 6
From zoom 0 to zoom 5 are used Natural Earth lakes. 
  - There is a new joining mat. view (`match_osm_ne_id`) contains which Natural Earth ID should convert to OSM ID. This logic is used to keep a consistent ID between switching between NE (zooms 0 - 5) and OSM (zooms 6 - 12). For smaller areas (not the whole planet), where are not available OSM lakes, the NE lakes keep their NE ID.
  - There are also switch the final views to the mat. views - this should slightly increase performance (get rid of multipolygons).
  - FIX typo for zooms 0 - 3 (`lakes` instead of `lake`).

There are also some manual changes to NE v4 data which should be fixed in a newer version.

![water_osm_id](https://user-images.githubusercontent.com/5182210/166723557-7df15b27-617b-4ea7-b481-6279fc32a0e2.png)


Close https://github.com/openmaptiles/openmaptiles/issues/1382