### PR TITLE
boundary.sql Parallelization Issue

### DIFF
--- a/layers/boundary/boundary.sql
+++ b/layers/boundary/boundary.sql
@@ -348,7 +348,8 @@ FROM ne_110m_admin_0_boundary_lines_land_gen_z0
 -- etldoc: ne_50m_admin_0_boundary_lines_land_gen_z1  -> boundary_z1
 -- etldoc: ne_10m_admin_1_states_provinces_lines_gen_z1 -> boundary_z1
 -- etldoc: osm_border_disp_linestring_gen_z1 -> boundary_z1
-CREATE OR REPLACE VIEW boundary_z1 AS
+DROP MATERIALIZED VIEW IF EXISTS boundary_z1 CASCADE;
+CREATE MATERIALIZED VIEW boundary_z1 AS
 (
 SELECT geometry,
        admin_level,
@@ -380,12 +381,14 @@ SELECT geometry,
        maritime
 FROM osm_border_disp_linestring_gen_z1
     );
+CREATE INDEX IF NOT EXISTS boundary_z1_idx ON boundary_z1 USING gist (geometry);
 
 
 -- etldoc: ne_50m_admin_0_boundary_lines_land_gen_z2 -> boundary_z2
 -- etldoc: ne_10m_admin_1_states_provinces_lines_gen_z2 -> boundary_z2
 -- etldoc: osm_border_disp_linestring_gen_z2 -> boundary_z2
-CREATE OR REPLACE VIEW boundary_z2 AS
+DROP MATERIALIZED VIEW IF EXISTS boundary_z2 CASCADE;
+CREATE MATERIALIZED VIEW boundary_z2 AS
 (
 SELECT geometry,
        admin_level,
@@ -417,11 +420,13 @@ SELECT geometry,
        maritime
 FROM osm_border_disp_linestring_gen_z2
     );
+CREATE INDEX IF NOT EXISTS boundary_z2_idx ON boundary_z2 USING gist (geometry);
 
 -- etldoc: ne_50m_admin_0_boundary_lines_land_gen_z3 -> boundary_z3
 -- etldoc: ne_10m_admin_1_states_provinces_lines_gen_z3 -> boundary_z3
 -- etldoc: osm_border_disp_linestring_gen_z3 -> boundary_z3
-CREATE OR REPLACE VIEW boundary_z3 AS
+DROP MATERIALIZED VIEW IF EXISTS boundary_z3 CASCADE;
+CREATE MATERIALIZED VIEW boundary_z3 AS
 (
 SELECT geometry,
        admin_level,
@@ -453,11 +458,13 @@ SELECT geometry,
        maritime
 FROM osm_border_disp_linestring_gen_z3
     );
+CREATE INDEX IF NOT EXISTS boundary_z3_idx ON boundary_z3 USING gist (geometry);
 
 -- etldoc: ne_10m_admin_0_boundary_lines_land_gen_z4 -> boundary_z4
 -- etldoc: ne_10m_admin_1_states_provinces_lines_gen_z4 -> boundary_z4
 -- etldoc: osm_border_linestring_gen_z4 -> boundary_z4
-CREATE OR REPLACE VIEW boundary_z4 AS
+DROP MATERIALIZED VIEW IF EXISTS boundary_z4 CASCADE;
+CREATE MATERIALIZED VIEW boundary_z4 AS
 (
 SELECT geometry,
        admin_level,
@@ -489,6 +496,7 @@ SELECT geometry,
        maritime
 FROM osm_border_linestring_gen_z4
     );
+CREATE INDEX IF NOT EXISTS boundary_z4_idx ON boundary_z4 USING gist (geometry);
 
 -- etldoc: osm_border_linestring_gen_z5 -> boundary_z5
 CREATE OR REPLACE VIEW boundary_z5 AS


