### PR TITLE
Improve getmvt performance on lower zooms (transportaion & poi)

### DIFF
--- a/layers/poi/poi.sql
+++ b/layers/poi/poi.sql
@@ -76,7 +76,7 @@ FROM (
                     ELSE osm_id * 10 + 1
                     END AS osm_id_hash
          FROM osm_poi_polygon
-         WHERE geometry && bbox AND
+         WHERE zoom_level > 9 AND geometry && bbox AND
            CASE
                WHEN zoom_level >= 14 THEN TRUE
                WHEN zoom_level >= 12 AND

--- a/layers/transportation/transportation.sql
+++ b/layers/transportation/transportation.sql
@@ -372,7 +372,7 @@ FROM (
                 hl.z_order
          FROM osm_highway_linestring hl
          LEFT OUTER JOIN osm_transportation_name_network n ON hl.osm_id = n.osm_id
-         WHERE NOT is_area
+         WHERE zoom_level > 11 AND NOT is_area
            AND
                CASE WHEN zoom_level = 12 THEN
                          CASE WHEN transportation_filter_z12(hl.highway, hl.construction) THEN TRUE


### PR DESCRIPTION
I noticed slow performance in `getmvt` when generating tiles at zoom levels ~ 0-8.

The issue was due to CASE blocks in the `transportation` and `poi` layers, which were processing unneccessary rows at lower zoom levels. To optimize this I added a pre-filter on `zoom_level` to reduce the workload. 

In my tests, I timed the query `select getmvt(0,0,0);`. 

`area=europe/united-kingdom`: 

* Before: ~17 seconds
* With this fix:  ~80 ms

 `area=planet`:
 * Before: have not yet timed it, but i believe it was around 15min if i remember correctly
 * With this fix: ~10 seconds

