### PR TITLE
Add cusine subclass for food POIs

### DIFF
--- a/layers/poi/mapping.yaml
+++ b/layers/poi/mapping.yaml
@@ -1,4 +1,3 @@
-
 # imposm3 mapping file for https://github.com/osm2vectortiles/imposm3
 # Warning: this is not the official imposm3
 
@@ -74,6 +73,15 @@ def_poi_mapping_barrier: &poi_mapping_barrier
   - sally_port
   - stile
   - toll_booth
+
+# cuisine values , see http://taginfo.openstreetmap.org/keys/cuisine#values
+def_poi_mapping_cuisine: &poi_mapping_cuisine
+  - burger
+  - coffee_shop
+  - donut;coffee_shop
+  - ice_cream
+  - pizza
+  - pizza;italian
 
 # building values , see http://taginfo.openstreetmap.org/keys/building#values
 def_poi_mapping_building: &poi_mapping_building
@@ -383,11 +391,15 @@ def_poi_fields: &poi_fields
   - name: brand
     key: brand
     type: string
+  - name: cuisine
+    key: cuisine
+    type: string
 
 def_poi_mapping: &poi_mapping
   aerialway: *poi_mapping_aerialway
   amenity: *poi_mapping_amenity
   barrier: *poi_mapping_barrier
+  cuisine: *poi_mapping_cuisine
   building: *poi_mapping_building
   highway: *poi_mapping_highway
   historic: *poi_mapping_historic

--- a/layers/poi/poi.sql
+++ b/layers/poi/poi.sql
@@ -32,6 +32,8 @@ SELECT osm_id_hash AS osm_id,
                THEN NULLIF(information, '')
            WHEN subclass = 'place_of_worship'
                THEN NULLIF(religion, '')
+           WHEN subclass IN ('fast_food', 'restaurant')
+               THEN NULLIF(cuisine, '')
            WHEN subclass = 'pitch'
                THEN NULLIF(sport, '')
            ELSE subclass

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -101,6 +101,7 @@ layer:
           Original value of either the
           [`amenity`](http://wiki.openstreetmap.org/wiki/Key:amenity),
           [`barrier`](http://wiki.openstreetmap.org/wiki/Key:barrier),
+          [`cuisine`](http://wiki.openstreetmap.org/wiki/Key:cuisine),
           [`historic`](http://wiki.openstreetmap.org/wiki/Key:historic),
           [`information`](http://wiki.openstreetmap.org/wiki/Key:information),
           [`landuse`](http://wiki.openstreetmap.org/wiki/Key:landuse),


### PR DESCRIPTION
This PR adds select `cuisine` values as subclass values for `fast_food` and `restaurant`. This allows for custom icons for common cuisine types such as "pizza", "burger", "donut", etc.