### PR TITLE
Remove unused indexes from osm_transportation_* tables

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -102,8 +102,6 @@ FROM (
       AND hl.highway <> ''
 ) AS t;
 CREATE UNIQUE INDEX IF NOT EXISTS osm_transportation_name_network_osm_id_idx ON osm_transportation_name_network (osm_id);
-CREATE INDEX IF NOT EXISTS osm_transportation_name_network_name_ref_idx ON osm_transportation_name_network (coalesce(tags->'name', ''), coalesce(ref, ''));
-CREATE INDEX IF NOT EXISTS osm_transportation_name_network_geometry_idx ON osm_transportation_name_network USING gist (geometry);
 
 -- Improve performance of the sql in transportation/update_route_member.sql
 CREATE INDEX IF NOT EXISTS osm_highway_linestring_highway_partial_idx
@@ -305,8 +303,6 @@ CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z10_geometry_
 CREATE UNIQUE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z10_id_idx
     ON osm_transportation_merge_linestring_gen_z10(id);
 
-CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z9_geometry_idx
-    ON osm_transportation_merge_linestring_gen_z9 USING gist (geometry);
 CREATE UNIQUE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z9_id_idx
     ON osm_transportation_merge_linestring_gen_z9(id);
 
@@ -357,8 +353,6 @@ FROM (
     ) osm_highway_linestring_normalized_brunnel_z9
 GROUP BY highway, network, construction, is_bridge, is_tunnel, is_ford, expressway
 ;
-CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z8_geometry_idx
-    ON osm_transportation_merge_linestring_gen_z8 USING gist (geometry);
 
 CREATE TABLE IF NOT EXISTS osm_transportation_merge_linestring_gen_z7
     (LIKE osm_transportation_merge_linestring_gen_z8);
@@ -532,27 +526,6 @@ END;
 $$ LANGUAGE plpgsql;
 
 SELECT insert_transportation_merge_linestring_gen_z7(NULL);
-
-CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z7_geometry_idx
-    ON osm_transportation_merge_linestring_gen_z7 USING gist (geometry);
-CREATE UNIQUE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z7_id_idx
-    ON osm_transportation_merge_linestring_gen_z7(id);
-
-CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z6_geometry_idx
-    ON osm_transportation_merge_linestring_gen_z6 USING gist (geometry);
-CREATE UNIQUE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z6_id_idx
-    ON osm_transportation_merge_linestring_gen_z6(id);
-
-CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z5_geometry_idx
-    ON osm_transportation_merge_linestring_gen_z5 USING gist (geometry);
-CREATE UNIQUE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z5_id_idx
-    ON osm_transportation_merge_linestring_gen_z5(id);
-
-CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z4_geometry_idx
-    ON osm_transportation_merge_linestring_gen_z4 USING gist (geometry);
-CREATE UNIQUE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z4_id_idx
-    ON osm_transportation_merge_linestring_gen_z4(id);
-
 
 -- Handle updates on
 -- osm_highway_linestring_gen_z11 -> osm_transportation_merge_linestring_gen_z11

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -92,7 +92,6 @@ FROM (
          GROUP BY name, name_en, name_de, tags, subclass, "level", layer
      ) AS highway_union
 ;
-CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_name_ref_idx ON osm_transportation_name_linestring (coalesce(tags->'name', ''), coalesce(ref, ''));
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_geometry_idx ON osm_transportation_name_linestring USING gist (geometry);
 
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_highway_partial_idx
@@ -117,8 +116,6 @@ WHERE (highway IN ('motorway', 'trunk') OR highway = 'construction' AND subclass
 CREATE TABLE IF NOT EXISTS osm_transportation_name_linestring_gen1 AS
 SELECT *
 FROM osm_transportation_name_linestring_gen1_view;
-CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen1_name_ref_idx ON osm_transportation_name_linestring_gen1((coalesce(tags->'name', ref)));
-CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen1_geometry_idx ON osm_transportation_name_linestring_gen1 USING gist (geometry);
 
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen1_highway_partial_idx
     ON osm_transportation_name_linestring_gen1 (highway, subclass)
@@ -142,8 +139,6 @@ WHERE (highway IN ('motorway', 'trunk') OR highway = 'construction' AND subclass
 CREATE TABLE IF NOT EXISTS osm_transportation_name_linestring_gen2 AS
 SELECT *
 FROM osm_transportation_name_linestring_gen2_view;
-CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen2_name_ref_idx ON osm_transportation_name_linestring_gen2((coalesce(tags->'name', ref)));
-CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen2_geometry_idx ON osm_transportation_name_linestring_gen2 USING gist (geometry);
 
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen2_highway_partial_idx
     ON osm_transportation_name_linestring_gen2 (highway, subclass)
@@ -167,8 +162,6 @@ WHERE (highway = 'motorway' OR highway = 'construction' AND subclass = 'motorway
 CREATE TABLE IF NOT EXISTS osm_transportation_name_linestring_gen3 AS
 SELECT *
 FROM osm_transportation_name_linestring_gen3_view;
-CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen3_name_ref_idx ON osm_transportation_name_linestring_gen3((coalesce(tags->'name', ref)));
-CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen3_geometry_idx ON osm_transportation_name_linestring_gen3 USING gist (geometry);
 
 CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen3_highway_partial_idx
     ON osm_transportation_name_linestring_gen3 (highway, subclass)
@@ -192,8 +185,6 @@ WHERE (highway = 'motorway' OR highway = 'construction' AND subclass = 'motorway
 CREATE TABLE IF NOT EXISTS osm_transportation_name_linestring_gen4 AS
 SELECT *
 FROM osm_transportation_name_linestring_gen4_view;
-CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen4_name_ref_idx ON osm_transportation_name_linestring_gen4((coalesce(tags->'name', ref)));
-CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_gen4_geometry_idx ON osm_transportation_name_linestring_gen4 USING gist (geometry);
 
 -- Handle updates
 


### PR DESCRIPTION
This is an initial attempt to get at removing unnecessary indexes as identified in #1516.

This PR removes apparently unused indexes from the osm_transportation_* tables.

I would appreciate feedback as to why these indexes appear to be unused and whether or not they are safe to remove for performance improvement.