### PR TITLE
Revert `e-road` and `a-road`.

### DIFF
--- a/layers/transportation/update_route_member.sql
+++ b/layers/transportation/update_route_member.sql
@@ -48,10 +48,6 @@ WHERE length(ref) > 1
 CREATE OR REPLACE FUNCTION osm_route_member_network_type(network text, ref text) RETURNS route_network_type AS
 $$
 SELECT CASE
-           -- https://wiki.openstreetmap.org/wiki/WikiProject_Europe/E-road_network
-           WHEN network = 'e-road' THEN 'e-road'::route_network_type
-           -- https://wiki.openstreetmap.org/wiki/Asia/Asian_Highway_Network
-           WHEN network = 'AsianHighway' THEN 'a-road'::route_network_type
            -- https://wiki.openstreetmap.org/wiki/United_States_roads_tagging
            WHEN network = 'US:I' THEN 'us-interstate'::route_network_type
            WHEN network = 'US:US' THEN 'us-highway'::route_network_type

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -824,7 +824,7 @@ BEGIN
             WHERE transportation.changes_z4_z5_z6_z7.is_old IS FALSE AND
                   transportation.changes_z4_z5_z6_z7.id = osm_transportation_merge_linestring_gen_z5.id
         )) AND
-        (highway = 'motorway' AND osm_national_network(network)
+        (highway = 'motorway' OR construction = 'motorway'
         ) AND
         -- Current view: national-importance motorways and trunks
         ST_Length(geometry) > 1000


### PR DESCRIPTION
Partial revert the `e-road` and `a-road` added in https://github.com/openmaptiles/openmaptiles/pull/1619.

This PR leads to breaking the change of `network` and `ref` attributes for roads, which are not included in `osm_route_member_network_type`.

(with this PR)
![image](https://github.com/openmaptiles/openmaptiles/assets/5182210/2d85ed5c-b94d-49f3-b56e-eca7a9a17099)

vs (current)

![image](https://github.com/openmaptiles/openmaptiles/assets/5182210/77a44c77-2bd1-424f-a7db-44456dacd964)
