### PR TITLE
Consider boundary_type=maritime to be maritime=1

### DIFF
--- a/layers/boundary/boundary.sql
+++ b/layers/boundary/boundary.sql
@@ -25,7 +25,8 @@ FROM (
                  OR BOOL_OR(disputed_by <> '') AS disputed,
              NULLIF(name, '') AS name,
              NULLIF(claimed_by, '') AS claimed_by,
-             BOOL_OR(maritime) AS maritime
+             BOOL_OR(maritime)
+                OR BOOL_OR(boundary_type = 'maritime') AS maritime
       FROM osm_border_linestring
       WHERE admin_level BETWEEN 3 AND 10
             AND type = 1 -- ways only


### PR DESCRIPTION
Some admin4-level boundaries are missing the maritime = 1 value, even though they are marked as maritime within OSM. It appears that some boundaries are marked within OSM with the tag maritime=yes and others with the tag boundary_type=maritime.

This PR considers both tags to be valid techniques of marking maritime borders.

Fixes #1482

I've created a [test style](https://gist.github.com/kevinschaul/ad8c9502c42ccd999323c9c854905e11) that can be used with Maputnik to view the behavior. Screenshots follow.

Teal lines are `maritime = 1`, purple lines are not.

**Current behavior**
![maritime-current](https://user-images.githubusercontent.com/675639/213765503-efa7862b-4efe-4035-a9ba-c7894d33173d.png)

**Proposed behavior**
![maritime-proposed](https://user-images.githubusercontent.com/675639/213765518-8194aedd-e9de-42d2-adc2-3c87c34f29d5.png)

