### PR TITLE
Fix maritime low zooms

### DIFF
--- a/layers/boundary/boundary.sql
+++ b/layers/boundary/boundary.sql
@@ -160,7 +160,7 @@ CREATE MATERIALIZED VIEW osm_border_disp_linestring_gen_z3 AS
 (
 SELECT ST_Simplify(geometry, ZRes(4)) AS geometry, adm0_l, adm0_r, admin_level, TRUE AS disputed, name, claimed_by, maritime
 FROM osm_border_linestring_gen_z4
-WHERE disputed -- AND admin_level = 2
+WHERE disputed AND NOT maritime -- AND admin_level = 2
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
 CREATE INDEX IF NOT EXISTS osm_border_disp_linestring_gen_z3_idx ON osm_border_disp_linestring_gen_z3 USING gist (geometry);
 

--- a/layers/boundary/boundary.sql
+++ b/layers/boundary/boundary.sql
@@ -154,34 +154,6 @@ WHERE admin_level = 2 AND maritime
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
 CREATE INDEX IF NOT EXISTS osm_border_linestring_gen_z4_idx ON osm_border_linestring_gen_z4 USING gist (geometry);
 
--- etldoc: osm_border_linestring_gen_z4 -> osm_border_disp_linestring_gen_z3
-DROP MATERIALIZED VIEW IF EXISTS osm_border_disp_linestring_gen_z3 CASCADE;
-CREATE MATERIALIZED VIEW osm_border_disp_linestring_gen_z3 AS
-(
-SELECT ST_Simplify(geometry, ZRes(4)) AS geometry, adm0_l, adm0_r, admin_level, TRUE AS disputed, name, claimed_by, maritime
-FROM osm_border_linestring_gen_z4
-WHERE disputed AND NOT maritime -- AND admin_level = 2
-    ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
-CREATE INDEX IF NOT EXISTS osm_border_disp_linestring_gen_z3_idx ON osm_border_disp_linestring_gen_z3 USING gist (geometry);
-
--- etldoc: osm_border_disp_linestring_gen_z3 -> osm_border_disp_linestring_gen_z2
-DROP MATERIALIZED VIEW IF EXISTS osm_border_disp_linestring_gen_z2 CASCADE;
-CREATE MATERIALIZED VIEW osm_border_disp_linestring_gen_z2 AS
-(
-SELECT ST_Simplify(geometry, ZRes(3)) AS geometry, adm0_l, adm0_r, admin_level, TRUE AS disputed, name, claimed_by, maritime
-FROM osm_border_disp_linestring_gen_z3
-    ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
-CREATE INDEX IF NOT EXISTS osm_border_disp_linestring_gen_z2_idx ON osm_border_disp_linestring_gen_z2 USING gist (geometry);
-
--- etldoc: osm_border_disp_linestring_gen_z2 -> osm_border_disp_linestring_gen_z1
-DROP MATERIALIZED VIEW IF EXISTS osm_border_disp_linestring_gen_z1 CASCADE;
-CREATE MATERIALIZED VIEW osm_border_disp_linestring_gen_z1 AS
-(
-SELECT ST_Simplify(geometry, ZRes(2)) AS geometry, adm0_l, adm0_r, admin_level, TRUE AS disputed, name, claimed_by, maritime
-FROM osm_border_disp_linestring_gen_z2
-    ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
-CREATE INDEX IF NOT EXISTS osm_border_disp_linestring_gen_z1_idx ON osm_border_disp_linestring_gen_z1 USING gist (geometry);
-
 -- ne_10m_admin_0_boundary_lines_land
 -- etldoc: ne_10m_admin_0_boundary_lines_land -> ne_10m_admin_0_boundary_lines_land_gen_z4
 DROP MATERIALIZED VIEW IF EXISTS ne_10m_admin_0_boundary_lines_land_gen_z4 CASCADE;
@@ -370,16 +342,6 @@ SELECT geometry,
        claimed_by,
        maritime
 FROM ne_10m_admin_1_states_provinces_lines_gen_z1
-UNION ALL
-SELECT geometry,
-       admin_level,
-       NULL::text AS adm0_l,
-       NULL::text AS adm0_r,
-       TRUE AS disputed,
-       edit_name(name) AS disputed_name,
-       claimed_by,
-       maritime
-FROM osm_border_disp_linestring_gen_z1
     );
 CREATE INDEX IF NOT EXISTS boundary_z1_idx ON boundary_z1 USING gist (geometry);
 
@@ -409,16 +371,6 @@ SELECT geometry,
        claimed_by,
        maritime
 FROM ne_10m_admin_1_states_provinces_lines_gen_z2
-UNION ALL
-SELECT geometry,
-       admin_level,
-       NULL::text AS adm0_l,
-       NULL::text AS adm0_r,
-       TRUE AS disputed,
-       edit_name(name) AS disputed_name,
-       claimed_by,
-       maritime
-FROM osm_border_disp_linestring_gen_z2
     );
 CREATE INDEX IF NOT EXISTS boundary_z2_idx ON boundary_z2 USING gist (geometry);
 
@@ -447,16 +399,6 @@ SELECT geometry,
        claimed_by,
        maritime
 FROM ne_10m_admin_1_states_provinces_lines_gen_z3
-UNION ALL
-SELECT geometry,
-       admin_level,
-       NULL::text AS adm0_l,
-       NULL::text AS adm0_r,
-       TRUE AS disputed,
-       edit_name(name) AS disputed_name,
-       claimed_by,
-       maritime
-FROM osm_border_disp_linestring_gen_z3
     );
 CREATE INDEX IF NOT EXISTS boundary_z3_idx ON boundary_z3 USING gist (geometry);
 

--- a/layers/boundary/boundary.sql
+++ b/layers/boundary/boundary.sql
@@ -150,7 +150,7 @@ CREATE MATERIALIZED VIEW osm_border_linestring_gen_z4 AS
 (
 SELECT ST_Simplify(geometry, ZRes(5)) AS geometry, adm0_l, adm0_r, admin_level, disputed, name, claimed_by, maritime
 FROM osm_border_linestring_gen_z5
-WHERE admin_level = 2 AND (maritime OR disputed)
+WHERE admin_level = 2 AND maritime
     ) /* DELAY_MATERIALIZED_VIEW_CREATION */ ;
 CREATE INDEX IF NOT EXISTS osm_border_linestring_gen_z4_idx ON osm_border_linestring_gen_z4 USING gist (geometry);
 


### PR DESCRIPTION
This PR fixes boundary layer at low zoom levels:

-z4 - remove maritime boundary (Peru, northern and southern end of boundary between Canada and Alaska).

![Screenshot from 2024-03-18 09-17-45](https://github.com/openmaptiles/openmaptiles/assets/19833762/7804bfc8-fcbc-474a-8845-363e5f9a3273)


-z1-z4 - do not mix disputed boundary from NE and OSM - linestrings got duplicated. Use only NE data (z0-z4), then OSM data (z5+)

![image](https://github.com/openmaptiles/openmaptiles/assets/19833762/96971fac-3d0e-4e87-9d3b-330941c7b856)
