### PR TITLE
Removed update trigger on osm_boundary_polygon

### DIFF
--- a/layers/boundary/update_boundary_polygon.sql
+++ b/layers/boundary/update_boundary_polygon.sql
@@ -29,8 +29,6 @@ DROP TRIGGER IF EXISTS update_row ON osm_boundary_polygon_gen_z8;
 DROP TRIGGER IF EXISTS update_row ON osm_boundary_polygon_gen_z7;
 DROP TRIGGER IF EXISTS update_row ON osm_boundary_polygon_gen_z6;
 DROP TRIGGER IF EXISTS update_row ON osm_boundary_polygon_gen_z5;
-DROP TRIGGER IF EXISTS trigger_flag ON osm_boundary_polygon;
-DROP TRIGGER IF EXISTS trigger_refresh ON boundary_polygon.updates;
 
 -- etldoc:  osm_boundary_polygon ->  osm_boundary_polygon
 -- etldoc:  osm_boundary_polygon_gen_z13 ->  osm_boundary_polygon_gen_z13


### PR DESCRIPTION
Removed update trigger on osm_boundary_polygon, which attempted to run `REFRESH MATERIALIZED VIEW` on the table `osm_boundary_polygon_gen_z5`, resulting in the following error: 

```
LOG:  Refresh boundary_polygon
CONTEXT:  PL/pgSQL function boundary_polygon.refresh() line 5 at RAISE
STATEMENT:  COMMIT
ERROR:  "osm_boundary_polygon_gen_z5" is not a materialized view
CONTEXT:  SQL statement "REFRESH MATERIALIZED VIEW osm_boundary_polygon_gen_z5"
	PL/pgSQL function boundary_polygon.refresh() line 9 at SQL statement
```
