### PR TITLE
Undo inverted brunnel filter for minor roads

### DIFF
--- a/layers/transportation/style.json
+++ b/layers/transportation/style.json
@@ -4535,7 +4535,7 @@
         [
           "all",
           [
-            "in",
+            "!in",
             "brunnel",
             "bridge",
             "tunnel"
@@ -4623,7 +4623,7 @@
         [
           "all",
           [
-            "in",
+            "!in",
             "brunnel",
             "bridge",
             "tunnel"


### PR DESCRIPTION
Re PR #1672: accidentally hides all minor roads except when brunnels
