### PR TITLE
CI - integrity - 2 months diff

### DIFF
--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -49,8 +49,8 @@ jobs:
           rm -fr data build cache
           # Create data/$area.repl.json
           make download-geofabrik area=$area
-          # Download 1+ month old data
-          export old_date=$(date --date="$(date +%Y-%m-15) -1 month" +'%y%m01')
+          # Download 2+ month old data
+          export old_date=$(date --date="$(date +%Y-%m-15) -2 month" +'%y%m01')
           echo Downloading $old_date extract of $area
           docker compose run --rm --user=$(id -u):$(id -g) openmaptiles-tools sh -c "wget -O data/$area.osm.pbf http://download.geofabrik.de/$area-$old_date.osm.pbf"
           # Initial import and tile generation


### PR DESCRIPTION
Back to 2 months diffs for Monaco (changed due to missing history versions in Geofabrik).