### PR TITLE
Bugfix: z4/z5 transportation layer progression

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -327,7 +327,14 @@ BEGIN
     FROM osm_transportation_merge_linestring_gen_z6
     WHERE
         (update_id IS NULL OR id = update_id) AND
-        -- Current view: motorway/trunk
+        -- Current view: all motorways and trunks of national-importance
+        (highway = 'motorway'
+            OR construction = 'motorway'
+            -- Allow trunk roads that are part of a nation's most important route network to show at z4
+            OR highway = 'trunk' AND
+                network <> '' AND
+                network IN ('ca-transcanada','us-interstate')
+        ) AND
         ST_Length(geometry) > 500;
 
     DELETE FROM osm_transportation_merge_linestring_gen_z4
@@ -349,13 +356,8 @@ BEGIN
     FROM osm_transportation_merge_linestring_gen_z5
     WHERE
         (update_id IS NULL OR id = update_id) AND
-        (highway = 'motorway'
-            OR construction = 'motorway'
-            -- Allow trunk roads that are part of a nation's most important route network to show at z4
-            OR highway = 'trunk' AND
-                network <> '' AND
-                network IN ('ca-transcanada','us-interstate')
-        ) AND
+        -- Current view: national-importance motorways and trunks
+        network IN ('ca-transcanada','us-interstate') AND
         ST_Length(geometry) > 1000;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
This PR improves the behavior introduced in #1440, which inadvertently included all motorways at z4, which was unintended.  Instead, this PR provides an appropriate progression from z4 to z5 with the highest national-importance highways being rendered at z4 (including where they degrade to trunk, as in Canada), and all motorways being added to the mix at z5.

|    | Current                                                             | This PR                                                             |
|----|---------------------------------------------------------------------|---------------------------------------------------------------------|
| z4 | All `highway=motorway` and "National importance" trunk + motorway   | "National importance" trunk + motorway                              |
| Z5 | All  `highway=motorway`  and "National importance" trunk + motorway | All  `highway=motorway`  and "National importance" trunk + motorway |

Zoom 4 North America:

![image](https://user-images.githubusercontent.com/3254090/203383183-ebe503f1-2324-423a-a9e9-1e17da48c399.png)

Zoom 5 North America:

![image](https://user-images.githubusercontent.com/3254090/203383277-61fa34c6-0c8b-4f6b-a533-f9d768496ad1.png)
