### PR TITLE
🐛 remove duplicate "requires" key

### DIFF
--- a/layers/place/place.yaml
+++ b/layers/place/place.yaml
@@ -5,7 +5,6 @@ layer:
       - ne_10m_admin_1_states_provinces
       - ne_10m_admin_0_countries
       - ne_10m_populated_places
-  requires:
     layers:
       - boundary
   description: |


### PR DESCRIPTION
We're reading and parsing the Yaml files within Node.Js and noticed that the parser won't handle the scenario where an object has the same keys twice.

I also assume that the first one is being ignored in favor of the second one.