### PR TITLE
Add route name fallback if no route ref exists

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -84,12 +84,12 @@ FROM (
         CASE WHEN highway IN ('footway', 'steps') THEN layer END AS layer,
         CASE WHEN highway IN ('footway', 'steps') THEN level END AS level,
         CASE WHEN highway IN ('footway', 'steps') THEN indoor END AS indoor,
-        NULLIF(rm1.network, '') || '=' || COALESCE(rm1.ref, '') AS route_1,
-        NULLIF(rm2.network, '') || '=' || COALESCE(rm2.ref, '') AS route_2,
-        NULLIF(rm3.network, '') || '=' || COALESCE(rm3.ref, '') AS route_3,
-        NULLIF(rm4.network, '') || '=' || COALESCE(rm4.ref, '') AS route_4,
-        NULLIF(rm5.network, '') || '=' || COALESCE(rm5.ref, '') AS route_5,
-        NULLIF(rm6.network, '') || '=' || COALESCE(rm6.ref, '') AS route_6,
+        NULLIF(rm1.network, '') || '=' || COALESCE(rm1.ref, rm1.name, '') AS route_1,
+        NULLIF(rm2.network, '') || '=' || COALESCE(rm2.ref, rm2.name, '') AS route_2,
+        NULLIF(rm3.network, '') || '=' || COALESCE(rm3.ref, rm3.name, '') AS route_3,
+        NULLIF(rm4.network, '') || '=' || COALESCE(rm4.ref, rm4.name, '') AS route_4,
+        NULLIF(rm5.network, '') || '=' || COALESCE(rm5.ref, rm5.name, '') AS route_5,
+        NULLIF(rm6.network, '') || '=' || COALESCE(rm6.ref, rm6.name, '') AS route_6,
         hl.z_order,
         LEAST(rm1.rank, rm2.rank, rm3.rank, rm4.rank, rm5.rank, rm6.rank) AS route_rank
     FROM osm_highway_linestring hl

--- a/layers/transportation_name/highway_classification.sql
+++ b/layers/transportation_name/highway_classification.sql
@@ -1,52 +1,46 @@
 CREATE OR REPLACE FUNCTION highway_to_val(hwy_class varchar)
 RETURNS int
 IMMUTABLE
-LANGUAGE plpgsql
+LANGUAGE sql
 AS $$
-BEGIN
-  CASE hwy_class
-    WHEN 'motorway'     THEN RETURN 6;
-    WHEN 'trunk'        THEN RETURN 5;
-    WHEN 'primary'      THEN RETURN 4;
-    WHEN 'secondary'    THEN RETURN 3;
-    WHEN 'tertiary'     THEN RETURN 2;
-    WHEN 'unclassified' THEN RETURN 1;
-    else RETURN 0;
-  END CASE;
-END;
+  SELECT CASE hwy_class
+    WHEN 'motorway'     THEN 6
+    WHEN 'trunk'        THEN 5
+    WHEN 'primary'      THEN 4
+    WHEN 'secondary'    THEN 3
+    WHEN 'tertiary'     THEN 2
+    WHEN 'unclassified' THEN 1
+    ELSE 0
+  END;
 $$;
 
 CREATE OR REPLACE FUNCTION val_to_highway(hwy_val int)
 RETURNS varchar
 IMMUTABLE
-LANGUAGE plpgsql
+LANGUAGE sql
 AS $$
-BEGIN
-  CASE hwy_val
-    WHEN 6 THEN RETURN 'motorway';
-    WHEN 5 THEN RETURN 'trunk';
-    WHEN 4 THEN RETURN 'primary';
-    WHEN 3 THEN RETURN 'secondary';
-    WHEN 2 THEN RETURN 'tertiary';
-    WHEN 1 THEN RETURN 'unclassified';
-    else RETURN null;
-  END CASE;
-END;
+  SELECT CASE hwy_val
+    WHEN 6 THEN 'motorway'
+    WHEN 5 THEN 'trunk'
+    WHEN 4 THEN 'primary'
+    WHEN 3 THEN 'secondary'
+    WHEN 2 THEN 'tertiary'
+    WHEN 1 THEN 'unclassified'
+    ELSE null
+  END;
 $$;
 
 CREATE OR REPLACE FUNCTION highest_hwy_sfunc(agg_state varchar, hwy_class varchar)
 RETURNS varchar
 IMMUTABLE
-LANGUAGE plpgsql
+LANGUAGE sql
 AS $$
-BEGIN
-  RETURN val_to_highway(
+  SELECT val_to_highway(
     GREATEST(
       highway_to_val(agg_state),
       highway_to_val(hwy_class)
     )
   );
-END;
 $$;
 
 DROP AGGREGATE IF EXISTS highest_highway (varchar);

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -720,12 +720,12 @@ BEGIN
             CASE WHEN highway IN ('footway', 'steps') THEN layer END AS layer,
             CASE WHEN highway IN ('footway', 'steps') THEN level END AS level,
             CASE WHEN highway IN ('footway', 'steps') THEN indoor END AS indoor,
-	    NULLIF(rm1.network, '') || '=' || COALESCE(rm1.ref, '') AS route_1,
-	    NULLIF(rm2.network, '') || '=' || COALESCE(rm2.ref, '') AS route_2,
-	    NULLIF(rm3.network, '') || '=' || COALESCE(rm3.ref, '') AS route_3,
-	    NULLIF(rm4.network, '') || '=' || COALESCE(rm4.ref, '') AS route_4,
-	    NULLIF(rm5.network, '') || '=' || COALESCE(rm5.ref, '') AS route_5,
-	    NULLIF(rm6.network, '') || '=' || COALESCE(rm6.ref, '') AS route_6,
+	    NULLIF(rm1.network, '') || '=' || COALESCE(rm1.ref, rm1.name, '') AS route_1,
+	    NULLIF(rm2.network, '') || '=' || COALESCE(rm2.ref, rm2.name, '') AS route_2,
+	    NULLIF(rm3.network, '') || '=' || COALESCE(rm3.ref, rm3.name, '') AS route_3,
+	    NULLIF(rm4.network, '') || '=' || COALESCE(rm4.ref, rm4.name, '') AS route_4,
+	    NULLIF(rm5.network, '') || '=' || COALESCE(rm5.ref, rm5.name, '') AS route_5,
+	    NULLIF(rm6.network, '') || '=' || COALESCE(rm6.ref, rm6.name, '') AS route_6,
             hl.z_order,
             LEAST(rm1.rank, rm2.rank, rm3.rank, rm4.rank, rm5.rank, rm6.rank) AS route_rank
         FROM osm_highway_linestring hl


### PR DESCRIPTION
This PR adds a route's name to the `route_X` attributes in `transportation_name` for cases where a route does not have a route number, but rather is named, for example in a case such as ZeLonewolf/openstreetmap-americana#912.

This prevents OSM mappers from manufacturing route refs solely for the purpose of drawing route shields.