### PR TITLE
Add swimming pool to class attribute.

### DIFF
--- a/layers/water/mapping.yaml
+++ b/layers/water/mapping.yaml
@@ -75,6 +75,9 @@ tables:
     - name: waterway
       key: waterway
       type: string
+    - name: leisure
+      key: leisure
+      type: string
     - name: water
       key: water
       type: string

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION water_class(waterway text, water text) RETURNS text AS
+CREATE OR REPLACE FUNCTION water_class(waterway text, water text, leisure text) RETURNS text AS
 $$
 SELECT CASE
            WHEN waterway='riverbank' THEN 'river'
@@ -406,7 +406,7 @@ UNION ALL
 -- etldoc:  osm_water_polygon_gen_z6 ->  water_z6
 SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
-       water_class(waterway, water) AS class,
+       water_class(waterway, water, leisure) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -429,7 +429,7 @@ UNION ALL
 -- etldoc:  osm_water_polygon_gen_z7 ->  water_z7
 SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
-       water_class(waterway, water) AS class,
+       water_class(waterway, water, leisure) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -452,7 +452,7 @@ UNION ALL
 -- etldoc:  osm_water_polygon_gen_z8 ->  water_z8
 SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
-       water_class(waterway, water) AS class,
+       water_class(waterway, water, leisure) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -475,7 +475,7 @@ UNION ALL
 -- etldoc:  osm_water_polygon_gen_z9 ->  water_z9
 SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
-       water_class(waterway, water) AS class,
+       water_class(waterway, water, leisure) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -498,7 +498,7 @@ UNION ALL
 -- etldoc:  osm_water_polygon_gen_z10 ->  water_z10
 SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
-       water_class(waterway, water) AS class,
+       water_class(waterway, water, leisure) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -521,7 +521,7 @@ UNION ALL
 -- etldoc:  osm_water_polygon_gen_z11 ->  water_z11
 SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
-       water_class(waterway, water) AS class,
+       water_class(waterway, water, leisure) AS class,
        is_intermittent,
        NULL::boolean AS is_bridge,
        NULL::boolean AS is_tunnel
@@ -544,7 +544,7 @@ UNION ALL
 -- etldoc:  osm_water_polygon ->  water_z12
 SELECT osm_id AS id,
        (ST_Dump(geometry)).geom AS geometry,
-       water_class(waterway, water) AS class,
+       water_class(waterway, water, leisure) AS class,
        is_intermittent,
        is_bridge,
        is_tunnel

--- a/layers/water/water.yaml
+++ b/layers/water/water.yaml
@@ -21,7 +21,8 @@ layer:
           All water polygons from [OpenStreetMapData](http://osmdata.openstreetmap.de/) have the class `ocean`.
           Water bodies with the [`waterway=riverbank`](http://wiki.openstreetmap.org/wiki/Tag:waterway=riverbank)
           or [`water=river`](http://wiki.openstreetmap.org/wiki/Tag:water=river) tag are classified as river.  Wet and dry docks
-          tagged [`waterway=dock`](http://wiki.openstreetmap.org/wiki/Tag:waterway=dock) are classified as a `dock`.
+          tagged [`waterway=dock`](http://wiki.openstreetmap.org/wiki/Tag:waterway=dock) are classified as a `dock`. 
+          Swimming pools tagged [`leisure=swimming_pool`](https://wiki.openstreetmap.org/wiki/Tag:leisure=swimming_pool) are classified as a `swimming_pool`
           All other water bodies are classified as `lake`.
       values:
         dock:
@@ -31,6 +32,8 @@ layer:
           waterway: 'riverbank'
         lake:
         ocean:
+        swimming_pool:
+          leisure: 'swimming_pool'
     intermittent:
       description: |
         Mark with `1` if it is an [intermittent](http://wiki.openstreetmap.org/wiki/Key:intermittent) water polygon.


### PR DESCRIPTION
This PR adds swimming pools as a class in the water layer. Until now all swimming pools were classified as `lake`.

![swimming_pool](https://user-images.githubusercontent.com/5182210/166937413-6f74bc70-f977-4668-ac4c-6da9034a2648.png)
(Portugal - swimming pools are red)
Close https://github.com/openmaptiles/openmaptiles/issues/1321