### PR TITLE
Unifying network names.

### DIFF
--- a/layers/transportation_name/transportation_name.sql
+++ b/layers/transportation_name/transportation_name.sql
@@ -58,32 +58,32 @@ SELECT geometry,
            WHEN length(coalesce(ref, '')) > 0
                THEN 'road'
            END AS network,
-       route_1->'network' AS route_1_network,
+       COALESCE(osm_route_member_network_type(route_1->'network', route_1->'ref')::text, route_1->'network') AS route_1_network,
        route_1->'ref' AS route_1_ref,
        route_1->'name' AS route_1_name,
        route_1->'colour' AS route_1_colour,
 
-       route_2->'network' AS route_2_network,
+       COALESCE(osm_route_member_network_type(route_2->'network', route_2->'ref')::text, route_2->'network') AS route_2_network,
        route_2->'ref' AS route_2_ref,
        route_2->'name' AS route_2_name,
        route_2->'colour' AS route_2_colour,
 
-       route_3->'network' AS route_3_network,
+       COALESCE(osm_route_member_network_type(route_3->'network', route_3->'ref')::text, route_3->'network') AS route_3_network,
        route_3->'ref' AS route_3_ref,
        route_3->'name' AS route_3_name,
        route_3->'colour' AS route_3_colour,
 
-       route_4->'network' AS route_4_network,
+       COALESCE(osm_route_member_network_type(route_4->'network', route_4->'ref')::text, route_4->'network') AS route_4_network,
        route_4->'ref' AS route_4_ref,
        route_4->'name' AS route_4_name,
        route_4->'colour' AS route_4_colour,
 
-       route_5->'network' AS route_5_network,
+       COALESCE(osm_route_member_network_type(route_5->'network', route_5->'ref')::text, route_5->'network') AS route_5_network,
        route_5->'ref' AS route_5_ref,
        route_5->'name' AS route_5_name,
        route_5->'colour' AS route_5_colour,
 
-       route_6->'network' AS route_6_network,
+       COALESCE(osm_route_member_network_type(route_6->'network', route_6->'ref')::text, route_6->'network') AS route_6_network,
        route_6->'ref' AS route_6_ref,
        route_6->'name' AS route_6_name,
        route_6->'colour' AS route_6_colour,


### PR DESCRIPTION
This PR is for discussion, if the network names should be unified between attributes `network` and `route_X_network` based on function `osm_route_member_network_type(network, ref)`

Kansas (8/38.087/-97.756) (this PR)
![image](https://github.com/openmaptiles/openmaptiles/assets/5182210/9d3c9486-2180-4d3f-ae0c-ee39a66498f3)

vs (current)
![image](https://github.com/openmaptiles/openmaptiles/assets/5182210/b79cebc1-1455-405e-a31e-1da8e68253c6)
