### PR TITLE
villages respect name:xx

### DIFF
--- a/layers/place/style.json
+++ b/layers/place/style.json
@@ -119,7 +119,17 @@
             "rank"
           ]
         ],
-        "text-field": "{name}",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
         "text-font": [
           "Open Sans Semibold",
           "Noto Sans Regular"


### PR DESCRIPTION
Villages use "name:xx" when available rather than the "name" (as described in #1734) 
