### PR TITLE
Remove LEAKPROOF attribute from functions

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -22,7 +22,7 @@ SELECT
     ST_Length(g) *
         COS(RADIANS(ST_Y(ST_Centroid(ST_Transform(g, 4326))))) *
         POW(2, zoom_level) / 20131560 > 0.02
-$$ LANGUAGE SQL IMMUTABLE LEAKPROOF
+$$ LANGUAGE SQL IMMUTABLE
                 PARALLEL SAFE;
 
 -- Determine whether a segment is long enough to have layer attributes
@@ -39,7 +39,7 @@ SELECT
         COS(RADIANS(ST_Y(ST_Centroid(ST_Transform(g, 4326))))) *
         POW(2, zoom_level) / 20131560 > 0.02
     THEN layer END
-$$ LANGUAGE SQL IMMUTABLE LEAKPROOF
+$$ LANGUAGE SQL IMMUTABLE
                 PARALLEL SAFE;
 
 -- Instead of using relations to find out the road names we


### PR DESCRIPTION
LEAKPROOF requires the executing user to have superuser privileges when creating the functions which would be the only statement required to be executed as a superuser.

My question would be if the performance gain is worth having to run the import as a superuser or if we could remove this again?