### PR TITLE
Bugfix: fix update_osm_route_member() function

### DIFF
--- a/layers/transportation/update_route_member.sql
+++ b/layers/transportation/update_route_member.sql
@@ -75,7 +75,8 @@ BEGIN
     WHERE rm.member IN
       (SELECT DISTINCT osm_id FROM transportation_name.network_changes)
     ON CONFLICT (id, osm_id) DO UPDATE SET concurrency_index = EXCLUDED.concurrency_index,
-                                           rank = EXCLUDED.rank;
+                                           rank = EXCLUDED.rank,
+                                           network_type = EXCLUDED.network_type;
 END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
Fixes #1374 

This PR fixes `update_osm_route_member()` function. Before this the column `network_type` became empty after daily-update.
This PR adds `network_type` into upsert together with `rank` and `concurrency_index` columns.
This bug had occurred once already and had been fixed in https://github.com/openmaptiles/openmaptiles/pull/1239 but then some columns were added and these new columns were not added into the upsert.