### PR TITLE
Analyzing of changes table during transportation_name updates

### DIFF
--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -1119,7 +1119,7 @@ BEGIN
     -- REFRESH osm_transportation_name_linestring from osm_shipway_linestring
 
     -- Analyze tracking and source tables before performing update
-    ANALYZE transportation_name.name_changes;
+    ANALYZE transportation_name.shipway_changes;
     ANALYZE osm_shipway_linestring;
 
     -- Fetch updated and deleted Merged-LineString from relation-table filtering for each Merged-LineString which
@@ -1288,7 +1288,7 @@ BEGIN
     -- REFRESH osm_transportation_name_linestring from osm_aerialway_linestring
 
     -- Analyze tracking and source tables before performing update
-    ANALYZE transportation_name.name_changes;
+    ANALYZE transportation_name.aerialway_changes;
     ANALYZE osm_aerialway_linestring;
 
     -- Fetch updated and deleted Merged-LineString from relation-table filtering for each Merged-LineString which


### PR DESCRIPTION
Fixes a typo analyzing the `name_changes` table during execution of `transportation_name.refresh_shipway_linestring` and `transportation_name.refresh_aerialway_linestring`