### PR TITLE
Build arm64 for apple silicon + nerdctl 

### DIFF
--- a/.env
+++ b/.env
@@ -11,16 +11,15 @@ TOOLS_VERSION=7.2
 # OPENMAPTILES_TOOLS_IMAGE=openmaptiles/openmaptiles-tools
 # IMPORT_DATA_IMAGE=openmaptiles/import-data
 # GENERATE_VECTORTILES_IMAGE=openmaptiles/generate-vectortiles
+OPENMAPTILES_TOOLS_IMAGE=local/openmaptiles-tools
+IMPORT_DATA_IMAGE=local/import-data
 
 # Make sure these values are in sync with the ones in .env-postgres file
-PGDATABASE=osm
-PGUSER=osm
-PGPASSWORD=osm
-PGHOST=host.docker.internal
+PGDATABASE=openmaptiles
+PGUSER=openmaptiles
+PGPASSWORD=openmaptiles
+PGHOST=postgres
 PGPORT=5432
-
-# Seconds to wait for PostgreSQL before giving up (default: 90)
-PGWAIT_TIMEOUT=10
 
 # BBOX may get overwritten by the computed bbox of the specific area:
 #   make generate-bbox-file

--- a/.env
+++ b/.env
@@ -6,12 +6,21 @@ TILESET_FILE=openmaptiles.yaml
 # Use 3-part patch version to ignore patch updates, e.g. 7.0.0
 TOOLS_VERSION=7.2
 
+# Optional image overrides. Useful on arm64 hosts when you build replacement
+# images locally because upstream OpenMapTiles images are published as amd64.
+# OPENMAPTILES_TOOLS_IMAGE=openmaptiles/openmaptiles-tools
+# IMPORT_DATA_IMAGE=openmaptiles/import-data
+# GENERATE_VECTORTILES_IMAGE=openmaptiles/generate-vectortiles
+
 # Make sure these values are in sync with the ones in .env-postgres file
-PGDATABASE=openmaptiles
-PGUSER=openmaptiles
-PGPASSWORD=openmaptiles
-PGHOST=postgres
+PGDATABASE=osm
+PGUSER=osm
+PGPASSWORD=osm
+PGHOST=host.docker.internal
 PGPORT=5432
+
+# Seconds to wait for PostgreSQL before giving up (default: 90)
+PGWAIT_TIMEOUT=10
 
 # BBOX may get overwritten by the computed bbox of the specific area:
 #   make generate-bbox-file

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,14 @@ endif
 export OMT_HOST := http://$(firstword $(subst :, ,$(subst tcp://,,$(DOCKER_HOST))) localhost)
 
 ARM64_PLATFORM ?= linux/arm64
-OPENMAPTILES_TOOLS_SRC_DIR ?= build/openmaptiles-tools-src
+OPENMAPTILES_TOOLS_DEFAULT_SRC_DIR := build/openmaptiles-tools-src
+OPENMAPTILES_TOOLS_LOCAL_SRC_DIR := ../openmaptiles-tools
+OPENMAPTILES_TOOLS_SRC_DIR ?= $(if $(wildcard $(OPENMAPTILES_TOOLS_LOCAL_SRC_DIR)/.git),$(OPENMAPTILES_TOOLS_LOCAL_SRC_DIR),$(OPENMAPTILES_TOOLS_DEFAULT_SRC_DIR))
 OPENMAPTILES_TOOLS_GIT_REF ?= $(OPENMAPTILES_TOOLS_GIT_REF_DEFAULT)
 LOCAL_OPENMAPTILES_TOOLS_IMAGE ?= local/openmaptiles-tools
 LOCAL_IMPORT_DATA_IMAGE ?= local/import-data
 LOCAL_GENERATE_VECTORTILES_IMAGE ?= local/generate-vectortiles
-NATIVE_ASYNCPG_VERSION ?= 0.27.0
+BUILD_LEGACY_GENERATE_VECTORTILES ?= no
 
 # This defines an easy $(newline) value to act as a "\n". Make sure to keep exactly two empty lines after newline.
 define newline
@@ -214,6 +216,7 @@ Hints for developers:
   make                                 # build source code
   make bash                            # start openmaptiles-tools /bin/bash terminal
 	make build-native-arm64-images       # build local linux/arm64 images from openmaptiles-tools source
+	make build-native-arm64-images BUILD_LEGACY_GENERATE_VECTORTILES=yes # also build legacy generate-vectortiles image
 	make show-native-arm64-env           # print .env overrides to activate local arm64 images
   make generate-bbox-file              # compute bounding box of a data file and store it in a file
   make generate-devdoc                 # generate devdoc including graphs for all layers [./layers/...]
