### PR TITLE
Drop `osm_transportation_name_network` table before recreation.

### DIFF
--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -66,7 +66,8 @@ $$ LANGUAGE SQL IMMUTABLE
 
 -- etldoc: osm_highway_linestring ->  osm_transportation_name_network
 -- etldoc: transportation_route_member_coalesced ->  osm_transportation_name_network
-CREATE TABLE IF NOT EXISTS osm_transportation_name_network AS
+DROP TABLE IF EXISTS osm_transportation_name_network;
+CREATE TABLE osm_transportation_name_network AS
 SELECT
     geometry,
     osm_id,


### PR DESCRIPTION
Drop the main table for layer `transportation_name` layer before creation.

For the first SQL import, it is OK, but for the second import (e.g. for a different country by `import-osm area=yyy`) without dropping the whole database it will keep `osm_transportation_name_network` filled with data from the first import (after first `import-sql` step)

This PR will drop the already-filled table from the first import and insert data from the reimported area.