### PR TITLE
Fix stops aggregation in osm_poi_point.

### DIFF
--- a/layers/poi/update_poi_point.sql
+++ b/layers/poi/update_poi_point.sql
@@ -60,7 +60,7 @@ BEGIN
                 THEN 1
         END
     WHERE
-        agg_stop != CASE
+        agg_stop IS DISTINCT FROM CASE
             WHEN p.subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
                 THEN 1
         END;
@@ -70,15 +70,15 @@ BEGIN
         agg_stop = (
         CASE
             WHEN p.subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
-                     AND r.rk IS NULL OR r.rk = 1
+                     AND (r.rk IS NULL OR r.rk = 1)
                 THEN 1
         END)
     FROM osm_poi_stop_rank r
     WHERE p.osm_id = r.osm_id AND
-        agg_stop != (
+        agg_stop IS DISTINCT FROM (
         CASE
             WHEN p.subclass IN ('bus_stop', 'bus_station', 'tram_stop', 'subway')
-                     AND r.rk IS NULL OR r.rk = 1
+                     AND (r.rk IS NULL OR r.rk = 1)
                 THEN 1
         END);
 


### PR DESCRIPTION
This PR fixing the stops aggregations which now returns always `NULL` and wasn't reflected in the tiles. 

Tested on Switzerland (19.29/47.3642186/8.5311424)
![image](https://user-images.githubusercontent.com/5182210/213101422-ce33f694-0eb7-4fe9-b451-6086ea82e716.png)
