### PR TITLE
Moved confectionery from ice_cream class to shop

### DIFF
--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -18,7 +18,7 @@ layer:
       values:
         shop:
           subclass: ['accessories', 'antiques', 'beauty', 'bed', 'boutique', 'camera', 'carpet', 'charity', 'chemist',
-                     'coffee', 'computer', 'convenience', 'copyshop', 'cosmetics', 'garden_centre', 'doityourself',
+                     'coffee', 'computer', 'convenience', 'confectionery', 'copyshop', 'cosmetics', 'garden_centre', 'doityourself',
                      'erotic', 'electronics', 'fabric', 'florist', 'frozen_food', 'furniture', 'video_games', 'video',
                      'general', 'gift', 'hardware', 'hearing_aids', 'hifi', 'ice_cream', 'interior_decoration',
                      'jewelry', 'kiosk', 'locksmith', 'lamps', 'mall', 'massage', 'motorcycle', 'mobile_phone',
@@ -69,7 +69,7 @@ layer:
         lodging:
           subclass: ['hotel', 'motel', 'bed_and_breakfast', 'guest_house', 'hostel', 'chalet', 'alpine_hut', 'dormitory']
         ice_cream:
-          subclass: ['chocolate', 'confectionery']
+          subclass: ['chocolate']
         post:
           subclass: ['post_box', 'post_office', 'parcel_locker']
         cafe:


### PR DESCRIPTION
Correct me if I'm wrong, but ice_cream doesn't sound like a good class for confectionery. It also confuses renderers and creates something like that (photo from MapTiler OpenStreetMap style):

[OSM POI location](https://www.openstreetmap.org/node/6357619085)
![image](https://github.com/openmaptiles/openmaptiles/assets/114614618/7fbf3714-dcf3-423d-9acf-4407c74d76f2)

This happened because of the classification of confectionery to ice_cream class instead of shop.