### PR TITLE
Remove buffering from point-only layers

### DIFF
--- a/layers/aerodrome_label/aerodrome_label.yaml
+++ b/layers/aerodrome_label/aerodrome_label.yaml
@@ -2,7 +2,7 @@ layer:
   id: aerodrome_label
   description: |
       [Aerodrome labels](http://wiki.openstreetmap.org/wiki/Tag:aeroway%3Daerodrome)
-  buffer_size: 64
+  buffer_size: 0
   srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
   fields:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Key:name) value of the aerodrome.

--- a/layers/housenumber/housenumber.yaml
+++ b/layers/housenumber/housenumber.yaml
@@ -4,7 +4,7 @@ layer:
       Everything in OpenStreetMap which contains a `addr:housenumber` tag useful for labelling housenumbers on a map.
       This adds significant size to *z14*. For buildings the centroid of the building is used as housenumber.
       Duplicates within a tile are dropped if they have the same street/block_number (records without name tag are prioritized for preservation).
-  buffer_size: 8
+  buffer_size: 0
   srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
   fields:
     housenumber: Value of the [`addr:housenumber`](http://wiki.openstreetmap.org/wiki/Key:addr) tag.

--- a/layers/mountain_peak/mountain_peak.yaml
+++ b/layers/mountain_peak/mountain_peak.yaml
@@ -5,7 +5,7 @@ layer:
       - ne_10m_admin_0_countries
   description: |
       [Natural peaks](http://wiki.openstreetmap.org/wiki/Tag:natural%3Dpeak)
-  buffer_size: 64
+  buffer_size: 0
   srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
   fields:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Key:name) value of the peak.

--- a/layers/place/place.yaml
+++ b/layers/place/place.yaml
@@ -65,7 +65,7 @@ layer:
           and states and for cities consists out of a shifted
           Natural Earth `scalerank` combined with a local rank
           within a grid for cities that do not have a Natural Earth `scalerank`.
-  buffer_size: 256
+  buffer_size: 0
   datasource:
     geometry_field: geometry
     key_field: osm_id

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -3,7 +3,7 @@ layer:
   description: |
       [Points of interests](http://wiki.openstreetmap.org/wiki/Points_of_interest) containing
       a of a variety of OpenStreetMap tags. Mostly contains amenities, sport, shop and tourist POIs.
-  buffer_size: 64
+  buffer_size: 0
   srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
   fields:
     name: The OSM [`name`](http://wiki.openstreetmap.org/wiki/Key:name) value of the POI.


### PR DESCRIPTION
Based on discussion on Slack and initial experimentation, it appears that we can potentially eliminate buffers on point-only layers, at least as far as maplibre-gl-js rendering is concerned.  It appears that labels and icons still render as expected across tile boundaries. This would save significant duplication in POI or place-heavy tiles.

Opening as draft pending further tests and screenshots to validate whether this can be done safely.

CC/@msbarry