### PR TITLE
fix unexpected error brought by typo: tigger -> trigger & fix `trigger_flag` was created on a wrong target

### DIFF
--- a/layers/park/update_park_polygon.sql
+++ b/layers/park/update_park_polygon.sql
@@ -48,8 +48,8 @@ DROP TRIGGER IF EXISTS update_row ON osm_park_polygon_gen_z7;
 DROP TRIGGER IF EXISTS update_row ON osm_park_polygon_gen_z6;
 DROP TRIGGER IF EXISTS update_row ON osm_park_polygon_gen_z5;
 DROP TRIGGER IF EXISTS update_row ON osm_park_polygon_gen_z4;
-DROP TRIGGER IF EXISTS tigger_flag ON osm_park_polygon;
-DROP TRIGGER IF EXISTS tigger_refresh ON park_polygon.updates;
+DROP TRIGGER IF EXISTS trigger_flag ON osm_park_polygon;
+DROP TRIGGER IF EXISTS trigger_refresh ON park_polygon.updates;
 
 -- etldoc:  osm_park_polygon ->  osm_park_polygon
 -- etldoc:  osm_park_polygon_gen_z13 ->  osm_park_polygon_gen_z13
@@ -248,7 +248,7 @@ EXECUTE PROCEDURE update_osm_park_dissolved_polygon_row();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE OR DELETE
-    ON osm_park_polygon_gen_z4
+    ON osm_park_polygon
     FOR EACH STATEMENT
 EXECUTE PROCEDURE park_polygon.flag();
 


### PR DESCRIPTION
Hi, I'm just working on OpenMapTiles, it's very cool! There are two issues that may be a bug:

1) The trigger name has a typo of `trigger`, which is incorrectly spelled as `tigger` and doesn't match the following create command: `CREATE TRIGGER trigger_flag`. This may result in an error when invoking `make import-sql`.

```
ERROR:  trigger "trigger_flag" for relation "osm_park_polygon_gen_z4" already exists
xargs: sh: exited with status 255; aborting
```

2) The `trigger_flag` may be created on the wrong target in line [#251](https://github.com/plainheart/openmaptiles/blob/master/layers/park/update_park_polygon.sql#L251). I think it should be an unintentional mistake. I'm sorry and will revert this change if it's not so.