### PR TITLE
Add support for county seats (capital=6)

### DIFF
--- a/layers/place/capital.sql
+++ b/layers/place/capital.sql
@@ -2,8 +2,8 @@ CREATE OR REPLACE FUNCTION normalize_capital_level(capital text)
     RETURNS int AS
 $$
 SELECT CASE
-           WHEN capital IN ('yes', '2') THEN 2
-           WHEN capital = '4' THEN 4
+           WHEN capital='yes' THEN 2
+           WHEN capital IN ('2', '4', '6') THEN capital::int
            END;
 $$ LANGUAGE SQL IMMUTABLE
                 STRICT

--- a/layers/place/capital.sql
+++ b/layers/place/capital.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION normalize_capital_level(capital text)
     RETURNS int AS
 $$
 SELECT CASE
-           WHEN capital='yes' THEN 2
+           WHEN capital = 'yes' THEN 2
            WHEN capital IN ('2', '4', '6') THEN capital::int
            END;
 $$ LANGUAGE SQL IMMUTABLE

--- a/layers/place/capital.sql
+++ b/layers/place/capital.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION normalize_capital_level(capital text)
 $$
 SELECT CASE
            WHEN capital = 'yes' THEN 2
-           WHEN capital IN ('2', '4', '6') THEN capital::int
+           WHEN capital IN ('2', '3', '4', '5', '6') THEN capital::int
            END;
 $$ LANGUAGE SQL IMMUTABLE
                 STRICT


### PR DESCRIPTION
Unblocks ZeLonewolf/openstreetmap-americana#384

This PR adds support for `capital=6` in the place layer, which is used for tagging county seats in the US.  A county seat is the capital of a county.  In addition, I reorganized the code a bit to be simpler.

As noted in ZeLonewolf/openstreetmap-americana#384, we would like to render county seats along with state and national capitals, as this is typical styling on American-style maps.

Render output:

![image](https://user-images.githubusercontent.com/3254090/173266471-dc914ca0-dad3-4d79-a169-44a69ea6d6e6.png)
