### PR TITLE
update transportation style filter format

### DIFF
--- a/layers/transportation/style.json
+++ b/layers/transportation/style.json
@@ -4535,29 +4535,15 @@
         [
           "all",
           [
-            "match",
-            [
-              "get",
-              "brunnel"
-            ],
-            [
-              "bridge",
-              "tunnel"
-            ],
-            false,
-            true
+            "in",
+            "brunnel",
+            "bridge",
+            "tunnel"
           ],
           [
-            "match",
-            [
-              "get",
-              "class"
-            ],
-            [
-              "minor"
-            ],
-            true,
-            false
+            "in",
+            "class",
+            "minor"
           ]
         ]
       ],
@@ -4637,29 +4623,15 @@
         [
           "all",
           [
-            "match",
-            [
-              "get",
-              "brunnel"
-            ],
-            [
-              "bridge",
-              "tunnel"
-            ],
-            false,
-            true
+            "in",
+            "brunnel",
+            "bridge",
+            "tunnel"
           ],
           [
-            "match",
-            [
-              "get",
-              "class"
-            ],
-            [
-              "minor_construction"
-            ],
-            true,
-            false
+            "in",
+            "class",
+            "minor"
           ]
         ]
       ],

--- a/layers/transportation/style.json
+++ b/layers/transportation/style.json
@@ -4631,7 +4631,7 @@
           [
             "in",
             "class",
-            "minor"
+            "minor_construction"
           ]
         ]
       ],


### PR DESCRIPTION
to fix https://github.com/openmaptiles/openmaptiles/issues/1663

the issue is transportation layer filter format not match [maplibre style spec](https://maplibre.org/maplibre-style-spec/deprecations/#combining-filters)

it cause tileserver-gl errors when parse the style.json:
```
The file "style.json" is not a valid style file:
undefined: layers[94].filter[2][1][0]: expected one of [==, !=, >, >=, <, <=, in, !in, all, any, none, has, !has], "match" found
undefined: layers[94].filter[2][2][0]: expected one of [==, !=, >, >=, <, <=, in, !in, all, any, none, has, !has], "match" found
undefined: layers[95].filter[2][1][0]: expected one of [==, !=, >, >=, <, <=, in, !in, all, any, none, has, !has], "match" found
undefined: layers[95].filter[2][2][0]: expected one of [==, !=, >, >=, <, <=, in, !in, all, any, none, has, !has], "match" found
```

note: to reproduce the errors, you need start the docker with entrypoitn bash and run the command `docker-entrypoint.sh` inside the docker

after fix:
![image](https://github.com/openmaptiles/openmaptiles/assets/1667374/649582a5-e558-4291-9040-cf7cf02a6edc)
