### PR TITLE
Convert PL/PGSQL to SQL

### DIFF
--- a/layers/transportation_name/highway_classification.sql
+++ b/layers/transportation_name/highway_classification.sql
@@ -1,52 +1,46 @@
 CREATE OR REPLACE FUNCTION highway_to_val(hwy_class varchar)
 RETURNS int
 IMMUTABLE
-LANGUAGE plpgsql
+LANGUAGE sql
 AS $$
-BEGIN
-  CASE hwy_class
-    WHEN 'motorway'     THEN RETURN 6;
-    WHEN 'trunk'        THEN RETURN 5;
-    WHEN 'primary'      THEN RETURN 4;
-    WHEN 'secondary'    THEN RETURN 3;
-    WHEN 'tertiary'     THEN RETURN 2;
-    WHEN 'unclassified' THEN RETURN 1;
-    else RETURN 0;
-  END CASE;
-END;
+  SELECT CASE hwy_class
+    WHEN 'motorway'     THEN 6
+    WHEN 'trunk'        THEN 5
+    WHEN 'primary'      THEN 4
+    WHEN 'secondary'    THEN 3
+    WHEN 'tertiary'     THEN 2
+    WHEN 'unclassified' THEN 1
+    ELSE 0
+  END;
 $$;
 
 CREATE OR REPLACE FUNCTION val_to_highway(hwy_val int)
 RETURNS varchar
 IMMUTABLE
-LANGUAGE plpgsql
+LANGUAGE sql
 AS $$
-BEGIN
-  CASE hwy_val
-    WHEN 6 THEN RETURN 'motorway';
-    WHEN 5 THEN RETURN 'trunk';
-    WHEN 4 THEN RETURN 'primary';
-    WHEN 3 THEN RETURN 'secondary';
-    WHEN 2 THEN RETURN 'tertiary';
-    WHEN 1 THEN RETURN 'unclassified';
-    else RETURN null;
-  END CASE;
-END;
+  SELECT CASE hwy_val
+    WHEN 6 THEN 'motorway'
+    WHEN 5 THEN 'trunk'
+    WHEN 4 THEN 'primary'
+    WHEN 3 THEN 'secondary'
+    WHEN 2 THEN 'tertiary'
+    WHEN 1 THEN 'unclassified'
+    ELSE null
+  END;
 $$;
 
 CREATE OR REPLACE FUNCTION highest_hwy_sfunc(agg_state varchar, hwy_class varchar)
 RETURNS varchar
 IMMUTABLE
-LANGUAGE plpgsql
+LANGUAGE sql
 AS $$
-BEGIN
-  RETURN val_to_highway(
+  SELECT val_to_highway(
     GREATEST(
       highway_to_val(agg_state),
       highway_to_val(hwy_class)
     )
   );
-END;
 $$;
 
 DROP AGGREGATE IF EXISTS highest_highway (varchar);


### PR DESCRIPTION
This PR converts three plpgsql functions in the `transportation_name` layer to sql functions, which perform better.