@@ -297,6 +300,8 @@ init-dirs:
 prepare-native-tools-src: init-dirs
 	@if [ ! -d "$(OPENMAPTILES_TOOLS_SRC_DIR)/.git" ]; then \
 		git clone --branch "$(OPENMAPTILES_TOOLS_GIT_REF)" --depth 1 https://github.com/openmaptiles/openmaptiles-tools.git "$(OPENMAPTILES_TOOLS_SRC_DIR)"; \
+	elif [ "$(OPENMAPTILES_TOOLS_SRC_DIR)" != "$(OPENMAPTILES_TOOLS_DEFAULT_SRC_DIR)" ]; then \
+		echo "Using local openmaptiles-tools repo at $(OPENMAPTILES_TOOLS_SRC_DIR) (skip fetch/checkout)."; \
 	else \
 		git -C "$(OPENMAPTILES_TOOLS_SRC_DIR)" fetch --tags --depth 1 origin; \
 		git -C "$(OPENMAPTILES_TOOLS_SRC_DIR)" checkout --force "$(OPENMAPTILES_TOOLS_GIT_REF)"; \
@@ -304,23 +309,31 @@ prepare-native-tools-src: init-dirs
 
 .PHONY: build-native-arm64-images
 build-native-arm64-images: prepare-native-tools-src
-	@sed -i.bak 's/^asyncpg==0.25.0$$/asyncpg==$(NATIVE_ASYNCPG_VERSION)/' "$(OPENMAPTILES_TOOLS_SRC_DIR)/requirements.txt" && rm -f "$(OPENMAPTILES_TOOLS_SRC_DIR)/requirements.txt.bak"
 	$(CONTAINER_BUILD_COMMAND) --platform=$(ARM64_PLATFORM) \
 		--tag "$(LOCAL_OPENMAPTILES_TOOLS_IMAGE):$(TOOLS_VERSION)" \
 		"$(OPENMAPTILES_TOOLS_SRC_DIR)"
 	$(CONTAINER_BUILD_COMMAND) --platform=$(ARM64_PLATFORM) \
 		--tag "$(LOCAL_IMPORT_DATA_IMAGE):$(TOOLS_VERSION)" \
 		"$(OPENMAPTILES_TOOLS_SRC_DIR)/docker/import-data"
+	@if [ "$(BUILD_LEGACY_GENERATE_VECTORTILES)" = "yes" ]; then \
 	$(CONTAINER_BUILD_COMMAND) --platform=$(ARM64_PLATFORM) \
 		--tag "$(LOCAL_GENERATE_VECTORTILES_IMAGE):$(TOOLS_VERSION)" \
-		"$(OPENMAPTILES_TOOLS_SRC_DIR)/docker/generate-vectortiles"
+		"$(OPENMAPTILES_TOOLS_SRC_DIR)/docker/generate-vectortiles"; \
+	else \
+		echo "Skipping legacy generate-vectortiles arm64 image build (BUILD_LEGACY_GENERATE_VECTORTILES=$(BUILD_LEGACY_GENERATE_VECTORTILES))."; \
+		echo "This is usually fine when using generate-tiles-pg (recommended)."; \
+	fi
 
 .PHONY: show-native-arm64-env
 show-native-arm64-env:
 	@echo "Add these lines to .env to use locally built linux/arm64 images:"
 	@echo "OPENMAPTILES_TOOLS_IMAGE=$(LOCAL_OPENMAPTILES_TOOLS_IMAGE)"
 	@echo "IMPORT_DATA_IMAGE=$(LOCAL_IMPORT_DATA_IMAGE)"
-	@echo "GENERATE_VECTORTILES_IMAGE=$(LOCAL_GENERATE_VECTORTILES_IMAGE)"
+	@if [ "$(BUILD_LEGACY_GENERATE_VECTORTILES)" = "yes" ]; then \
+		echo "GENERATE_VECTORTILES_IMAGE=$(LOCAL_GENERATE_VECTORTILES_IMAGE)"; \
+	else \
+		echo "# Leave GENERATE_VECTORTILES_IMAGE unset unless you built the legacy image"; \
+	fi
 
 build/openmaptiles.tm2source/data.yml: init-dirs
 ifeq (,$(wildcard build/openmaptiles.tm2source/data.yml))
@@ -478,7 +491,7 @@ else
 endif
 
 .PHONY: import-osm
-import-osm: all
+import-osm: all start-db-nowait
 	@$(assert_area_is_given)
 	$(DOCKER_COMPOSE) $(DC_CONFIG_CACHE) run $(DC_OPTS_CACHE) openmaptiles-tools sh -c 'pgwait && import-osm $(PBF_FILE)'
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,14 @@ SHELL         = /bin/bash
 
 # Layers definition and meta data
 TILESET_FILE := $(or $(TILESET_FILE),$(shell (. .env; echo $${TILESET_FILE})),openmaptiles.yaml)
