### PR TITLE
Add rock, clay, laterite to surface_value() unpaved classification

### DIFF
--- a/layers/transportation/class.sql
+++ b/layers/transportation/class.sql
@@ -50,7 +50,8 @@ SELECT CASE
            WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'concrete', 'concrete:lanes', 'concrete:plates', 'metal',
                             'paving_stones', 'sett', 'unhewn_cobblestone', 'wood', 'grade1') THEN 'paved'
            WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel',
-                            'gravel_turf', 'ground', 'ice', 'mud', 'pebblestone', 'salt', 'sand', 'snow', 'woodchips')
+                            'gravel_turf', 'ground', 'ice', 'mud', 'pebblestone', 'salt', 'sand', 'snow', 'woodchips',
+                            'rock', 'clay', 'laterite')
                THEN 'unpaved'
            END;
 $$ LANGUAGE SQL IMMUTABLE

--- a/layers/transportation/transportation.yaml
+++ b/layers/transportation/transportation.yaml
@@ -204,7 +204,7 @@ layer:
       values: [0, 1]
     surface:
       description: |
-          Values of [`surface`](https://wiki.openstreetmap.org/wiki/Key:surface) tag devided into 2 groups `paved` (paved, asphalt, cobblestone, concrete, concrete:lanes, concrete:plates, metal, paving_stones, sett, unhewn_cobblestone, wood) and `unpaved` (unpaved, compacted, dirt, earth, fine_gravel, grass, grass_paver, gravel, gravel_turf, ground, ice, mud, pebblestone, salt, sand, snow, woodchips).
+          Values of [`surface`](https://wiki.openstreetmap.org/wiki/Key:surface) tag devided into 2 groups `paved` (paved, asphalt, cobblestone, concrete, concrete:lanes, concrete:plates, metal, paving_stones, sett, unhewn_cobblestone, wood) and `unpaved` (unpaved, compacted, dirt, earth, fine_gravel, grass, grass_paver, gravel, gravel_turf, ground, ice, mud, pebblestone, salt, sand, snow, woodchips, rock, clay, laterite).
       values:
       - paved
       - unpaved


### PR DESCRIPTION
## Summary
`surface_value()` in `layers/transportation/class.sql` classifies `surface` into `paved`/`unpaved`. Three fairly common values fall through unclassified (NULL) today:

- `rock`: 34,201 uses (taginfo)
- `clay`: 42,844 uses
- `laterite`: 2,250 uses, documented via OSM's approved [Proposal:Surface=laterite](https://wiki.openstreetmap.org/wiki/Proposal:Surface%3Dlaterite) (29-0-0)

All three exceed the usage of several values already in the unpaved list (`salt` at 511, `snow` at 508), so this isn't a usage-threshold question, they were simply missed when the lists were last assembled. Also updated the field description in `transportation.yaml` to match, per CONTRIBUTING.md.

Fixes #1806

## Test plan
- [ ] Recommended per CONTRIBUTING.md to add a SQL unit test for this, but that requires the full Postgres/osm2pgsql import harness (see TESTING.md), which I couldn't stand up in this environment. The change itself just extends an existing literal-value `IN (...)` list with the same pattern as the 17 values already there, relying on CI/review here.