### PR TITLE
[Bugfix] Set paved attribute for paved tracks

### DIFF
--- a/layers/transportation/class.sql
+++ b/layers/transportation/class.sql
@@ -48,7 +48,7 @@ CREATE OR REPLACE FUNCTION surface_value(surface text) RETURNS text AS
 $$
 SELECT CASE
            WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'concrete', 'concrete:lanes', 'concrete:plates', 'metal',
-                            'paving_stones', 'sett', 'unhewn_cobblestone', 'wood') THEN 'paved'
+                            'paving_stones', 'sett', 'unhewn_cobblestone', 'wood', 'grade1') THEN 'paved'
            WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel',
                             'gravel_turf', 'ground', 'ice', 'mud', 'pebblestone', 'salt', 'sand', 'snow', 'woodchips')
                THEN 'unpaved'

--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -180,6 +180,9 @@ tables:
     - name: construction
       key: construction
       type: string
+    - name: tracktype
+      key: tracktype
+      type: string
     - *ref
     - *network
     - *z_order

--- a/layers/transportation/transportation.sql
+++ b/layers/transportation/transportation.sql
@@ -368,7 +368,7 @@ FROM (
                 foot,
                 horse,
                 mtb_scale,
-                surface_value(surface) AS "surface",
+                surface_value(COALESCE(NULLIF(surface, ''), tracktype)) AS "surface",
                 hl.z_order
          FROM osm_highway_linestring hl
          LEFT OUTER JOIN osm_transportation_name_network n ON hl.osm_id = n.osm_id


### PR DESCRIPTION
This PR sets `surface=paved` for `highway=track` + `tracktype=grade1` if no other value of `surface` is set.  Roads tagged in this way are [generally paved](https://wiki.openstreetmap.org/wiki/Key:tracktype) and therefore encoding them as a paved road is appropriate.

Render samples for a road marked as a [paved track road](https://www.openstreetmap.org/way/1126554999):

![image](https://user-images.githubusercontent.com/3254090/214414023-7ec17112-4a59-409e-81a1-89b347f8d4f2.png)

Compare to [current baseline](https://6ug7hetxl9.execute-api.us-east-2.amazonaws.com/data/v3/#15.84/41.618992/-71.419593):

![image](https://user-images.githubusercontent.com/3254090/214414340-a88fa2ed-a6e0-47a0-b3c8-c4ce1367a5f3.png)