+TOOLS_VERSION := $(or $(TOOLS_VERSION),$(shell (. .env; echo $${TOOLS_VERSION})),latest)
+
+TOOLS_VERSION_PARTS := $(words $(subst ., ,$(TOOLS_VERSION)))
+ifeq ($(TOOLS_VERSION_PARTS),2)
+	OPENMAPTILES_TOOLS_GIT_REF_DEFAULT := v$(TOOLS_VERSION).0
+else
+	OPENMAPTILES_TOOLS_GIT_REF_DEFAULT := v$(TOOLS_VERSION)
+endif
 
 # Options to run with docker and docker-compose - ensure the container is destroyed on exit
 # Containers run as the current user rather than root (so that created files are not root-owned)
@@ -25,13 +33,17 @@ export TPORT
 STYLE_FILE := build/style/style.json
 STYLE_HEADER_FILE := style/style-header.json
 
-# Support newer `docker compose` syntax in addition to `docker-compose`
-
-ifeq (, $(shell which docker-compose))
+ifneq (, $(shell which nerdctl))
+  DOCKER_COMPOSE_COMMAND := nerdctl compose
+	CONTAINER_BUILD_COMMAND := nerdctl build
+  $(info Using containerd compose (nerdctl compose))
+else ifeq (, $(shell which docker-compose))
   DOCKER_COMPOSE_COMMAND := docker compose
+	CONTAINER_BUILD_COMMAND := docker build
   $(info Using docker compose V2 (docker compose))
 else
   DOCKER_COMPOSE_COMMAND := docker-compose
+	CONTAINER_BUILD_COMMAND := docker build
   $(info Using docker compose V1 (docker-compose))
 endif
 
@@ -66,6 +78,14 @@ endif
 
 # Set OpenMapTiles host
 export OMT_HOST := http://$(firstword $(subst :, ,$(subst tcp://,,$(DOCKER_HOST))) localhost)
+
+ARM64_PLATFORM ?= linux/arm64
+OPENMAPTILES_TOOLS_SRC_DIR ?= build/openmaptiles-tools-src
+OPENMAPTILES_TOOLS_GIT_REF ?= $(OPENMAPTILES_TOOLS_GIT_REF_DEFAULT)
+LOCAL_OPENMAPTILES_TOOLS_IMAGE ?= local/openmaptiles-tools
+LOCAL_IMPORT_DATA_IMAGE ?= local/import-data
+LOCAL_GENERATE_VECTORTILES_IMAGE ?= local/generate-vectortiles
+NATIVE_ASYNCPG_VERSION ?= 0.27.0
 
 # This defines an easy $(newline) value to act as a "\n". Make sure to keep exactly two empty lines after newline.
 define newline
@@ -193,6 +213,8 @@ Hints for designers:
 Hints for developers:
   make                                 # build source code
   make bash                            # start openmaptiles-tools /bin/bash terminal
+	make build-native-arm64-images       # build local linux/arm64 images from openmaptiles-tools source
+	make show-native-arm64-env           # print .env overrides to activate local arm64 images
   make generate-bbox-file              # compute bounding box of a data file and store it in a file
   make generate-devdoc                 # generate devdoc including graphs for all layers [./layers/...]
   make generate-qa                     # statistics for a given layer's field
@@ -270,6 +292,35 @@ init-dirs:
 	@mkdir -p data
 	@mkdir -p cache
 	@ ! ($(DOCKER_COMPOSE) 2>/dev/null run $(DC_OPTS) openmaptiles-tools df --output=fstype /tileset| grep -q 9p) < /dev/null || ($(win_fs_error))
