### PR TITLE
vacuum-db:  use parenthesis for  vacuum options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -596,7 +596,7 @@ psql-list-tables: init-dirs
 .PHONY: vacuum-db
 vacuum-db: init-dirs
 	@echo "Start - postgresql: VACUUM ANALYZE VERBOSE;"
-	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools psql.sh -v ON_ERROR_STOP=1 -P pager=off -c 'VACUUM ANALYZE VERBOSE;'
+	$(DOCKER_COMPOSE) run $(DC_OPTS) openmaptiles-tools psql.sh -v ON_ERROR_STOP=1 -P pager=off -c 'VACUUM (ANALYZE, VERBOSE);'
 
 .PHONY: analyze-db
 analyze-db: init-dirs


### PR DESCRIPTION
Updated `vacuum-db` target to have the vacuum options within parenthesis to avoid syntax error. 

```sql
syntax error at or near "VERBOSE"
LINE 1: VACUUM ANALYZE VERBOSE;
```

When not using parenthesis, the options had to be ordered as listed in https://www.postgresql.org/docs/14/sql-vacuum.html. 