### PR TITLE
Change place/poi centroids to use pointonsurface

### DIFF
--- a/layers/boundary/update_boundary_polygon.sql
+++ b/layers/boundary/update_boundary_polygon.sql
@@ -47,43 +47,43 @@ $$
 BEGIN
     UPDATE osm_boundary_polygon
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_boundary_polygon_gen_z13
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_boundary_polygon_gen_z12
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_boundary_polygon_gen_z11
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_boundary_polygon_gen_z10
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_boundary_polygon_gen_z9
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_boundary_polygon_gen_z8
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_boundary_polygon_gen_z7
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_boundary_polygon_gen_z6
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_boundary_polygon_gen_z5
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
 END;
 $$ LANGUAGE plpgsql;
@@ -142,7 +142,7 @@ AS
 $$
 BEGIN
     NEW.tags = update_tags(NEW.tags, NEW.geometry);
-    NEW.geometry_point = st_centroid(NEW.geometry);
+    NEW.geometry_point = ST_PointOnSurface(NEW.geometry);
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/layers/park/update_park_polygon.sql
+++ b/layers/park/update_park_polygon.sql
@@ -67,43 +67,43 @@ $$
 BEGIN
     UPDATE osm_park_polygon
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_park_polygon_gen_z13
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_park_polygon_gen_z12
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_park_polygon_gen_z11
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_park_polygon_gen_z10
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_park_polygon_gen_z9
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_park_polygon_gen_z8
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_park_polygon_gen_z7
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_park_polygon_gen_z6
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     UPDATE osm_park_polygon_gen_z5
     SET tags           = update_tags(tags, geometry),
-        geometry_point = st_centroid(geometry);
+        geometry_point = ST_PointOnSurface(geometry);
 
     REFRESH MATERIALIZED VIEW CONCURRENTLY osm_park_polygon_dissolve_z4;
 END;
@@ -165,7 +165,7 @@ AS
 $$
 BEGIN
     NEW.tags = update_tags(NEW.tags, NEW.geometry);
-    NEW.geometry_point = st_centroid(NEW.geometry);
+    NEW.geometry_point = ST_PointOnSurface(NEW.geometry);
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/layers/poi/style.json
+++ b/layers/poi/style.json
@@ -28,7 +28,10 @@
             "image",
             [
               "match",
-              ["get", "subclass"],
+              [
+                "get",
+                "subclass"
+              ],
               "chocolate",
               "confectionery",
               "wine",
@@ -39,7 +42,10 @@
               "perfumery",
               "wholesale",
               "trade",
-              ["get", "subclass"]
+              [
+                "get",
+                "subclass"
+              ]
             ]
           ],
           [
@@ -118,10 +124,16 @@
         },
         "icon-image": [
           "match",
-          ["get", "subclass"],
+          [
+            "get",
+            "subclass"
+          ],
           "chocolate",
           "confectionery",
-          ["get", "subclass"]
+          [
+            "get",
+            "subclass"
+          ]
         ],
         "text-field": "{name:latin}\n{name:nonlatin}",
         "visibility": "visible",


### PR DESCRIPTION
Fixes #1640 

This ensures that place and poi points computed from areas result in a point node that is actually inside the area that it's derived from.  Unusual shaped areas (like a banana shape, for example) may produce points that aren't actually contained.