### PR TITLE
Bump OpenMapTiles Tools version.

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@
 TILESET_FILE=openmaptiles.yaml
 
 # Use 3-part patch version to ignore patch updates, e.g. 7.0.0
-TOOLS_VERSION=7.0
+TOOLS_VERSION=7.1
 
 # Make sure these values are in sync with the ones in .env-postgres file
 PGDATABASE=openmaptiles


### PR DESCRIPTION
Bump OMT-T version.

[Changelog](https://github.com/openmaptiles/openmaptiles-tools/releases/tag/v7.1.0).
