### PR TITLE
Keep the filter for motorways on z4 same as z5.

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -807,8 +807,7 @@ BEGIN
             WHERE transportation.changes_z4_z5_z6_z7.is_old IS FALSE AND
                   transportation.changes_z4_z5_z6_z7.id = osm_transportation_merge_linestring_gen_z5.id
         )) AND
-        osm_national_network(network) AND
-        -- Current view: national-importance motorways and trunks
+        -- Current view: same as z5
         ST_Length(geometry) > 1000
     ON CONFLICT (id) DO UPDATE SET osm_id = excluded.osm_id, highway = excluded.highway, network = excluded.network,
                                    construction = excluded.construction, is_bridge = excluded.is_bridge,


### PR DESCRIPTION
During development of https://github.com/openmaptiles/openmaptiles/pull/1440 and https://github.com/openmaptiles/openmaptiles/pull/1446 were prefered national-importance motorways included in https://github.com/openmaptiles/openmaptiles/blob/eb7f6be45545cdb2db0afbe180864c9b0afb18c1/layers/transportation/network_type.sql#L26-L34

It works for the US and the CA, where these attributes are filled. But the rest of the world on a zoom 4 is empty. 

This PR returns highways for a zoom 4 worldwide.

@ZeLonewolf as these two PRs are from you, is it OK to keep it like this?

Visuals of the Czech Republic (over zoom with 200% to see more CZ)

Current state ->
![Screenshot from 2024-01-19 17-45-33](https://github.com/openmaptiles/openmaptiles/assets/5182210/8664551b-b009-4793-813c-140da405066d)

PR proposal ->
![Screenshot from 2024-01-19 17-45-37](https://github.com/openmaptiles/openmaptiles/assets/5182210/be81eff5-431b-4282-ac46-1802fbf7b2dd)



