### PR TITLE
More roads for z4 and z5.

### DIFF
--- a/layers/transportation/network_type.sql
+++ b/layers/transportation/network_type.sql
@@ -31,7 +31,11 @@ $$
         -- Canada
         'ca-transcanada', 'ca-provincial-arterial',
         -- United States
-        'us-interstate',
+        'us-interstate', 'us-highway',
+        -- UK
+        'gb-motorway', 'gb-trunk',
+        -- Ireland
+        'ie-motorway', 'ie-national',
         -- Europe
         'e-road',
         -- Asia

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -807,7 +807,8 @@ BEGIN
             WHERE transportation.changes_z4_z5_z6_z7.is_old IS FALSE AND
                   transportation.changes_z4_z5_z6_z7.id = osm_transportation_merge_linestring_gen_z5.id
         )) AND
-        osm_national_network(network) AND
+        (highway = 'motorway' AND osm_national_network(network)
+        ) AND
         -- Current view: national-importance motorways and trunks
         ST_Length(geometry) > 1000
     ON CONFLICT (id) DO UPDATE SET osm_id = excluded.osm_id, highway = excluded.highway, network = excluded.network,


### PR DESCRIPTION
This PR adds more roads to the zoom 4 for the United Kingdom and Ireland. Adding more roads for the USA at zoom 5.

The United Kingdom and Ireland zoom 4 now

![Screenshot from 2024-03-12 17-07-32](https://github.com/openmaptiles/openmaptiles/assets/5182210/cd746c89-f122-41ad-b16e-a48296be9782)

after
![image](https://github.com/openmaptiles/openmaptiles/assets/5182210/0eab48d2-b460-4a3c-8341-6c6a56cb6341)

The USA zoom 5 now

![image](https://github.com/openmaptiles/openmaptiles/assets/5182210/d42aa9d6-7d1e-4ba1-8291-4334c3a1642f)

after

![image](https://github.com/openmaptiles/openmaptiles/assets/5182210/cde92bc9-e84c-490e-9309-7303e3264d4c)