### PR DESCRIPTION
VectorTiles generated via the [openmaptiles-tools](https://github.com/openmaptiles/openmaptiles-tools) toolchain and using the OpenMaptiles-SQL-Layers as the query-source result in tiles which can contain duplicated keys.

This is because PostGIS `ST_AsMVT` is used to generate the Tiles and due to the way they [implemented parallelization](https://trac.osgeo.org/postgis/ticket/4310).

Although it is not prohibited by the Mapbox-Vector-Tile-Specification MapBox as well as MapLibre depending on version either throw a lot of warnings or even crash when encountering tiles with duplicated keys.
https://github.com/mapbox/vector-tile/issues/55
https://github.com/maplibre/maplibre-native/issues/795

After investigating I identified the boundary layer in zoom-leves 1 - 4 as the only layers containing duplicated keys.
example tile 1/1/1 inspected with https://github.com/mapbox/vt2geojson:
```
VectorTileLayer {
  version: 2,
  name: 'boundary',
  extent: 4096,
  length: 545,
  _pbf: {
    buf: <Buffer 1a 90 0e 0a 05 77 61 74 65 72 12 cc 0c 12 02 01 00 18 03 22 c3 0c 09 e2 27 7f fa 10 15 06 07 26 23 08 21 0f 19 1e 00 52 16 28 18 0c 06 3e 44 02 10 16 ... 213537 more bytes>,
    pos: 213587,
    length: 213587
  },
  _keys: [
    'admin_level',   'adm0_l',
    'adm0_r',        'disputed',
    'disputed_name', 'claimed_by',
    'maritime',      'admin_level',
    'adm0_l',        'adm0_r',
    'disputed',      'disputed_name',
    'claimed_by',    'maritime'
  ],
  _values: [
    2,
    0,
    1,
    'ne50m_341',
    4,
    2,
    1,
    'Burundi-Rwanda',
    0,
    'Malaysia-Indonesia'
  ],
  _features: [
    2262, 2286, 2310, 2334, 2370, 2395, 2424, 2445, 2468, 2489,
    2544, 2577, 2607, 2631, 2669, 2714, 2735, 2760, 2781, 2807,
    2831, 2856, 2883, 2940, 2969, 2990, 3013, 3047, 3080, 3103,
    3126, 3148, 3187, 3223, 3245, 3289, 3311, 3341, 3363, 3386,
    3408, 3432, 3469, 3515, 3537, 3571, 3595, 3620, 3646, 3680,
    3710, 3732, 3753, 3774, 3795, 3817, 3838, 3859, 3880, 3901,
    3922, 3943, 3964, 3989, 4011, 4035, 4057, 4079, 4100, 4122,
    4144, 4166, 4188, 4209, 4230, 4251, 4272, 4293, 4314, 4336,
    4358, 4380, 4402, 4424, 4446, 4468, 4490, 4536, 4558, 4586,
    4614, 4666, 4688, 4722, 4762, 4784, 4818, 4848, 4870, 4892,
    ... 445 more items
  ]
}
```
As you can see all keys are duplicated and after some thought my reasoning was that the undelying issue must be the `UNION ALL` queries from the views `boundary_z1` - `boundary_z4`.
As i understand the query-planner in postgres 14 will always choose multiple workers in `UNION ALL` queries if the sources are actual physical tables/materialized-views. And as mentioned [here](https://trac.osgeo.org/postgis/ticket/4310) `ST_AsMVT` will not deduplicate keys if the source-data is fetched in parallel.

Refactoring these views to materialized-views should move the parallel fetching of source-data to preprocessing and after doing so we can see this in the generated tiles:
example tile 1/1/1 after the changes of the PR are applied:
```
VectorTileLayer {
  version: 2,
  name: 'boundary',
  extent: 4096,
  length: 540,
  _pbf: {
    buf: <Buffer 1a 90 0e 0a 05 77 61 74 65 72 12 cc 0c 12 02 01 00 18 03 22 c3 0c 09 e2 27 7f fa 10 15 06 07 26 23 08 21 0f 19 1e 00 52 16 28 18 0c 06 3e 44 02 10 16 ... 213286 more bytes>,
    pos: 213336,
    length: 213336
  },
  _keys: [
    'admin_level',
    'adm0_l',
    'adm0_r',
    'disputed',
    'disputed_name',
    'claimed_by',
    'maritime'
  ],
  _values: [ 4, 0, 2, 1, 'Malaysia-Indonesia', 'Burundi-Rwanda', 'ne50m_341' ],
  _features: [
    2262, 2284, 2306, 2328, 2350, 2396, 2418, 2452, 2474, 2532,
    2554, 2588, 2616, 2644, 2666, 2690, 2720, 2748, 2838, 2872,
    2912, 2934, 3010, 3033, 3056, 3079, 3109, 3132, 3161, 3369,
    3435, 3458, 3849, 3871, 3899, 3927, 3949, 4001, 4059, 4139,
    4161, 4213, 4235, 4257, 4305, 4333, 4355, 4381, 4411, 4445,
    4471, 4495, 4519, 4547, 4575, 4598, 4620, 4644, 4681, 4703,
    4724, 4745, 4766, 4788, 4809, 4830, 4851, 4872, 4893, 4914,
    4935, 4960, 4982, 5006, 5028, 5050, 5071, 5093, 5115, 5137,
    5159, 5180, 5201, 5222, 5243, 5264, 5285, 5307, 5329, 5351,
    5373, 5401, 5429, 5481, 5503, 5543, 5577, 5607, 5629, 5651,
    ... 440 more items
  ]
}
```

This fix is not future proof and we should check other layers as well for these issues because the only way to guarantee that no duplicated keys exist is to disable multiprocessing entirely.
This will have a big performance impact and if possible i'd like to avoid that also until now we didn't see any errors after applying this fix.

Also addresses https://github.com/openmaptiles/openmaptiles-tools/issues/425