### PR TITLE
Bigger areas for landcover layer

### DIFF
--- a/layers/landcover/generalized.sql
+++ b/layers/landcover/generalized.sql
@@ -22,7 +22,7 @@ CREATE TABLE simplify_vw_z13 AS
              ST_SimplifyVW(geometry, power(zres(13),2)),
              0.001)) AS geometry
     FROM osm_landcover_polygon
-    WHERE ST_Area(geometry) > power(zres(10),2)
+    WHERE ST_Area(geometry) > power(zres(12),2)
 );
 CREATE INDEX ON simplify_vw_z13 USING GIST (geometry);
 
@@ -58,7 +58,7 @@ CREATE TABLE simplify_vw_z12 AS
              ST_SimplifyVW(geometry, power(zres(12),2)),
              0.001)) AS geometry
     FROM simplify_vw_z13
-    WHERE ST_Area(geometry) > power(zres(9),2)
+    WHERE ST_Area(geometry) > power(zres(11),2)
 );
 CREATE INDEX ON simplify_vw_z12 USING GIST (geometry);
 
@@ -94,7 +94,7 @@ CREATE TABLE simplify_vw_z11 AS
              ST_SimplifyVW(geometry, power(zres(11),2)),
              0.001)) AS geometry
     FROM simplify_vw_z12
-    WHERE ST_Area(geometry) > power(zres(8),2)
+    WHERE ST_Area(geometry) > power(zres(10),2)
 );
 CREATE INDEX ON simplify_vw_z11 USING GIST (geometry);
 
@@ -130,7 +130,7 @@ CREATE TABLE simplify_vw_z10 AS
              ST_SimplifyVW(geometry, power(zres(10),2)),
              0.001)) AS geometry
     FROM simplify_vw_z11
-    WHERE ST_Area(geometry) > power(zres(8),2)
+    WHERE ST_Area(geometry) > power(zres(9),2)
 );
 CREATE INDEX ON simplify_vw_z10 USING GIST (geometry);
 
@@ -166,7 +166,7 @@ CREATE TABLE simplify_vw_z9 AS
              ST_SimplifyVW(geometry, power(zres(9),2)),
              0.001)) AS geometry
     FROM simplify_vw_z10
-    WHERE ST_Area(geometry) > power(zres(7),2)
+    WHERE ST_Area(geometry) > power(zres(8),2)
 );
 CREATE INDEX ON simplify_vw_z9 USING GIST (geometry);
 
@@ -214,7 +214,7 @@ CREATE TABLE simplify_vw_z8 AS
              ST_SimplifyVW(geometry, power(zres(8),2)),
              0.001)) AS geometry
     FROM simplify_vw_z9
-    WHERE ST_Area(geometry) > power(zres(6),2)
+    WHERE ST_Area(geometry) > power(zres(7),2)
     );
 CREATE INDEX ON simplify_vw_z8 USING GIST (geometry);
 
@@ -231,6 +231,7 @@ SELECT subclass,
                ST_ClusterDBSCAN(geometry, eps := 0, minpoints := 1) OVER () AS cid,
                geometry
         FROM simplify_vw_z8
+        WHERE subclass IN ('wood', 'forest')
         ) union_geom
     GROUP BY subclass,
              cid
@@ -253,7 +254,7 @@ CREATE TABLE simplify_vw_z7 AS
              ST_SimplifyVW(geometry, power(zres(7),2)),
              0.001)) AS geometry
     FROM simplify_vw_z8
-    WHERE ST_Area(geometry) > power(zres(5),2)
+    WHERE ST_Area(geometry) > power(zres(6),2)
 );
 CREATE INDEX ON simplify_vw_z7 USING GIST (geometry);
 


### PR DESCRIPTION
Add bigger areas (smaller polygons) into landcover layer for zooms 7 - 13

It will raise the tile size, but it will create nicer, greener areas.

e. g. for Slovenia
Old zoom 7
![slovenia_old](https://user-images.githubusercontent.com/5182210/185206413-d78d5996-5776-45ff-bd72-2700a350d6d1.png)
New zoom 7
![slovenia_new](https://user-images.githubusercontent.com/5182210/185206420-918c6732-626d-457a-a378-959d93b4669e.png)
New zoom 8
![slovenia_new2](https://user-images.githubusercontent.com/5182210/185207218-7b3a87e1-26cf-4dc5-9625-a17f83f9647a.png)


fix #1351
Partial fix of #1358