### PR TITLE
Restore missing low-zoom transportation_name features

### DIFF
--- a/layers/transportation_name/transportation_name.sql
+++ b/layers/transportation_name/transportation_name.sql
@@ -94,7 +94,7 @@ FROM (
                 NULL::int AS level,
                 NULL::boolean AS indoor
          FROM osm_transportation_name_linestring_gen3
-         WHERE zoom_level = 7
+         WHERE ST_Length(geometry) > 20000 AND zoom_level = 7
          UNION ALL
 
          -- etldoc: osm_transportation_name_linestring_gen2 ->  layer_transportation_name:z8
@@ -116,7 +116,7 @@ FROM (
                 NULL::int AS level,
                 NULL::boolean AS indoor
          FROM osm_transportation_name_linestring_gen2
-         WHERE zoom_level = 8
+         WHERE ST_Length(geometry) > 14000 AND zoom_level = 8
          UNION ALL
 
          -- etldoc: osm_transportation_name_linestring_gen1 ->  layer_transportation_name:z9
@@ -140,7 +140,7 @@ FROM (
                 NULL::int AS level,
                 NULL::boolean AS indoor
          FROM osm_transportation_name_linestring_gen1
-         WHERE zoom_level BETWEEN 9 AND 11
+         WHERE ST_Length(geometry) > 8000 / POWER(2, zoom_level - 9) AND zoom_level BETWEEN 9 AND 11
          UNION ALL
 
          -- etldoc: osm_transportation_name_linestring ->  layer_transportation_name:z12

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -267,7 +267,7 @@ CREATE INDEX IF NOT EXISTS osm_transportation_name_linestring_geometry_idx
 -- Create table for simplified LineStrings
 CREATE TABLE IF NOT EXISTS osm_transportation_name_linestring_gen1 (
     id integer,
-    geometry geometry('LineString'),
+    geometry geometry,
     tags hstore,
     ref text,
     highway varchar,
@@ -425,20 +425,30 @@ BEGIN
     -- etldoc: osm_transportation_name_linestring -> osm_transportation_name_linestring_gen1
     INSERT INTO osm_transportation_name_linestring_gen1 (id, geometry, tags, ref, highway, subclass, brunnel, network,
                                                          route_1, route_2, route_3, route_4, route_5, route_6, z_order)
-    SELECT id, ST_Simplify(geometry, 50) AS geometry, tags, ref, highway, subclass, brunnel, network, route_1, route_2,
-           route_3, route_4, route_5, route_6, z_order
-    FROM osm_transportation_name_linestring
+    SELECT MIN(id) as id,
+           ST_Simplify(ST_LineMerge(ST_Collect(geometry)), 50) AS geometry,
+           tags, ref, highway, subclass, brunnel, network,
+           route_1, route_2, route_3, route_4, route_5, route_6, z_order
+    FROM (
+        SELECT id,
+               geometry,
+               tags, ref, highway, subclass,
+               CASE WHEN ST_Length(geometry) > 8000 THEN brunnel ELSE '' END AS brunnel,
+               network, route_1, route_2, route_3, route_4, route_5, route_6, z_order
+        FROM osm_transportation_name_linestring
+    ) osm_transportation_name_linestring_gen1_pre_merge
     WHERE (
         full_update IS TRUE OR EXISTS (
             SELECT NULL
             FROM transportation_name.name_changes_gen
             WHERE transportation_name.name_changes_gen.is_old IS FALSE AND
-                  transportation_name.name_changes_gen.id = osm_transportation_name_linestring.id
+                  transportation_name.name_changes_gen.id = osm_transportation_name_linestring_gen1_pre_merge.id
         )
     ) AND (
-        (highway IN ('motorway', 'trunk') OR highway = 'construction' AND subclass IN ('motorway', 'trunk')) AND
-        ST_Length(geometry) > 8000
-    ) ON CONFLICT (id) DO UPDATE SET geometry = excluded.geometry, tags = excluded.tags, ref = excluded.ref,
+        (highway IN ('motorway', 'trunk') OR highway = 'construction' AND subclass IN ('motorway', 'trunk'))
+    )
+    GROUP BY tags, ref, highway, subclass, brunnel, network, route_1, route_2, route_3, route_4, route_5, route_6, z_order
+    ON CONFLICT (id) DO UPDATE SET geometry = excluded.geometry, tags = excluded.tags, ref = excluded.ref,
                                      highway = excluded.highway, subclass = excluded.subclass,
                                      brunnel = excluded.brunnel, network = excluded.network, route_1 = excluded.route_1,
                                      route_2 = excluded.route_2, route_3 = excluded.route_3, route_4 = excluded.route_4,
@@ -458,20 +468,30 @@ BEGIN
     -- etldoc: osm_transportation_name_linestring_gen1 -> osm_transportation_name_linestring_gen2
     INSERT INTO osm_transportation_name_linestring_gen2 (id, geometry, tags, ref, highway, subclass, brunnel, network,
                                                          route_1, route_2, route_3, route_4, route_5, route_6, z_order)
-    SELECT id, ST_Simplify(geometry, 120) AS geometry, tags, ref, highway, subclass, brunnel, network, route_1, route_2,
-           route_3, route_4, route_5, route_6, z_order
-    FROM osm_transportation_name_linestring_gen1
+    SELECT MIN(id) as id,
+           ST_Simplify(ST_LineMerge(ST_Collect(geometry)), 120) AS geometry,
+           tags, ref, highway, subclass, brunnel, network,
+           route_1, route_2, route_3, route_4, route_5, route_6, z_order
+    FROM (
+        SELECT id,
+               (ST_Dump(geometry)).geom AS geometry,
+               tags, ref, highway, subclass,
+               CASE WHEN ST_Length(geometry) > 14000 THEN brunnel ELSE '' END AS brunnel,
+               network, route_1, route_2, route_3, route_4, route_5, route_6, z_order
+        FROM osm_transportation_name_linestring_gen1
+    ) osm_transportation_name_linestring_gen2_pre_merge
     WHERE (
         full_update IS TRUE OR EXISTS (
             SELECT NULL
             FROM transportation_name.name_changes_gen
             WHERE transportation_name.name_changes_gen.is_old IS FALSE AND
-                  transportation_name.name_changes_gen.id = osm_transportation_name_linestring_gen1.id
+                  transportation_name.name_changes_gen.id = osm_transportation_name_linestring_gen2_pre_merge.id
         )
     ) AND (
-        (highway IN ('motorway', 'trunk') OR highway = 'construction' AND subclass IN ('motorway', 'trunk')) AND
-        ST_Length(geometry) > 14000
-    ) ON CONFLICT (id) DO UPDATE SET geometry = excluded.geometry, tags = excluded.tags, ref = excluded.ref,
+        (highway IN ('motorway', 'trunk') OR highway = 'construction' AND subclass IN ('motorway', 'trunk'))
+    )
+    GROUP BY tags, ref, highway, subclass, brunnel, network, route_1, route_2, route_3, route_4, route_5, route_6, z_order
+    ON CONFLICT (id) DO UPDATE SET geometry = excluded.geometry, tags = excluded.tags, ref = excluded.ref,
                                      highway = excluded.highway, subclass = excluded.subclass,
                                      brunnel = excluded.brunnel, network = excluded.network, route_1 = excluded.route_1,
                                      route_2 = excluded.route_2, route_3 = excluded.route_3, route_4 = excluded.route_4,
@@ -491,20 +511,30 @@ BEGIN
     -- etldoc: osm_transportation_name_linestring_gen2 -> osm_transportation_name_linestring_gen3
     INSERT INTO osm_transportation_name_linestring_gen3 (id, geometry, tags, ref, highway, subclass, brunnel, network,
                                                          route_1, route_2, route_3, route_4, route_5, route_6, z_order)
-    SELECT id, ST_Simplify(geometry, 200) AS geometry, tags, ref, highway, subclass, brunnel, network, route_1, route_2,
-           route_3, route_4, route_5, route_6, z_order
-    FROM osm_transportation_name_linestring_gen2
+    SELECT MIN(id) as id,
+           ST_Simplify(ST_LineMerge(ST_Collect(geometry)), 200) AS geometry,
+           tags, ref, highway, subclass, brunnel, network,
+           route_1, route_2, route_3, route_4, route_5, route_6, z_order
+    FROM (
+        SELECT id,
+               (ST_Dump(geometry)).geom AS geometry,
+               tags, ref, highway, subclass,
+               CASE WHEN ST_Length(geometry) > 20000 THEN brunnel ELSE '' END AS brunnel,
+               network, route_1, route_2, route_3, route_4, route_5, route_6, z_order
+        FROM osm_transportation_name_linestring_gen2
+    ) osm_transportation_name_linestring_gen3_pre_merge
     WHERE (
         full_update IS TRUE OR EXISTS (
             SELECT NULL
             FROM transportation_name.name_changes_gen
             WHERE transportation_name.name_changes_gen.is_old IS FALSE AND
-                  transportation_name.name_changes_gen.id = osm_transportation_name_linestring_gen2.id
+                  transportation_name.name_changes_gen.id = osm_transportation_name_linestring_gen3_pre_merge.id
         )
     ) AND (
-        (highway = 'motorway' OR highway = 'construction' AND subclass = 'motorway') AND
-        ST_Length(geometry) > 20000
-    ) ON CONFLICT (id) DO UPDATE SET geometry = excluded.geometry, tags = excluded.tags, ref = excluded.ref,
+        (highway = 'motorway' OR highway = 'construction' AND subclass = 'motorway')
+    )
+    GROUP BY tags, ref, highway, subclass, brunnel, network, route_1, route_2, route_3, route_4, route_5, route_6, z_order
+    ON CONFLICT (id) DO UPDATE SET geometry = excluded.geometry, tags = excluded.tags, ref = excluded.ref,
                                      highway = excluded.highway, subclass = excluded.subclass,
                                      brunnel = excluded.brunnel, network = excluded.network, route_1 = excluded.route_1,
                                      route_2 = excluded.route_2, route_3 = excluded.route_3, route_4 = excluded.route_4,


### PR DESCRIPTION
Unblocks #1576

This PR restores missing transportation_name features that are missing from zoom 11 and improves the mechanism by which transportation_name features are merged through lower zooms. This prevents route features from being dropped due to bridge interleaving (when a bridge interrupts an otherwise continuous route).

This fix moves the length check to a later stage of processing and merges bridges/tunnels if they're too small.  This is similar to the work done in the transportation layer to merge bridges that are too small to render lines.  In this layer, bridges are merged when they're too small to justify a separate label.

Current Release:
![image](https://github.com/openmaptiles/openmaptiles/assets/3254090/a5a7d5f1-714f-4c47-9f93-da4c8d7b5f58)

Before this PR:
![image](https://github.com/openmaptiles/openmaptiles/assets/3254090/af4081ef-846c-45d8-af07-881424c610ab)

After this PR:
![image](https://github.com/openmaptiles/openmaptiles/assets/3254090/ab647580-bc87-41e2-bed4-76f67513bf9f)
