### PR TITLE
Add British crown dependencies to UK transportation route processing

### DIFF
--- a/layers/transportation/update_route_member.sql
+++ b/layers/transportation/update_route_member.sql
@@ -6,7 +6,7 @@ DROP TRIGGER IF EXISTS trigger_store_transportation_highway_linestring ON osm_hi
 CREATE TABLE IF NOT EXISTS ne_10m_admin_0_gb_buffer AS
 SELECT ST_Buffer(geometry, 10000)
 FROM ne_10m_admin_0_countries
-WHERE iso_a2 = 'GB';
+WHERE iso_a2 IN ('GB', 'IM', 'JE', 'GG');
 
 -- etldoc: ne_10m_admin_0_countries ->  ne_10m_admin_0_ie_buffer
 CREATE TABLE IF NOT EXISTS ne_10m_admin_0_ie_buffer AS


### PR DESCRIPTION
This PR adds the British crown dependencies of Isle of Man, Jersey, and Guernsey to the pseudo-route processing for Great Britain roads, since they use the same numbering scheme.

See also: ZeLonewolf/openstreetmap-americana#1105