### PR TITLE
Fix housenumber_display.sql function

### DIFF
--- a/layers/housenumber/housenumber_display.sql
+++ b/layers/housenumber/housenumber_display.sql
@@ -15,6 +15,6 @@ RETURNS text AS $$
     WHEN raw_housenumber ~ '[^0-9;]' THEN display_housenumber_nonnumeric(raw_housenumber)
     ELSE
       (SELECT min(value)::text || '–' || max(value)::text
-       FROM unnest(array_remove(string_to_array(raw_housenumber, ';'), '')::int[]) AS value)
+        FROM unnest(array_remove(string_to_array(raw_housenumber, ';'), '')::bigint[]) AS value)
   END
 $$ LANGUAGE SQL IMMUTABLE;


### PR DESCRIPTION
Fixes `housenumber_display.sql` function and further improves https://github.com/openmaptiles/openmaptiles/pull/1632

Parsing text values that contain `;`, the string was split into array of values which were casted to `integer`. However, that fails for housenumber that exceed Postgres `int` range `-2147483648` to `+2147483647`.
There are such housenumber, e.g.: https://www.openstreetmap.org/way/1091331906#map=19/-3.82721/-38.59269