### PR TITLE
Add 'official' boolean property to foot paths

### DIFF
--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -193,6 +193,14 @@ sac_scale_field: &sac_scale
   key: sac_scale
   name: sac_scale
   type: string
+operator_field: &operator
+  key: operator
+  name: operator
+  type: string
+informal_field: &informal
+  key: informal
+  name: informal
+  type: string
 surface_field: &surface
   key: surface
   name: surface
@@ -249,6 +257,8 @@ tables:
     - *horse
     - *mtb_scale
     - *sac_scale
+    - *operator
+    - *informal
     - *surface
     - *expressway
     mapping:

--- a/layers/transportation/transportation.sql
+++ b/layers/transportation/transportation.sql
@@ -30,6 +30,7 @@ CREATE OR REPLACE FUNCTION layer_transportation(bbox geometry, zoom_level int)
                 foot       text,
                 horse      text,
                 mtb_scale  text,
+                official   int,
                 surface    text
             )
 AS
@@ -70,6 +71,9 @@ SELECT osm_id,
        NULLIF(foot, '') AS foot,
        NULLIF(horse, '') AS horse,
        NULLIF(mtb_scale, '') AS mtb_scale,
+       CASE WHEN highway IN ('path', 'footway', 'cycleway', 'bridleway') THEN official::int
+            ELSE NULL
+       END AS official,
        NULLIF(surface, '') AS surface
 FROM (
          -- etldoc: osm_transportation_merge_linestring_gen_z4 -> layer_transportation:z4
@@ -99,6 +103,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_transportation_merge_linestring_gen_z4
@@ -132,6 +137,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_transportation_merge_linestring_gen_z5
@@ -165,6 +171,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_transportation_merge_linestring_gen_z6
@@ -198,6 +205,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_transportation_merge_linestring_gen_z7
@@ -231,6 +239,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_transportation_merge_linestring_gen_z8
@@ -264,6 +273,10 @@ FROM (
                 foot,
                 horse,
                 mtb_scale,
+                CASE WHEN informal = 'yes' THEN FALSE
+                     WHEN informal = 'no' OR operator != '' THEN TRUE
+                     ELSE NULL
+                END AS official,
                 NULL AS surface,
                 z_order
          FROM osm_transportation_merge_linestring_gen_z9
@@ -297,6 +310,10 @@ FROM (
                 foot,
                 horse,
                 mtb_scale,
+                CASE WHEN informal = 'yes' THEN FALSE
+                     WHEN informal = 'no' OR operator != '' THEN TRUE
+                     ELSE NULL
+                END AS official,
                 NULL AS surface,
                 z_order
          FROM osm_transportation_merge_linestring_gen_z10
@@ -330,6 +347,10 @@ FROM (
                 foot,
                 horse,
                 mtb_scale,
+                CASE WHEN informal = 'yes' THEN FALSE
+                     WHEN informal = 'no' OR operator != '' THEN TRUE
+                     ELSE NULL
+                END AS official,
                 NULL AS surface,
                 z_order
          FROM osm_transportation_merge_linestring_gen_z11
@@ -368,6 +389,10 @@ FROM (
                 foot,
                 horse,
                 mtb_scale,
+                CASE WHEN hl.informal = 'yes' THEN FALSE
+                     WHEN hl.informal = 'no' OR hl.operator != '' THEN TRUE
+                     ELSE NULL
+                END AS official,
                 surface_value(COALESCE(NULLIF(surface, ''), tracktype)) AS "surface",
                 hl.z_order
          FROM osm_highway_linestring hl
@@ -420,6 +445,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_railway_linestring_gen_z8
@@ -456,6 +482,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_railway_linestring_gen_z9
@@ -492,6 +519,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_railway_linestring_gen_z10
@@ -527,6 +555,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_railway_linestring_gen_z11
@@ -562,6 +591,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_railway_linestring_gen_z12
@@ -598,6 +628,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_railway_linestring
@@ -634,6 +665,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_aerialway_linestring_gen_z12
@@ -668,6 +700,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_aerialway_linestring
@@ -701,6 +734,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_shipway_linestring_gen_z4
@@ -734,6 +768,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_shipway_linestring_gen_z5
@@ -767,6 +802,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_shipway_linestring_gen_z6
@@ -800,6 +836,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_shipway_linestring_gen_z7
@@ -833,6 +870,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_shipway_linestring_gen_z8
@@ -866,6 +904,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_shipway_linestring_gen_z9
@@ -899,6 +938,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_shipway_linestring_gen_z10
@@ -932,6 +972,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_shipway_linestring_gen_z11
@@ -965,6 +1006,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_shipway_linestring_gen_z12
@@ -999,6 +1041,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_shipway_linestring
@@ -1040,6 +1083,7 @@ FROM (
                 NULL AS foot,
                 NULL AS horse,
                 NULL AS mtb_scale,
+                NULL::boolean AS official,
                 NULL AS surface,
                 z_order
          FROM osm_highway_polygon

--- a/layers/transportation/transportation.yaml
+++ b/layers/transportation/transportation.yaml
@@ -198,6 +198,10 @@ layer:
     mtb_scale:
       description: |
           Original value of the [`mtb:scale`](http://wiki.openstreetmap.org/wiki/Key:mtb:scale) tag (highways only).
+    official:
+      description: |
+          Whether or not a path or trail is official according to the land manager.
+      values: [0, 1]
     surface:
       description: |
           Values of [`surface`](https://wiki.openstreetmap.org/wiki/Key:surface) tag devided into 2 groups `paved` (paved, asphalt, cobblestone, concrete, concrete:lanes, concrete:plates, metal, paving_stones, sett, unhewn_cobblestone, wood) and `unpaved` (unpaved, compacted, dirt, earth, fine_gravel, grass, grass_paver, gravel, gravel_turf, ground, ice, mud, pebblestone, salt, sand, snow, woodchips).
@@ -207,7 +211,7 @@ layer:
   datasource:
     geometry_field: geometry
     srid: 900913
-    query: (SELECT geometry, class, subclass, network, oneway, ramp, brunnel, service, access, toll, expressway, layer, level, indoor, bicycle, foot, horse, mtb_scale, surface FROM layer_transportation(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, class, subclass, network, oneway, ramp, brunnel, service, access, toll, expressway, layer, level, indoor, bicycle, foot, horse, mtb_scale, official, surface FROM layer_transportation(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./network_type.sql
   - ./class.sql

--- a/layers/transportation/update_transportation_merge.sql
+++ b/layers/transportation/update_transportation_merge.sql
@@ -78,6 +78,8 @@ SELECT
     brunnel,
     "level",
     sac_scale,
+    operator,
+    informal,
     layer,
     indoor,
     network_type,
@@ -99,6 +101,8 @@ FROM (
         NULLIF(hl.construction, '') AS subclass,
         brunnel(hl.is_bridge, hl.is_tunnel, hl.is_ford) AS brunnel,
         sac_scale,
+        operator,
+        informal,
         CASE WHEN highway IN ('footway', 'steps') THEN layer END AS layer,
         CASE WHEN highway IN ('footway', 'steps') THEN level END AS level,
         CASE WHEN highway IN ('footway', 'steps') THEN indoor END AS indoor,
@@ -157,6 +161,8 @@ CREATE TABLE IF NOT EXISTS osm_transportation_merge_linestring_gen_z11(
     horse character varying,
     mtb_scale character varying,
     sac_scale character varying,
+    operator character varying,
+    informal character varying,
     access text,
     toll boolean,
     layer integer
@@ -197,8 +203,8 @@ TRUNCATE osm_transportation_merge_linestring_gen_z11_source_ids;
 -- each group via ST_ClusterDBSCAN
 INSERT INTO osm_transportation_merge_linestring_gen_z11 (geometry, source_ids, highway, network, construction,
                                                          is_bridge, is_tunnel, is_ford, expressway, z_order,
-                                                         bicycle, foot, horse, mtb_scale, sac_scale, access, toll,
-                                                         layer)
+                                                         bicycle, foot, horse, mtb_scale, sac_scale, operator,
+                                                         informal, access, toll, layer)
 SELECT (ST_Dump(ST_LineMerge(ST_Union(geometry)))).geom AS geometry,
        -- We use St_Union instead of St_Collect to ensure no overlapping points exist within the geometries to
        -- merge. https://postgis.net/docs/ST_Union.html
@@ -223,6 +229,8 @@ SELECT (ST_Dump(ST_LineMerge(ST_Union(geometry)))).geom AS geometry,
        horse,
        mtb_scale,
        sac_scale,
+       operator,
+       informal,
        CASE
            WHEN access IN ('private', 'no') THEN 'no'
            ELSE NULL::text END AS access,
@@ -260,6 +268,8 @@ FROM (
                horse,
                mtb_scale,
                sac_scale,
+               operator,
+               informal,
                access,
                toll,
                visible_layer(geometry, layer, 11) AS layer
@@ -267,7 +277,7 @@ FROM (
     ) osm_highway_linestring_normalized_brunnel_z11
 ) q
 GROUP BY cluster_group, cluster, highway, network, construction, is_bridge, is_tunnel, is_ford, expressway,
-         bicycle, foot, horse, mtb_scale, sac_scale, access, toll, layer;
+         bicycle, foot, horse, mtb_scale, sac_scale, operator, informal, access, toll, layer;
 
 -- Geometry Index
 CREATE INDEX IF NOT EXISTS osm_transportation_merge_linestring_gen_z11_geometry_idx
@@ -376,6 +386,8 @@ BEGIN
         horse,
         mtb_scale,
         sac_scale,
+        operator,
+        informal,
         access,
         toll,
         visible_layer(geometry, layer, 11) AS layer
@@ -395,6 +407,7 @@ BEGIN
                                    expressway = excluded.expressway, z_order = excluded.z_order,
                                    bicycle = excluded.bicycle, foot = excluded.foot, horse = excluded.horse,
                                    mtb_scale = excluded.mtb_scale, sac_scale = excluded.sac_scale,
+                                   operator = excluded.operator, informal = excluded.informal,
                                    access = excluded.access, toll = excluded.toll, layer = excluded.layer;
 
     -- Remove entries which have been deleted from source table
@@ -427,6 +440,8 @@ BEGIN
         horse,
         mtb_scale,
         sac_scale,
+        operator,
+        informal,
         access,
         toll,
         visible_layer(geometry, layer, 10) AS layer
@@ -442,6 +457,7 @@ BEGIN
                                    expressway = excluded.expressway, z_order = excluded.z_order,
                                    bicycle = excluded.bicycle, foot = excluded.foot, horse = excluded.horse,
                                    mtb_scale = excluded.mtb_scale, sac_scale = excluded.sac_scale,
+                                   operator = excluded.operator, informal = excluded.informal,
                                    access = excluded.access, toll = excluded.toll, layer = excluded.layer;
 
     -- noinspection SqlWithoutWhere


### PR DESCRIPTION
Closes #1706.

This adds a field called `official` to `highway={path,footway,cycleway,bridleway}` features in the `transportation` layer. The field's value is:
- `0` if the OSM element is tagged `informal=yes`
- `1` if the feature has an `operator` in OSM (or is tagged `informal=no`)
- unset otherwise (this is the large majority of cases in the data today, especially when considering sidewalks, bike lanes, etc that aren't typically tagged with an `operator`).

The field is present only at 

Questions I have about whether this PR is correct:
1. The `official` field is conceptually an optional boolean. I chose to make it an `int` because I saw that existing boolean fields in the tiles (e.g. `intermittent` on waterways, `toll` on roads) have been implemented as 0/1 integers. Is this the right type for this field?
2. I added `description` and `values` fields to the transportation layer's `mapping.yaml` file. Is there anything else I should do to document this new field? Not sure how the schema docs on opentrailmap.org are built, but I am assuming they're generated from these mapping files somehow.

---

Here's a screenshot of a demo map style I whipped up (by mild tweaking of OSM Liberty) as an example of how this field helps make better trail maps.

On the left is a trail map where no distinction is made between official an unofficial trails. In the area shown, there is a dense braided network of social trails which are causing damage to the alpine meadow environment.

On the right is the same map but with official trails emphasized and unofficial ones de-emphasized. This can hopefully help hikers who want to stick to the official trails navigate the area responsibly.

<img width="48%" alt="Screenshot 2025-02-17 at 10 31 56 PM" src="https://github.com/user-attachments/assets/3ed5d461-cb0d-4ccc-aa57-d4ff96054b53" />
<img width="48%" alt="Screenshot 2025-02-17 at 10 32 01 PM" src="https://github.com/user-attachments/assets/1fb507ab-f070-4680-958d-15c0d6b1ecb6" />

