### PR TITLE
Drop name_en and name_de from the transportation layers

### DIFF
--- a/layers/transportation/highway_name.sql
+++ b/layers/transportation/highway_name.sql
@@ -1,10 +1,8 @@
-CREATE OR REPLACE FUNCTION transportation_name_tags(geometry geometry, tags hstore, name text, name_en text, name_de text) RETURNS hstore AS
+CREATE OR REPLACE FUNCTION transportation_name_tags(geometry geometry, tags hstore, name text) RETURNS hstore AS
 $$
 SELECT hstore(string_agg(nullif(slice_language_tags(tags ||
                      hstore(ARRAY [
-                       'name',    CASE WHEN length(name) > 15    THEN osml10n_street_abbrev_all(name)   ELSE NULLIF(name, '') END,
-                       'name:en', CASE WHEN length(name_en) > 15 THEN osml10n_street_abbrev_en(name_en) ELSE NULLIF(name_en, '') END,
-                       'name:de', CASE WHEN length(name_de) > 15 THEN osml10n_street_abbrev_de(name_de) ELSE NULLIF(name_de, '') END
+                       'name',    CASE WHEN length(name) > 15    THEN osml10n_street_abbrev_all(name)   ELSE NULLIF(name, '') END
                      ]))::text,
                      ''), ','));
 $$ LANGUAGE SQL IMMUTABLE

--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -52,14 +52,6 @@ name_field: &name
   name: name
   key: name
   type: string
-name_en_field: &name_en
-  name: name_en
-  key: name:en
-  type: string
-name_de_field: &name_de
-  name: name_de
-  key: name:de
-  type: string
 short_name_field: &short_name
   key: short_name
   name: short_name
@@ -187,8 +179,6 @@ tables:
     - *level
     - *indoor
     - *name
-    - *name_en
-    - *name_de
     - name: tags
       type: hstore_tags
     - *short_name
@@ -267,8 +257,6 @@ tables:
     - *level
     - *indoor
     - *name
-    - *name_en
-    - *name_de
     - name: tags
       type: hstore_tags
     - *short_name
@@ -306,8 +294,6 @@ tables:
     - *z_order
     - *layer
     - *name
-    - *name_en
-    - *name_de
     - name: tags
       type: hstore_tags
     - *short_name
@@ -345,8 +331,6 @@ tables:
     - *z_order
     - *layer
     - *name
-    - *name_en
-    - *name_de
     - name: tags
       type: hstore_tags
     - *short_name
@@ -415,8 +399,6 @@ tables:
     - *layer
     - *level
     - *name
-    - *name_en
-    - *name_de
     - name: tags
       type: hstore_tags
     - name: ref

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -35,7 +35,7 @@ FROM (
     SELECT DISTINCT ON (hl.osm_id)
         hl.geometry,
         hl.osm_id,
-        transportation_name_tags(hl.geometry, hl.tags, hl.name, hl.name_en, hl.name_de) AS tags,
+        transportation_name_tags(hl.geometry, hl.tags, hl.name) AS tags,
         rm1.network_type,
         CASE
             WHEN rm1.network_type IS NOT NULL AND rm1.ref::text <> ''

--- a/layers/transportation_name/transportation_name.sql
+++ b/layers/transportation_name/transportation_name.sql
@@ -6,8 +6,6 @@ CREATE OR REPLACE FUNCTION layer_transportation_name(bbox geometry, zoom_level i
             (
                 geometry   geometry,
                 name       text,
-                name_en    text,
-                name_de    text,
                 tags       hstore,
                 ref        text,
                 ref_length int,
@@ -29,8 +27,6 @@ AS
 $$
 SELECT geometry,
        tags->'name' AS name,
-       COALESCE(tags->'name:en', tags->'name') AS name_en,
-       COALESCE(tags->'name:de', tags->'name', tags->'name:en') AS name_de,
        tags,
        ref,
        NULLIF(LENGTH(ref), 0) AS ref_length,

--- a/layers/transportation_name/transportation_name.yaml
+++ b/layers/transportation_name/transportation_name.yaml
@@ -13,8 +13,6 @@ layer:
   srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
   fields:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Highways#Names_and_references) value of the highway.
-    name_en: English name `name:en` if available, otherwise `name`.
-    name_de: German name `name:de` if available, otherwise `name` or `name:en`.
     ref: The OSM [`ref`](http://wiki.openstreetmap.org/wiki/Key:ref) tag of the motorway or its network.
     ref_length: Length of the `ref` field. Useful for having a shield icon as background for labeling motorways.
     network:
@@ -106,7 +104,7 @@ layer:
   datasource:
     geometry_field: geometry
     srid: 900913
-    query: (SELECT geometry, name, name_en, name_de, {name_languages}, ref, ref_length, network::text, class::text, subclass, brunnel, layer, level, indoor, route_1, route_2, route_3, route_4, route_5, route_6 FROM layer_transportation_name(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, name, {name_languages}, ref, ref_length, network::text, class::text, subclass, brunnel, layer, level, indoor, route_1, route_2, route_3, route_4, route_5, route_6 FROM layer_transportation_name(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./highway_classification.sql
   - ./update_transportation_name.sql

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -45,7 +45,7 @@ FROM (
          UNION ALL
 
          SELECT ST_LineMerge(ST_Collect(geometry)) AS geometry,
-                transportation_name_tags(NULL::geometry, tags, name, name_en, name_de) AS tags,
+                transportation_name_tags(NULL::geometry, tags, name) AS tags,
                 NULL AS ref,
                 'shipway' AS highway,
                 shipway AS subclass,
@@ -65,11 +65,11 @@ FROM (
                 NULL::int AS route_rank
          FROM osm_shipway_linestring
          WHERE name <> ''
-         GROUP BY name, name_en, name_de, tags, subclass, "level", layer
+         GROUP BY name, tags, subclass, "level", layer
          UNION ALL
 
          SELECT ST_LineMerge(ST_Collect(geometry)) AS geometry,
-                transportation_name_tags(NULL::geometry, tags, name, name_en, name_de) AS tags,
+                transportation_name_tags(NULL::geometry, tags, name) AS tags,
                 NULL AS ref,
                 'aerialway' AS highway,
                 aerialway AS subclass,
@@ -89,7 +89,7 @@ FROM (
                 NULL::int AS route_rank
          FROM osm_aerialway_linestring
          WHERE name <> ''
-         GROUP BY name, name_en, name_de, tags, subclass, "level", layer
+         GROUP BY name, tags, subclass, "level", layer
      ) AS highway_union
 ;
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_name_ref_idx ON osm_transportation_name_linestring (coalesce(tags->'name', ''), coalesce(ref, ''));
@@ -294,7 +294,7 @@ BEGIN
     FROM (
         SELECT hl.geometry,
             hl.osm_id,
-            transportation_name_tags(hl.geometry, hl.tags, hl.name, hl.name_en, hl.name_de) AS tags,
+            transportation_name_tags(hl.geometry, hl.tags, hl.name) AS tags,
             rm1.network_type,
             CASE
                 WHEN rm1.network_type IS NOT NULL AND rm1.ref::text <> ''


### PR DESCRIPTION
This PR proposes to remove `name_en` and `name_de` from the transportation_name layer. These values are deprecated in favor of `name:en` and `name:de` which are imported via openmaptiles-tools.  Thus, these legacy values are just extra code and space that isn't needed.

If this PR is accepted, I intend to submit additional PRs to remove these from the other layers that use them.