+
+.PHONY: prepare-native-tools-src
+prepare-native-tools-src: init-dirs
+	@if [ ! -d "$(OPENMAPTILES_TOOLS_SRC_DIR)/.git" ]; then \
+		git clone --branch "$(OPENMAPTILES_TOOLS_GIT_REF)" --depth 1 https://github.com/openmaptiles/openmaptiles-tools.git "$(OPENMAPTILES_TOOLS_SRC_DIR)"; \
+	else \
+		git -C "$(OPENMAPTILES_TOOLS_SRC_DIR)" fetch --tags --depth 1 origin; \
+		git -C "$(OPENMAPTILES_TOOLS_SRC_DIR)" checkout --force "$(OPENMAPTILES_TOOLS_GIT_REF)"; \
+	fi
+
+.PHONY: build-native-arm64-images
+build-native-arm64-images: prepare-native-tools-src
+	@sed -i.bak 's/^asyncpg==0.25.0$$/asyncpg==$(NATIVE_ASYNCPG_VERSION)/' "$(OPENMAPTILES_TOOLS_SRC_DIR)/requirements.txt" && rm -f "$(OPENMAPTILES_TOOLS_SRC_DIR)/requirements.txt.bak"
+	$(CONTAINER_BUILD_COMMAND) --platform=$(ARM64_PLATFORM) \
+		--tag "$(LOCAL_OPENMAPTILES_TOOLS_IMAGE):$(TOOLS_VERSION)" \
+		"$(OPENMAPTILES_TOOLS_SRC_DIR)"
+	$(CONTAINER_BUILD_COMMAND) --platform=$(ARM64_PLATFORM) \
+		--tag "$(LOCAL_IMPORT_DATA_IMAGE):$(TOOLS_VERSION)" \
+		"$(OPENMAPTILES_TOOLS_SRC_DIR)/docker/import-data"
+	$(CONTAINER_BUILD_COMMAND) --platform=$(ARM64_PLATFORM) \
+		--tag "$(LOCAL_GENERATE_VECTORTILES_IMAGE):$(TOOLS_VERSION)" \
+		"$(OPENMAPTILES_TOOLS_SRC_DIR)/docker/generate-vectortiles"
+
+.PHONY: show-native-arm64-env
+show-native-arm64-env:
+	@echo "Add these lines to .env to use locally built linux/arm64 images:"
+	@echo "OPENMAPTILES_TOOLS_IMAGE=$(LOCAL_OPENMAPTILES_TOOLS_IMAGE)"
+	@echo "IMPORT_DATA_IMAGE=$(LOCAL_IMPORT_DATA_IMAGE)"
+	@echo "GENERATE_VECTORTILES_IMAGE=$(LOCAL_GENERATE_VECTORTILES_IMAGE)"
 
 build/openmaptiles.tm2source/data.yml: init-dirs
 ifeq (,$(wildcard build/openmaptiles.tm2source/data.yml))
@@ -427,7 +478,7 @@ else
 endif
 
 .PHONY: import-osm
-import-osm: all start-db-nowait
+import-osm: all
 	@$(assert_area_is_given)
 	$(DOCKER_COMPOSE) $(DC_CONFIG_CACHE) run $(DC_OPTS_CACHE) openmaptiles-tools sh -c 'pgwait && import-osm $(PBF_FILE)'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,17 @@ services:
       PGPORT: ${PGPORT:-5432}
 
   import-data:
-    image: "openmaptiles/import-data:${TOOLS_VERSION}"
+    image: "${IMPORT_DATA_IMAGE:-openmaptiles/import-data}:${TOOLS_VERSION}"
     env_file: .env
     networks:
       - postgres
 
   openmaptiles-tools: &openmaptiles-tools
-    image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"
+    image: "${OPENMAPTILES_TOOLS_IMAGE:-openmaptiles/openmaptiles-tools}:${TOOLS_VERSION}"
+    deploy:
+      resources:
+        limits:
+          memory: 8g
     env_file: .env
     environment:
       # Must match the version of this file (first line)
@@ -54,6 +58,7 @@ services:
       PGDATABASE: ${PGDATABASE:-openmaptiles}
       PGUSER: ${PGUSER:-openmaptiles}
       PGPASSWORD: ${PGPASSWORD:-openmaptiles}
+      PGHOST: ${PGHOST:-postgres}
       PGPORT: ${PGPORT:-5432}
       MBTILES_FILE: ${MBTILES_FILE}
     networks:
@@ -72,7 +77,7 @@ services:
     command: import-update
 
   generate-changed-vectortiles:
-    image: "openmaptiles/generate-vectortiles:${TOOLS_VERSION}"
+    image: "${GENERATE_VECTORTILES_IMAGE:-openmaptiles/generate-vectortiles}:${TOOLS_VERSION}"
     command: ./export-list.sh
     volumes:
       - ./data:/export
@@ -90,7 +95,7 @@ services:
       PGPORT: ${PGPORT:-5432}
 
   generate-vectortiles:
-    image: "openmaptiles/generate-vectortiles:${TOOLS_VERSION}"
+    image: "${GENERATE_VECTORTILES_IMAGE:-openmaptiles/generate-vectortiles}:${TOOLS_VERSION}"
     volumes:
       - ./data:/export
       - ./build/openmaptiles.tm2source:/tm2source
@@ -111,7 +116,7 @@ services:
       PGPORT: ${PGPORT:-5432}
 
   postserve:
-    image: "openmaptiles/openmaptiles-tools:${TOOLS_VERSION}"
+    image: "${OPENMAPTILES_TOOLS_IMAGE:-openmaptiles/openmaptiles-tools}:${TOOLS_VERSION}"
     command: "postserve ${TILESET_FILE} --verbose --serve=${OMT_HOST:-http://localhost}:${PPORT:-8090}"
     env_file: .env
     environment:


### PR DESCRIPTION
added build target for making binaries for linux/arm64 for apple silicon macs, added nerdctl support, and local testing with openmaptiles-tools
