### PR TITLE
Update to Natural Earth v5.1.2

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@
 TILESET_FILE=openmaptiles.yaml
 
 # Use 3-part patch version to ignore patch updates, e.g. 5.0.0
-TOOLS_VERSION=6.2
+TOOLS_VERSION=latest
 
 # Make sure these values are in sync with the ones in .env-postgres file
 PGDATABASE=openmaptiles

--- a/layers/place/update_city_point.sql
+++ b/layers/place/update_city_point.sql
@@ -23,8 +23,8 @@ $$
              LEFT JOIN ne_10m_populated_places AS ne ON
             (
                 (osm.tags ? 'wikidata' AND osm.tags->'wikidata' = ne.wikidataid) OR
-                lower(osm.name) IN (lower(ne.name), lower(ne.namealt), lower(ne.meganame), lower(ne.gn_ascii), lower(ne.nameascii)) OR
-                lower(osm.name_en) IN (lower(ne.name), lower(ne.namealt), lower(ne.meganame), lower(ne.gn_ascii), lower(ne.nameascii)) OR
+                lower(osm.name) IN (lower(ne.name), lower(ne.namealt), lower(ne.meganame), lower(ne.name_en), lower(ne.nameascii)) OR
+                lower(osm.name_en) IN (lower(ne.name), lower(ne.namealt), lower(ne.meganame), lower(ne.name_en), lower(ne.nameascii)) OR
                 ne.name = unaccent(osm.name)
             )
           AND osm.place IN ('city', 'town', 'village')

--- a/layers/water/water.sql
+++ b/layers/water/water.sql
@@ -18,18 +18,6 @@ $$ LANGUAGE SQL IMMUTABLE
                 STRICT
                 PARALLEL SAFE;
 
--- Add ne_id for missing ne_50m_lakes.
-UPDATE ne_50m_lakes SET ne_id = ne_10m_lakes.ne_id
-FROM ne_50m_lakes lakes
-LEFT JOIN ne_10m_lakes USING (wikidataid)
-WHERE   ne_50m_lakes.wikidataid = ne_10m_lakes.wikidataid
-    AND ne_50m_lakes.ne_id = 0;
-
--- Update ne_110_lakes ne_id where two lakes (Lake Onega) have identical attributes.
--- New ne_id is taken from ne_50m_lakes
-UPDATE ne_110m_lakes SET ne_id = 1159126421
-WHERE   ne_id = 1159113251
-    AND ST_Area(geometry) < 10000000000;
 
 -- Get matching osm id for natural earth id.
 DROP MATERIALIZED VIEW IF EXISTS match_osm_ne_id CASCADE;


### PR DESCRIPTION
This PR updating Natural Earth dataset from v4.1 to 5.1.2. It is in cooperation with https://github.com/openmaptiles/openmaptiles-tools/pull/414, where is `import-data` docker image updated.

PR removes manual fixes for lake merging (already fixed in version 5.1.2)

Switched comparison from `gn_ascii` (removed from NE5) to `name_en`.

Could be merged after https://github.com/openmaptiles/openmaptiles-tools/pull/413. After OMT-T is merged, it will use `latest` image (until the release of OMT-T v7)

Solves https://github.com/openmaptiles/openmaptiles/issues/1379
