### PR TITLE
Show the Trans-Canada Highway at z4

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -349,7 +349,13 @@ BEGIN
     FROM osm_transportation_merge_linestring_gen_z5
     WHERE
         (update_id IS NULL OR id = update_id) AND
-        (highway = 'motorway' OR construction = 'motorway') AND
+        (highway = 'motorway'
+            OR construction = 'motorway'
+            -- Allow trunk roads that are part of a nation's most important route network to show at z4
+            OR highway = 'trunk' AND
+                network <> '' AND
+                network IN ('ca-transcanada','us-interstate')
+        ) AND
         ST_Length(geometry) > 1000;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Fixes #1439 

This adds support to show the Trans-Canada Highway at zoom 4.  Despite being the most important highway network in Canada, portions are `highway=trunk` due to the remoteness of the countryside.  However, it's still important to show a connected highway network at the lowest zoom without showing all trunk roads at this zoom.

This change also adds support for US Interstate Highways to be drawn at z4 when they're tagged as trunks.  There's only a few examples of this, but it removes those (tiny) gaps from the generalized road geometries. As we identify additional countries which should have their most important road network rendered at the lowest road zoom even if they're trunk, we can add them to the list of networks that get this treatment.

Tested on Prince Edward Island:
![image](https://user-images.githubusercontent.com/3254090/200148481-099e8bb8-808f-463e-b683-99bcb284a624.png)
