### PR TITLE
Use pg_trigger_depth to avoid re-trigger in update

### DIFF
--- a/layers/aerodrome_label/update_aerodrome_label_point.sql
+++ b/layers/aerodrome_label/update_aerodrome_label_point.sql
@@ -93,12 +93,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_aerodrome_label_point
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE aerodrome_label.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_aerodrome_label_point
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE aerodrome_label.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/housenumber/housenumber_centroid.sql
+++ b/layers/housenumber/housenumber_centroid.sql
@@ -86,12 +86,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_housenumber_point
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE housenumber.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_housenumber_point
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE housenumber.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/mountain_peak/update_mountain_linestring.sql
+++ b/layers/mountain_peak/update_mountain_linestring.sql
@@ -71,12 +71,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_mountain_linestring
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE mountain_linestring.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_mountain_linestring
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE mountain_linestring.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/mountain_peak/update_peak_point.sql
+++ b/layers/mountain_peak/update_peak_point.sql
@@ -71,12 +71,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_peak_point
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE mountain_peak_point.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_peak_point
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE mountain_peak_point.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/place/update_city_point.sql
+++ b/layers/place/update_city_point.sql
@@ -99,12 +99,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_city_point
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_city.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_city_point
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_city.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/place/update_continent_point.sql
+++ b/layers/place/update_continent_point.sql
@@ -71,12 +71,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_continent_point
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_continent_point.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_continent_point
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_continent_point.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/place/update_country_point.sql
+++ b/layers/place/update_country_point.sql
@@ -148,12 +148,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_country_point
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_country.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_country_point
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_country.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/place/update_island_point.sql
+++ b/layers/place/update_island_point.sql
@@ -71,12 +71,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_island_point
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_island_point.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_island_point
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_island_point.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/place/update_island_polygon.sql
+++ b/layers/place/update_island_polygon.sql
@@ -78,12 +78,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_island_polygon
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_island_polygon.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_island_polygon
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_island_polygon.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/place/update_state_point.sql
+++ b/layers/place/update_state_point.sql
@@ -110,12 +110,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_state_point
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_state.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_state_point
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE place_state.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/poi/update_poi_point.sql
+++ b/layers/poi/update_poi_point.sql
@@ -155,12 +155,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_poi_point
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE poi_point.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_poi_point
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE poi_point.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/poi/update_poi_polygon.sql
+++ b/layers/poi/update_poi_polygon.sql
@@ -109,12 +109,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_poi_polygon
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE poi_polygon.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_poi_polygon
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE poi_polygon.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/water_name/update_marine_point.sql
+++ b/layers/water_name/update_marine_point.sql
@@ -93,12 +93,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE
     ON osm_marine_point
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE water_name_marine.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE
     ON osm_marine_point
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE water_name_marine.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/water_name/update_water_name.sql
+++ b/layers/water_name/update_water_name.sql
@@ -197,12 +197,14 @@ CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE OR DELETE
     ON osm_water_polygon
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE water_name.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE OR DELETE
     ON osm_water_polygon
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE water_name.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh

--- a/layers/waterway/update_important_waterway.sql
+++ b/layers/waterway/update_important_waterway.sql
@@ -549,18 +549,21 @@ CREATE TRIGGER trigger_important_waterway_linestring_store
     AFTER INSERT OR UPDATE OR DELETE
     ON osm_important_waterway_linestring
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE waterway_important.important_waterway_linestring_store();
 
 CREATE TRIGGER trigger_store
     AFTER INSERT OR UPDATE OR DELETE
     ON osm_waterway_linestring
     FOR EACH ROW
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE waterway_important.store();
 
 CREATE TRIGGER trigger_flag
     AFTER INSERT OR UPDATE OR DELETE
     ON osm_waterway_linestring
     FOR EACH STATEMENT
+    WHEN (pg_trigger_depth() < 1)
 EXECUTE PROCEDURE waterway_important.flag();
 
 CREATE CONSTRAINT TRIGGER trigger_refresh


### PR DESCRIPTION
Some of the `update_osm_${LAYER}`-functions, which are executed by triggers on updates, execute an UPDATE statement on the same tables that have these triggers. This causes the trigger functions `flag` and `store` to run multiple times for one record. 

For instance, if I add log in the trigger functions and run an INSERT on `osm_housenumber_point`, this output is generated:  

```
NOTICE:  Store
NOTICE:  Flag
NOTICE:  Refresh housenumber
NOTICE:  Flag
NOTICE:  Store
NOTICE:  Flag
INSERT 0 1
```

If we limit the triggers from executing if they are called from another trigger using `pg_trigger_depth() < 1`, the triggers will only be triggered once per record:

```
NOTICE:  Store
NOTICE:  Flag
NOTICE:  Refresh housenumber
INSERT 0 1
```

This will prevent redunant executions and might improve update performance.  