### PR TITLE
Transportation: add filter to reject unsigned routes

### DIFF
--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -491,6 +491,9 @@ tables:
     - name: colour
       key: colour
       type: string
+    filters:
+      reject:
+        unsigned: ["yes"]
     mapping:
       route:
       - road


### PR DESCRIPTION
This is my suggested fix for issue #1613. It discards transportation routes tagged with `unsigned=yes`.

The code is inspired by the already-existing filtering of water polygons with `covered=yes` in the water layer.

Disclaimer: I have no experience with this code repository and have not tested this.