### PR TITLE
Fix QUIET var handling in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ else
 endif
 
 # Make some operations quieter (e.g. inside the test script)
-ifeq ($(or $(QUIET),$(shell (. .env; echo $${QUIET})))),)
+ifeq ($(or $(QUIET),$(shell (. .env; echo $${QUIET}))),)
   QUIET_FLAG :=
 else
   QUIET_FLAG := --quiet


### PR DESCRIPTION
The brackets were unbalanced and the condition always evaluated to false so the --quiet flag was always added.

Fix #1717 