### PR TITLE
Add parcel lockers to POI layer

### DIFF
--- a/layers/poi/mapping.yaml
+++ b/layers/poi/mapping.yaml
@@ -39,6 +39,7 @@ def_poi_mapping_amenity: &poi_mapping_amenity
   - motorcycle_parking
   - nightclub
   - nursing_home
+  - parcel_locker
   - parking
   - pharmacy
   - place_of_worship

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -61,7 +61,7 @@ layer:
         ice_cream:
           subclass: ['chocolate', 'confectionery']
         post:
-          subclass: ['post_box', 'post_office']
+          subclass: ['post_box', 'post_office', 'parcel_locker']
         cafe:
           subclass: ['cafe']
         school:


### PR DESCRIPTION
This PR adds `amenity=parcel_locker` to the POI layer.  This was approved in a [2021 proposal](https://wiki.openstreetmap.org/w/index.php?oldid=2261304) and has [over 12,000 usages and growing](https://taginfo.openstreetmap.org/tags/?key=amenity&value=parcel_locker#chronology).  Since the COVID-19 pandemic, this feature class has grown dramatically as people have increasingly had goods shipped to them, so this is an important POI that we should add to OpenMapTiles.  I added this to the "post" class as it fits in with post offices and post boxes.

Sample render location: `#17/41.670227/-71.907889`
![image](https://user-images.githubusercontent.com/3254090/168955075-555d058e-ecc1-419e-b479-c63464f46f55.png)