### PR TITLE
Prep dirs before tileserver starts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ generate-changed-tiles: data/tiles.txt
 	fi
 
 .PHONY: start-tileserver
-start-tileserver: init-dirs
+start-tileserver: init-dirs build-style download-fonts
 	@echo " "
 	@echo "***********************************************************"
 	@echo "* "


### PR DESCRIPTION
This PR adds `build-style` and `download-fonts` targets to `start-tileserver` target. 
Without a style built and fonts not downloaded user can get an error as mentioned by @ZeLonewolf 
![image](https://user-images.githubusercontent.com/19833762/203797415-0160734f-3f79-411a-a039-176c4d08ff3d.png)

Calling `build-style` and `download-fonts` ensures that there is the OSM OpenMapTiles style build and ready and fonts downloaded.
