### PR TITLE
Fixed generating lake labels

### DIFF
--- a/layers/water_name/update_water_name.sql
+++ b/layers/water_name/update_water_name.sql
@@ -20,6 +20,8 @@ FROM osm_water_polygon AS wp
 WHERE wp.name <> ''
   AND ST_IsValid(wp.geometry);
 
+DROP TABLE IF EXISTS osm_water_lakeline CASCADE;
+
 -- etldoc:  osm_water_polygon ->  osm_water_lakeline
 -- etldoc:  lake_centerline  ->  osm_water_lakeline
 CREATE TABLE IF NOT EXISTS osm_water_lakeline AS
@@ -74,6 +76,8 @@ SELECT osm_id,
        area / (405279708033600 * COS(ST_Y(ST_Transform(geometry,4326))*PI()/180)) as earth_area,
        is_intermittent
 FROM osm_water_point_view;
+
+DROP TABLE IF EXISTS osm_water_point CASCADE;
 
 -- etldoc:  osm_water_point_earth_view ->  osm_water_point
 CREATE TABLE IF NOT EXISTS osm_water_point AS


### PR DESCRIPTION
I noticed that OpenMapTiles generate lake labels only when run for the first time. After that, it never recreates `osm_water_lakeline` and `osm_water_point` tables, so when I generate one region after another, only the first one has lake labels. This PR fixes that.