### PR TITLE
Preserving the highway network in Canada for z4.

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -825,6 +825,8 @@ BEGIN
                   transportation.changes_z4_z5_z6_z7.id = osm_transportation_merge_linestring_gen_z5.id
         )) AND
         (highway = 'motorway' OR construction = 'motorway'
+        ) OR 
+        (osm_national_network(network) AND network != 'gb-trunk'
         ) AND
         -- Current view: national-importance motorways and trunks
         ST_Length(geometry) > 1000


### PR DESCRIPTION
With https://github.com/openmaptiles/openmaptiles/pull/1648 I accidentally remove the Canada TransCanada network from z4. This PR reverts this important road to zoom 4.

![image](https://github.com/openmaptiles/openmaptiles/assets/5182210/049f73a5-db2f-46e8-a45a-b093d9158e65)


At zoom 4, the network `gb-trunk` is too dense, so it is moved to zoom 5+.

![image](https://github.com/openmaptiles/openmaptiles/assets/5182210/3ed7026b-dd94-48a7-8fb0-05a94ec5ad87)

![image](https://github.com/openmaptiles/openmaptiles/assets/5182210/62e39d97-9e5e-4e99-a80d-8eac07a60ed6)
