### PR TITLE
include mountain peaks without elevation, but with name tag

### DIFF
--- a/layers/mountain_peak/mountain_peak.sql
+++ b/layers/mountain_peak/mountain_peak.sql
@@ -72,8 +72,10 @@ FROM (
                     )::int AS "rank"
          FROM peak_point
          WHERE geometry && bbox
-           AND ele IS NOT NULL
-           AND ele ~ E'^-?\\d{1,4}(\\D|$)'
+           AND (
+            (ele IS NOT NULL AND ele ~ E'^-?\\d{1,4}(\\D|$)')
+            OR name <> ''
+           )
      ) AS ranked_peaks
 WHERE zoom_level >= 7
   AND (rank <= 5 OR zoom_level >= 14)


### PR DESCRIPTION
Fixes #761 and #1328

According to the https://github.com/openmaptiles/openmaptiles/issues/1328#issuecomment-1463800079 I included peaks without elevation, but with a name.